### PR TITLE
feat: Add --logit-transform option to convert Beta values to M-values

### DIFF
--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -280,6 +280,14 @@ def corr(
         " optimized inversion; 'lstsq' uses torch.linalg.lstsq."
     ),
 )
+@click.option(
+    '--logit-transform',
+    is_flag=True,
+    show_default=True,
+    default=False,
+    type=bool,
+    help='Whether to logit-transform M-values (log2(beta/(1-beta)))',
+)
 @click.pass_context
 def mlr(
     ctx: click.Context,
@@ -293,6 +301,7 @@ def mlr(
     full_output: bool,
     p_only: bool,
     mlr_method: str,
+    logit_transform: bool,
 ) -> None:
     logger: Logger = ctx.obj['logger']
 
@@ -351,7 +360,7 @@ def mlr(
         ]
     )
     args.append(None if not chunking else output_path)  # output_dir
-    args.extend([methylation_only, p_only])
+    args.extend([methylation_only, p_only, logit_transform])
 
     if mlr_method == 'lstsq':
         output = tecpg_mlr_lstsq(*args, **logger)
@@ -393,6 +402,14 @@ def mlr(
 @click.option(
     '--no-p', is_flag=True, show_default=True, default=False, type=bool
 )
+@click.option(
+    '--logit-transform',
+    is_flag=True,
+    show_default=True,
+    default=False,
+    type=bool,
+    help='Whether to logit-transform M-values (log2(beta/(1-beta)))',
+)
 @click.pass_context
 def mlr_single(
     ctx: click.Context,
@@ -405,6 +422,7 @@ def mlr_single(
     no_err: bool,
     no_t: bool,
     no_p: bool,
+    logit_transform: bool,
 ) -> None:
     """
     Calculates the multiple linear regression.
@@ -462,6 +480,11 @@ def mlr_single(
     args.extend((methylation_only, 1))
     if regressions_per_chunk:
         args.append(output_path)
+    else:
+        args.append(None)
+
+    args.append(logit_transform)
+
     output = regression_single(*args, **logger)
     if not regressions_per_chunk:
         save_dataframes([output], output_path, [data['output_file']], **logger)

--- a/tecpg/helper.py
+++ b/tecpg/helper.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Tuple, TypeVar
 import numpy as np
 import pandas
 import requests
+import torch
 
 from .logger import Logger
 
@@ -115,3 +116,25 @@ def default_region_parameter(
         )
         return None
     return region_parameter
+
+
+def logit_transform_torch(
+    tensor: torch.Tensor, epsilon: float = 1e-6
+) -> torch.Tensor:
+    """
+    Clips the tensor values to [epsilon, 1 - epsilon] and applies a
+    logit transformation: log2(x / (1 - x)).
+    """
+    tensor = tensor.clamp(epsilon, 1 - epsilon)
+    return torch.log2(tensor / (1 - tensor))
+
+
+def logit_transform_pandas(
+    df: pandas.DataFrame, epsilon: float = 1e-6
+) -> pandas.DataFrame:
+    """
+    Clips the dataframe values to [epsilon, 1 - epsilon] and applies a
+    logit transformation: log2(x / (1 - x)).
+    """
+    df = df.clip(epsilon, 1 - epsilon)
+    return np.log2(df / (1 - df))

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -10,7 +10,7 @@ import torch
 from colorama import Fore as colors
 
 from .config import DTYPE, get_device
-from .helper import trim_dataframes
+from .helper import logit_transform_torch, trim_dataframes
 from .import_data import initialize_dir, save_dataframe_part
 from .logger import Logger
 
@@ -42,6 +42,7 @@ def tecpg_mlr_lstsq(
     output_dir: Optional[str] = None,
     methylation_only: bool = True,
     p_only: bool = False,
+    logit_transform: bool = False,
     file_format: str = '{meth_chunk}-{gene_chunk}.csv',
     *,
     logger: Logger = Logger(),
@@ -239,6 +240,10 @@ def tecpg_mlr_lstsq(
             Mt: torch.Tensor = torch.tensor(
                 M_chunk.to_numpy(), device=device, dtype=dtype
             ).unsqueeze(2)
+
+            if logit_transform:
+                Mt = logit_transform_torch(Mt)
+
             ones = torch.ones((mt_count, nrows, 1), device=device, dtype=dtype)
             X: torch.Tensor = torch.cat((ones, Mt, Ct), 2) # (M, S, K)
             del Mt, ones

--- a/tecpg/regression_full.py
+++ b/tecpg/regression_full.py
@@ -10,7 +10,7 @@ import torch
 from colorama import Fore as colors
 
 from .config import DTYPE, get_device
-from .helper import trim_dataframes
+from .helper import logit_transform_torch, trim_dataframes
 from .import_data import initialize_dir, save_dataframe_part
 from .logger import Logger
 from .test_data import generate_data
@@ -60,6 +60,7 @@ def regression_full(
     output_dir: Optional[str] = None,
     methylation_only: bool = True,
     p_only: bool = False,
+    logit_transform: bool = False,
     file_format: str = '{meth_chunk}-{gene_chunk}.csv',
     *,
     logger: Logger = Logger(),
@@ -311,6 +312,10 @@ def regression_full(
             Mt: torch.Tensor = torch.tensor(
                 M_chunk.to_numpy(), device=device, dtype=dtype
             ).unsqueeze(2)
+
+            if logit_transform:
+                Mt = logit_transform_torch(Mt)
+
             ones = torch.ones((mt_count, nrows, 1), device=device, dtype=dtype)
             X: torch.Tensor = torch.cat((ones, Mt, Ct), 2)
             del Mt, ones

--- a/tecpg/regression_single.py
+++ b/tecpg/regression_single.py
@@ -9,6 +9,7 @@ import pandas
 import torch
 
 from .config import get_device
+from .helper import logit_transform_pandas
 from .import_data import initialize_dir, save_dataframe_part
 from .logger import Logger
 from .test_data import generate_data
@@ -28,6 +29,7 @@ def regression_single(
     methylation_only: bool = True,
     update_period: Optional[float] = 1,
     output_dir: Optional[str] = None,
+    logit_transform: bool = False,
     *,
     logger: Logger = Logger(),
 ) -> pandas.DataFrame:
@@ -109,6 +111,10 @@ def regression_single(
         logger.info('Clearing output directory')
         initialize_dir(output_dir, **logger)
 
+    if logit_transform:
+        logger.info('Transforming M using logit function')
+        M = logit_transform_pandas(M)
+
     logger.start_timer(
         'info',
         'Running full regression in {0} mode with "{1}" region filtration.',
@@ -166,7 +172,7 @@ def regression_single(
     last_time = time.time()
     with Pool() if regressions_per_chunk else nullcontext() as pool:
         for (gene_site, G_row) in G.iterrows():
-            y = torch.tensor(G_row, dtype=torch.float32).to(device)
+            y = torch.tensor(G_row.to_numpy(), dtype=torch.float32).to(device)
             for (meth_site, M_row) in M.iterrows():
                 if region != 'all':
                     if (

--- a/tests/test_logit.py
+++ b/tests/test_logit.py
@@ -1,0 +1,143 @@
+import os
+import sys
+import unittest
+import pandas as pd
+import numpy as np
+import torch
+
+# Ensure we can import tecpg
+root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if root_dir not in sys.path:
+    sys.path.insert(0, root_dir)
+
+from tecpg.test_data import generate_data
+from tecpg.regression_full import regression_full
+from tecpg.regression_single import regression_single
+from tecpg.processing import tecpg_mlr_lstsq
+from tecpg.helper import logit_transform_pandas
+from tecpg.logger import Logger
+
+class TestLogitTransform(unittest.TestCase):
+    def setUp(self):
+        # Generate small dummy data
+        self.sample_size = 50
+        self.m_loci = 20
+        self.g_loci = 10
+        self.M, self.G, self.C, self.M_annot, self.G_annot = generate_data(
+            self.sample_size, self.m_loci, self.g_loci, annotation=True
+        )
+        self.logger = Logger(carry_data={'use_cpu': True})
+        self.logger.start_timer()
+
+    def test_logit_transform_full(self):
+        # Manual transform
+        M_trans = logit_transform_pandas(self.M)
+
+        # Run regression_full with manual transform
+        res_manual = regression_full(
+            M_trans, self.G, self.C,
+            self.M_annot, self.G_annot,
+            region='all', p_thresh=None,
+            logger=self.logger,
+            logit_transform=False
+        )
+
+        # Run regression_full with flag
+        res_flag = regression_full(
+            self.M, self.G, self.C,
+            self.M_annot, self.G_annot,
+            region='all', p_thresh=None,
+            logger=self.logger,
+            logit_transform=True
+        )
+
+        # Compare results
+        # We expect them to be identical or very close
+        pd.testing.assert_frame_equal(res_manual, res_flag, check_exact=False, rtol=1e-3)
+
+        # Ensure they are DIFFERENT from non-transformed results
+        res_raw = regression_full(
+            self.M, self.G, self.C,
+            self.M_annot, self.G_annot,
+            region='all', p_thresh=None,
+            logger=self.logger,
+            logit_transform=False
+        )
+
+        # Check estimates are different
+        self.assertFalse(np.allclose(res_raw['mt_est'], res_flag['mt_est'], rtol=1e-3))
+
+    def test_logit_transform_lstsq(self):
+        # Manual transform
+        M_trans = logit_transform_pandas(self.M)
+
+        # Run lstsq with manual transform
+        res_manual = tecpg_mlr_lstsq(
+            M_trans, self.G, self.C,
+            self.M_annot, self.G_annot,
+            region='all', p_thresh=None,
+            logger=self.logger,
+            logit_transform=False
+        )
+
+        # Run lstsq with flag
+        res_flag = tecpg_mlr_lstsq(
+            self.M, self.G, self.C,
+            self.M_annot, self.G_annot,
+            region='all', p_thresh=None,
+            logger=self.logger,
+            logit_transform=True
+        )
+
+        # Compare results
+        pd.testing.assert_frame_equal(res_manual, res_flag, check_exact=False, rtol=1e-3)
+
+        # Ensure difference from raw
+        res_raw = tecpg_mlr_lstsq(
+            self.M, self.G, self.C,
+            self.M_annot, self.G_annot,
+            region='all', p_thresh=None,
+            logger=self.logger,
+            logit_transform=False
+        )
+        self.assertFalse(np.allclose(res_raw['mt_est'], res_flag['mt_est'], rtol=1e-3))
+
+    def test_logit_transform_single(self):
+        # Manual transform
+        M_trans = logit_transform_pandas(self.M)
+
+        # Run single with manual transform
+        # regression_single returns concatenated DF.
+        res_manual = regression_single(
+            M_trans, self.G, self.C,
+            region='all', p_thresh=None,
+            logger=self.logger,
+            logit_transform=False
+        )
+
+        # Run single with flag
+        res_flag = regression_single(
+            self.M, self.G, self.C,
+            region='all', p_thresh=None,
+            logger=self.logger,
+            logit_transform=True
+        )
+
+        # Compare results
+        pd.testing.assert_frame_equal(res_manual, res_flag, check_exact=False, rtol=1e-3)
+
+        # Ensure difference from raw
+        res_raw = regression_single(
+            self.M, self.G, self.C,
+            region='all', p_thresh=None,
+            logger=self.logger,
+            logit_transform=False
+        )
+        self.assertFalse(np.allclose(
+            res_raw['mt_est'].astype(float),
+            res_flag['mt_est'].astype(float),
+            rtol=1e-3
+        ))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds the `--logit-transform` option to `mlr` and `mlr_single` commands, allowing users to convert DNA methylation Beta values to M-values before regression analysis. The transformation uses a base-2 logarithm and clamps values to avoid numerical instability. It also includes a fix for Pandas Series to PyTorch tensor conversion in `regression_single.py`.

---
*PR created automatically by Jules for task [11357127383082929544](https://jules.google.com/task/11357127383082929544) started by @kordk*