### PR TITLE
Fix test failures by prioritizing local imports over installed package

### DIFF
--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -10,7 +10,7 @@ from typing import List
 # Ensure we can import tecpg
 root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if root_dir not in sys.path:
-    sys.path.append(root_dir)
+    sys.path.insert(0, root_dir)
 
 import tecpg
 from tecpg.test_data import generate_data

--- a/tests/test_mlr_comparison.py
+++ b/tests/test_mlr_comparison.py
@@ -8,7 +8,7 @@ import numpy as np
 # Ensure we can import tecpg
 root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if root_dir not in sys.path:
-    sys.path.append(root_dir)
+    sys.path.insert(0, root_dir)
 
 from tecpg.test_data import generate_data
 from tecpg.regression_full import regression_full


### PR DESCRIPTION
Fixed `ModuleNotFoundError` in `tests/test_mlr_comparison.py` and `tests/test_accuracy.py`. The issue was caused by `sys.path.append` putting the local project root at the end of the Python path, allowing an incomplete installed version of `tecpg` to be imported instead. Changed to `sys.path.insert(0, ...)` to prioritize the local source code.verified by reproducing the issue with a dummy installed package and confirming the fix resolves it.

---
*PR created automatically by Jules for task [14718528685538835388](https://jules.google.com/task/14718528685538835388) started by @kordk*