### PR TITLE
Add GPU and RAM usage logging to MLR methods

### DIFF
--- a/tecpg/logger.py
+++ b/tecpg/logger.py
@@ -1,4 +1,6 @@
 import os
+import psutil
+import torch
 import time
 from collections.abc import Mapping
 from datetime import datetime
@@ -139,7 +141,7 @@ class Logger(PassAsKwarg):
         self.get_time_func = time.perf_counter
         self.start_time = self.get_time_func()
         self.end_time = self.start_time
-        self.times: List[float] = []
+        self.times: List[float] = [self.start_time]
 
         self.timer_count: int = 0
         self.total_time: float = 0
@@ -318,6 +320,26 @@ class Logger(PassAsKwarg):
         iterations (including previous iterations).
         """
         return self.average_time * (n - self.timer_count)
+
+    def memory_check(self, function_name: str, *args, **kwargs) -> None:
+        """
+        Logs memory usage for RAM and GPU.
+        """
+        process = psutil.Process(os.getpid())
+        ram_usage = process.memory_info().rss / 1024 ** 2
+        if torch.cuda.is_available():
+            gpu_usage = torch.cuda.memory_allocated() / 1024 ** 2
+        else:
+            gpu_usage = 0
+
+        self.info(
+            '[{0}] RAM: {1:.2f} MB, GPU: {2:.2f} MB',
+            function_name,
+            ram_usage,
+            gpu_usage,
+            *args,
+            **kwargs,
+        )
 
     def save(
         self, log_dir: Optional[str] = None, file_name: Optional[str] = None

--- a/tecpg/regression_full.py
+++ b/tecpg/regression_full.py
@@ -261,6 +261,7 @@ def regression_full(
         for meth_chunk_index in (
             (0,) if meth_loci_per_chunk is None else range(meth_chunk_count)
         ):
+            logger.memory_check('regression_full')
             # Log methylation chunk index
             logger.info('STARTING METHYLATION CHUNK {0}', meth_chunk_index + 1)
             mc_logger.info_template = (
@@ -325,23 +326,9 @@ def regression_full(
             XtXi_Xt = XtXi.bmm(Xt)
             del Xt, XtXi
 
-            # Display amount of total memory occupied by the constants
-            # for the current methylation chunk (if the device is CUDA
-            # enabled)
-            if allocated_memory := torch.cuda.memory_allocated():
-                device_properties: torch.cuda._CudaDeviceProperties = (
-                    torch.cuda.get_device_properties(0)
-                )
-                total_memory: int = device_properties.total_memory
+            mc_logger.memory_check('regression_full')
+            if allocated_memory := torch.cuda.memory_allocated() if torch.cuda.is_available() else 0:
                 torch.cuda.empty_cache()
-                mc_logger.info(
-                    (
-                        'CUDA device memory: {0} MB allocated by constants out'
-                        ' of {1} MB total'
-                    ),
-                    allocated_memory / 1_000_000,
-                    total_memory / 1_000_000,
-                )
 
             # Inner loop over each gene expression locus
             last_index = 0
@@ -484,16 +471,7 @@ def regression_full(
                     # CUDA memory notice
                     if index == gene_loci_per_chunk and allocated_memory:
                         torch.cuda.empty_cache()
-                        allocated_memory = torch.cuda.max_memory_allocated()
-                        mc_logger.info(
-                            (
-                                'CUDA device memory, chunk 1: {0} MB allocated'
-                                ' out of {1} MB total. If needed, increase'
-                                ' --loci-per-chunk accordingly'
-                            ),
-                            allocated_memory / 1_000_000,
-                            total_memory / 1_000_000,
-                        )
+                        mc_logger.memory_check('regression_full')
 
                     # Save output with multiprocessing pool
                     mc_logger.count(

--- a/tecpg/regression_single.py
+++ b/tecpg/regression_single.py
@@ -121,6 +121,7 @@ def regression_single(
         ('methylation only' if methylation_only else 'full output'),
         region,
     )
+    logger.memory_check('regression_single')
 
     if output_dir is None and regressions_per_chunk:
         message = (
@@ -241,6 +242,7 @@ def regression_single(
                         regressions_per_chunk
                         and i % regressions_per_chunk == 0
                     ):
+                        logger.memory_check('regression_single')
                         file_name = str(logger.current_count + 1) + '.csv'
                         file_path = os.path.join(output_dir, file_name)
                         logger.count(


### PR DESCRIPTION
Implemented memory usage logging in `tecpg` for both `regression_full` and `regression_single`.

-   Added `memory_check` method to `tecpg/logger.py` using `psutil` and `torch.cuda`.
-   Updated `tecpg/regression_full.py` to log memory usage at the start of methylation chunks and replaced existing ad-hoc CUDA logging.
-   Updated `tecpg/regression_single.py` to log memory usage at start and during chunk saving.
-   Fixed a bug in `tecpg/logger.py` where `self.times` was not initialized, causing crashes if `time()` was called without `start_timer()`.


---
*PR created automatically by Jules for task [16520456924123611964](https://jules.google.com/task/16520456924123611964) started by @kordk*