### PR TITLE
Fix scipy TypeError and add test documentation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy>=1.24.1
 pandas>=1.3.5
 psutil>=5.9.4
 requests>=2.26.0
-scipy>=1.10.0
+scipy>=1.12.0
 setuptools>=63.3.0
 torch>=1.13.1
 statsmodels

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,39 @@
+# Tests for tecpg
+
+This directory contains validation and regression tests for `tecpg`.
+
+## Files
+
+- **`test_accuracy.py`**: Validates the accuracy of `tecpg`'s regression results against `statsmodels` (OLS). It generates synthetic data, runs `tecpg` regression, and then randomly selects pairs of methylation/gene expression to compare with `statsmodels.OLS`.
+- **`test_mlr_comparison.py`**: Compares the two implementation backends of `tecpg`:
+  - `regression_full` (Manual implementation of Normal Equations)
+  - `tecpg_mlr_lstsq` (Using PyTorch's `linalg.lstsq`)
+  This test ensures both methods produce consistent results across different chunking and region filtration scenarios.
+- **`validation_utils.py`**: Contains helper functions used by `test_accuracy.py`, such as running OLS with `statsmodels` and comparing results.
+
+## Usage
+
+To run the accuracy validation test:
+```bash
+python test_accuracy.py
+```
+
+To run the MLR backend comparison test:
+```bash
+python test_mlr_comparison.py
+```
+
+## Troubleshooting
+
+### `TypeError: C function scipy.spatial._qhull._barycentric_coordinates has wrong signature`
+
+If you encounter this error when running tests, it indicates a version mismatch between `scipy` and `numpy` (or other compiled extensions) in your environment.
+
+**Fix:**
+Upgrade `scipy` to a version compatible with your `numpy` installation (typically `scipy>=1.12.0`). You can try reinstalling dependencies:
+
+```bash
+pip install --upgrade scipy numpy
+# or re-install all requirements
+pip install -r ../requirements.txt
+```


### PR DESCRIPTION
This PR addresses a `TypeError` encountered when running `tests/test_accuracy.py`, which was caused by a version mismatch in the `scipy` dependency.

Changes:
1.  **Update `requirements.txt`**: Bumped `scipy` requirement from `>=1.10.0` to `>=1.12.0`. This ensures that users install a version of `scipy` that is compatible with newer `numpy` versions, preventing the `_barycentric_coordinates` signature mismatch error.
2.  **Add `tests/README.md`**: Created a README file in the `tests/` directory. This file:
    *   Describes the purpose of `test_accuracy.py` (validation against statsmodels) and `test_mlr_comparison.py` (consistency check between implementations).
    *   Provides instructions on how to run the tests.
    *   Includes a troubleshooting section specifically for the `scipy` error, explaining the cause and the fix (upgrading `scipy`).

Verification:
- Ran `python tests/test_accuracy.py` successfully.
- Ran `python tests/test_mlr_comparison.py` successfully.
- Verified that `scipy` can be imported without errors.

---
*PR created automatically by Jules for task [15410694589979727421](https://jules.google.com/task/15410694589979727421) started by @kordk*