### PR TITLE
Update MLR comparison and accuracy tests to include M-values

### DIFF
--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -16,14 +16,16 @@ import tecpg
 from tecpg.test_data import generate_data
 from tecpg.regression_full import regression_full
 from tecpg.logger import Logger
+from tecpg.helper import logit_transform_pandas
 
 try:
     from tests.validation_utils import run_statsmodels_ols, compare_results, save_scatter_plot
 except ImportError:
     from validation_utils import run_statsmodels_ols, compare_results, save_scatter_plot
 
-def main():
-    print("Starting tecpg accuracy validation test...")
+def run_accuracy_test(logit_transform=False):
+    transform_name = "M-values" if logit_transform else "Beta-values"
+    print(f"\nStarting tecpg accuracy validation test ({transform_name})...")
 
     # 1. Generate Data
     sample_size = 100
@@ -46,6 +48,7 @@ def main():
         M_annot, G_annot,
         region='all',
         p_thresh=None, # Get all results to validate
+        logit_transform=logit_transform,
         logger=logger
     )
 
@@ -69,6 +72,9 @@ def main():
         # Get data for this pair
         m_series = M.loc[mt_id]
         g_series = G.loc[gt_id]
+
+        if logit_transform:
+            m_series = logit_transform_pandas(m_series)
 
         # Get tecpg result row
         # tecpg index is (gt_id, mt_id)
@@ -145,7 +151,8 @@ def main():
     print(f"Degrees of Freedom: {df_val}")
 
     # 6. Save Report
-    report_path = "validation_report.csv"
+    suffix = "_transformed" if logit_transform else ""
+    report_path = f"validation_report{suffix}.csv"
     results_df.to_csv(report_path, index=False)
     print(f"Detailed validation results saved to {report_path}")
 
@@ -153,17 +160,25 @@ def main():
     print("Generating validation plots...")
     save_scatter_plot(results_df['sm_est'], results_df['tecpg_est'],
                       'Statsmodels Estimate', 'Tecpg Estimate',
-                      'Methylation Estimate Comparison', 'accuracy_est_comparison.png')
+                      f'Methylation Estimate Comparison ({transform_name})', f'accuracy_est_comparison{suffix}.png')
     save_scatter_plot(results_df['sm_err'], results_df['tecpg_err'],
                       'Statsmodels Std Error', 'Tecpg Std Error',
-                      'Methylation Std Error Comparison', 'accuracy_err_comparison.png')
+                      f'Methylation Std Error Comparison ({transform_name})', f'accuracy_err_comparison{suffix}.png')
     save_scatter_plot(results_df['sm_t'], results_df['tecpg_t'],
                       'Statsmodels T-stat', 'Tecpg T-stat',
-                      'Methylation T-statistic Comparison', 'accuracy_t_comparison.png')
+                      f'Methylation T-statistic Comparison ({transform_name})', f'accuracy_t_comparison{suffix}.png')
     save_scatter_plot(results_df['sm_p'], results_df['tecpg_p'],
                       'Statsmodels P-value', 'Tecpg P-value',
-                      'Methylation P-value Comparison', 'accuracy_p_comparison.png')
+                      f'Methylation P-value Comparison ({transform_name})', f'accuracy_p_comparison{suffix}.png')
     print("Plots saved to tests/plots/")
+
+def main():
+    try:
+        run_accuracy_test(logit_transform=False)
+        run_accuracy_test(logit_transform=True)
+    except Exception as e:
+        print(f"\nTEST FAILED: {e}")
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_mlr_comparison.py
+++ b/tests/test_mlr_comparison.py
@@ -74,7 +74,7 @@ def read_chunk_results(output_dir):
     full_df.sort_index(inplace=True)
     return full_df
 
-def run_comparison_test(test_name, M, G, C, M_annot=None, G_annot=None, **kwargs):
+def run_comparison_test(test_name, M, G, C, M_annot=None, G_annot=None, logit_transform=False, **kwargs):
     print(f"\n--- Running Test: {test_name} ---")
     logger = Logger()
 
@@ -83,7 +83,8 @@ def run_comparison_test(test_name, M, G, C, M_annot=None, G_annot=None, **kwargs
         'M_annot': M_annot, 'G_annot': G_annot,
         'logger': logger,
         'p_only': False,
-        'methylation_only': False
+        'methylation_only': False,
+        'logit_transform': logit_transform,
     }
     args.update(kwargs)
 
@@ -206,33 +207,47 @@ def main():
         g_rows = 50
         M, G, C = generate_data(sample_size, m_rows, g_rows, annotation=False)
 
-        run_comparison_test("All Region", M, G, C, region='all')
+        for logit_transform in [False, True]:
+            transform_suffix = " (M-values)" if logit_transform else " (Beta)"
 
-        run_comparison_test(
-            "All Region Chunked",
-            M, G, C,
-            region='all',
-            meth_loci_per_chunk=20,
-            output_dir="test_output_chunked"
-        )
+            run_comparison_test(
+                f"All Region{transform_suffix}",
+                M, G, C,
+                region='all',
+                logit_transform=logit_transform
+            )
+
+            run_comparison_test(
+                f"All Region Chunked{transform_suffix}",
+                M, G, C,
+                region='all',
+                meth_loci_per_chunk=20,
+                output_dir=f"test_output_chunked{'_transformed' if logit_transform else ''}",
+                logit_transform=logit_transform
+            )
 
         print("\nGenerating data with annotation...")
         M, G, C, M_annot, G_annot = generate_data(sample_size, m_rows, g_rows, annotation=True)
         M_annot.set_index('name', inplace=True)
         G_annot.set_index('name', inplace=True)
 
-        run_comparison_test(
-            "Cis Region",
-            M, G, C, M_annot, G_annot,
-            region='cis',
-            window_base=0, upstream=50000, downstream=50000
-        )
+        for logit_transform in [False, True]:
+            transform_suffix = " (M-values)" if logit_transform else " (Beta)"
 
-        run_comparison_test(
-            "Trans Region",
-            M, G, C, M_annot, G_annot,
-            region='trans'
-        )
+            run_comparison_test(
+                f"Cis Region{transform_suffix}",
+                M, G, C, M_annot, G_annot,
+                region='cis',
+                window_base=0, upstream=50000, downstream=50000,
+                logit_transform=logit_transform
+            )
+
+            run_comparison_test(
+                f"Trans Region{transform_suffix}",
+                M, G, C, M_annot, G_annot,
+                region='trans',
+                logit_transform=logit_transform
+            )
 
         print("\nAll tests passed successfully!")
 


### PR DESCRIPTION
This PR updates the test suite to ensure that the Multiple Linear Regression (MLR) implementations (`regression_full` and `tecpg_mlr_lstsq`) are validated not only on raw Beta values but also on logit-transformed M-values.

Changes:
- `tests/test_mlr_comparison.py`: Updated `main` to iterate through `logit_transform=[False, True]`, passing this flag to `run_comparison_test`.
- `tests/test_accuracy.py`: Refactored `main` into `run_accuracy_test` which accepts `logit_transform`. When `True`, it applies the logit transformation to the input methylation data before running the StatsModels OLS validation, ensuring a correct comparison against `tecpg`'s internal transformation.

This ensures that the transformation logic and the regression on transformed data are correctly implemented and consistent across backends and against reference implementations.

---
*PR created automatically by Jules for task [9411353381060530233](https://jules.google.com/task/9411353381060530233) started by @kordk*