### PR TITLE
Add Scatter Plots for MLR Test Comparisons

### DIFF
--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -18,9 +18,9 @@ from tecpg.regression_full import regression_full
 from tecpg.logger import Logger
 
 try:
-    from tests.validation_utils import run_statsmodels_ols, compare_results
+    from tests.validation_utils import run_statsmodels_ols, compare_results, save_scatter_plot
 except ImportError:
-    from validation_utils import run_statsmodels_ols, compare_results
+    from validation_utils import run_statsmodels_ols, compare_results, save_scatter_plot
 
 def main():
     print("Starting tecpg accuracy validation test...")
@@ -90,6 +90,12 @@ def main():
         diffs['mt_id'] = mt_id
         diffs['sm_p'] = sm_vals['mt_p']
         diffs['tecpg_p'] = tecpg_vals['mt_p']
+        diffs['sm_est'] = sm_vals['mt_est']
+        diffs['tecpg_est'] = tecpg_vals['mt_est']
+        diffs['sm_err'] = sm_vals['mt_err']
+        diffs['tecpg_err'] = tecpg_vals['mt_err']
+        diffs['sm_t'] = sm_vals['mt_t']
+        diffs['tecpg_t'] = tecpg_vals['mt_t']
 
         results.append(diffs)
 
@@ -142,6 +148,22 @@ def main():
     report_path = "validation_report.csv"
     results_df.to_csv(report_path, index=False)
     print(f"Detailed validation results saved to {report_path}")
+
+    # Generate Plots
+    print("Generating validation plots...")
+    save_scatter_plot(results_df['sm_est'], results_df['tecpg_est'],
+                      'Statsmodels Estimate', 'Tecpg Estimate',
+                      'Methylation Estimate Comparison', 'accuracy_est_comparison.png')
+    save_scatter_plot(results_df['sm_err'], results_df['tecpg_err'],
+                      'Statsmodels Std Error', 'Tecpg Std Error',
+                      'Methylation Std Error Comparison', 'accuracy_err_comparison.png')
+    save_scatter_plot(results_df['sm_t'], results_df['tecpg_t'],
+                      'Statsmodels T-stat', 'Tecpg T-stat',
+                      'Methylation T-statistic Comparison', 'accuracy_t_comparison.png')
+    save_scatter_plot(results_df['sm_p'], results_df['tecpg_p'],
+                      'Statsmodels P-value', 'Tecpg P-value',
+                      'Methylation P-value Comparison', 'accuracy_p_comparison.png')
+    print("Plots saved to tests/plots/")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_mlr_comparison.py
+++ b/tests/test_mlr_comparison.py
@@ -15,6 +15,11 @@ from tecpg.regression_full import regression_full
 from tecpg.processing import tecpg_mlr_lstsq
 from tecpg.logger import Logger
 
+try:
+    from tests.validation_utils import save_scatter_plot
+except ImportError:
+    from validation_utils import save_scatter_plot
+
 def summarize_comparison(df1, df2):
     """
     Prints a summary comparison between two dataframes.
@@ -154,6 +159,32 @@ def run_comparison_test(test_name, M, G, C, M_annot=None, G_annot=None, **kwargs
 
     # Compare values with tolerance
     summarize_comparison(res_manual, res_lstsq)
+
+    sanitized_name = test_name.replace(" ", "_").lower()
+    save_scatter_plot(
+        res_manual['mt_est'], res_lstsq['mt_est'],
+        'Manual Estimate', 'Lstsq Estimate',
+        f'Comparison ({test_name}) - Estimate',
+        f'comparison_{sanitized_name}_est.png'
+    )
+    save_scatter_plot(
+        res_manual['mt_err'], res_lstsq['mt_err'],
+        'Manual Std Error', 'Lstsq Std Error',
+        f'Comparison ({test_name}) - Std Error',
+        f'comparison_{sanitized_name}_err.png'
+    )
+    save_scatter_plot(
+        res_manual['mt_t'], res_lstsq['mt_t'],
+        'Manual T-stat', 'Lstsq T-stat',
+        f'Comparison ({test_name}) - T-statistic',
+        f'comparison_{sanitized_name}_t.png'
+    )
+    save_scatter_plot(
+        res_manual['mt_p'], res_lstsq['mt_p'],
+        'Manual P-value', 'Lstsq P-value',
+        f'Comparison ({test_name}) - P-value',
+        f'comparison_{sanitized_name}_p.png'
+    )
 
     try:
         pd.testing.assert_frame_equal(res_manual, res_lstsq, rtol=1e-3, atol=1e-3)

--- a/tests/validation_utils.py
+++ b/tests/validation_utils.py
@@ -2,6 +2,8 @@
 import pandas as pd
 import numpy as np
 import statsmodels.api as sm
+import matplotlib.pyplot as plt
+import os
 from typing import Tuple, Dict, Any, List
 
 def run_statsmodels_ols(
@@ -70,3 +72,44 @@ def compare_results(
         'diff_p': abs(tecpg_res['mt_p'] - sm_res['mt_p']),
         'rel_diff_est': abs(tecpg_res['mt_est'] - sm_res['mt_est']) / (abs(sm_res['mt_est']) + 1e-9),
     }
+
+def save_scatter_plot(
+    x: Any,
+    y: Any,
+    xlabel: str,
+    ylabel: str,
+    title: str,
+    filename: str
+):
+    """
+    Generates a scatter plot with a y=x reference line and saves it.
+    """
+    output_dir = os.path.join(os.path.dirname(__file__), 'plots')
+    os.makedirs(output_dir, exist_ok=True)
+
+    plt.figure(figsize=(8, 8))
+    plt.scatter(x, y, alpha=0.5)
+
+    # Add y=x line
+    # Calculate limits based on data, handle cases where data might be constant or empty
+    if len(x) > 0 and len(y) > 0:
+        min_val = min(np.min(x), np.min(y))
+        max_val = max(np.max(x), np.max(y))
+        padding = (max_val - min_val) * 0.05
+        if padding == 0:
+            padding = 1.0 # Default padding if all values are same
+
+        lims = [min_val - padding, max_val + padding]
+        plt.plot(lims, lims, 'k--', alpha=0.75, zorder=0)
+        plt.xlim(lims)
+        plt.ylim(lims)
+
+    plt.xlabel(xlabel)
+    plt.ylabel(ylabel)
+    plt.title(title)
+    plt.grid(True)
+
+    filepath = os.path.join(output_dir, filename)
+    plt.savefig(filepath)
+    plt.close()
+    print(f"Saved plot to {filepath}")


### PR DESCRIPTION
Implemented scatter plots for visualizing the comparisons in `tests/test_accuracy.py` and `tests/test_mlr_comparison.py`.

The plots compare:
1.  `tecpg` vs `statsmodels` (in `test_accuracy.py`) for Estimate, Standard Error, T-statistic, and P-value.
2.  `regression_full` (manual) vs `tecpg_mlr_lstsq` (torch lstsq) (in `test_mlr_comparison.py`) for the same metrics across multiple test scenarios (All Region, Cis Region, Trans Region).

Plots are saved as PNG files in `tests/plots/`.
Verified by running the tests and checking the output directory.

---
*PR created automatically by Jules for task [15644469076865121360](https://jules.google.com/task/15644469076865121360) started by @kordk*