### PR TITLE
Fix environment verification to check installed package version

### DIFF
--- a/tests/verify_env.sh
+++ b/tests/verify_env.sh
@@ -31,7 +31,7 @@ echo "✅ Git branch 'dev' is checked out."
 
 # 3. Verify Library Version and Installation Status
 # Querying the installed package metadata directly via Python
-TECPG_VERSION=$(python3 -c "
+TECPG_VERSION=$(cd / && python3 -c "
 try:
     import importlib.metadata
     print(importlib.metadata.version('tecpg'))


### PR DESCRIPTION
Modified `tests/verify_env.sh` to change directory to a neutral location (`/`) before checking the installed `tecpg` version.
This prevents `importlib.metadata` from picking up stale metadata (e.g., version `0.0.1`) from a local `tecpg.egg-info` directory or source tree in the current working directory, ensuring the verification reflects the actual package installed in the environment (e.g., `1.2.0.dev0`).

This resolves the issue where `verify_env.sh` reported `0.0.1` despite `pip install` correctly installing the latest development version.

---
*PR created automatically by Jules for task [8439414895845434477](https://jules.google.com/task/8439414895845434477) started by @kordk*