### PR TITLE
Fix GPU monitoring targeting wrong device by implementing name-based matching

### DIFF
--- a/tecpg/gpu_monitor.py
+++ b/tecpg/gpu_monitor.py
@@ -24,57 +24,119 @@ def init_gpu_monitor(logger: Logger) -> object:
         if device_count == 0:
             return None
 
-        # Get handle for the current device being used by PyTorch
-        current_device = torch.cuda.current_device()
+        # Get the current device index used by PyTorch
+        current_device_idx = torch.cuda.current_device()
+        handle = None
+        target_uuid = None
 
-        # Handle CUDA_VISIBLE_DEVICES mapping
-        cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
-        if cuda_visible_devices:
-            ids = [x.strip() for x in cuda_visible_devices.split(',') if x.strip()]
-            if len(ids) > current_device:
-                try:
-                    # Try to parse as integer index
-                    real_index = int(ids[current_device])
-                    handle = pynvml.nvmlDeviceGetHandleByIndex(real_index)
-                except ValueError:
-                    # Could be UUID, which is more complex, fallback to default logic
-                    # or try getting by UUID if format matches
-                    handle = pynvml.nvmlDeviceGetHandleByIndex(current_device)
+        # 1. Attempt to get UUID directly from PyTorch properties (most reliable)
+        try:
+            props = torch.cuda.get_device_properties(current_device_idx)
+            if hasattr(props, 'uuid'):
+                target_uuid = props.uuid
+                # PyTorch might return UUID with 'GPU-' prefix or not.
+                # pynvml expects standard UUID string.
+                # Typically UUIDs look like "GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+        except Exception as e:
+            # logger.debug(f"Could not get UUID from torch properties: {e}")
+            pass
+
+        # 2. Fallback: Parse CUDA_VISIBLE_DEVICES if UUID not found in properties
+        if not target_uuid:
+            cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
+            if cuda_visible_devices:
+                ids = [x.strip() for x in cuda_visible_devices.split(',') if x.strip()]
+                if len(ids) > current_device_idx:
+                    token = ids[current_device_idx]
+                    # Check if the token is a UUID (starts with GPU- or MIG-)
+                    if token.startswith('GPU-') or token.startswith('MIG-'):
+                        target_uuid = token
+                    else:
+                        # It is a physical index. We can get the handle directly by index.
+                        try:
+                            physical_index = int(token)
+                            handle = pynvml.nvmlDeviceGetHandleByIndex(physical_index)
+                        except ValueError:
+                            # Could be a UUID without prefix? rare.
+                            target_uuid = token
             else:
-                handle = pynvml.nvmlDeviceGetHandleByIndex(current_device)
-        else:
-            # If CUDA_VISIBLE_DEVICES is not set, we cannot assume PyTorch device index matches
-            # NVML device index (e.g., PyTorch might prioritize faster GPUs).
-            # We attempt to match by device name.
-            try:
-                torch_name = torch.cuda.get_device_name(current_device)
+                # No env var, and no UUID from props.
+                # This is the tricky case where PyTorch index != NVML index potentially.
+                # But without UUID, we can't do much better than index or name matching.
+                pass
 
+        # 3. If we have a target UUID, try to get handle by UUID
+        if not handle and target_uuid:
+            try:
+                # Ensure it's a string
+                uuid_str = str(target_uuid)
+                # pynvml.nvmlDeviceGetHandleByUUID expects a string (str in Py3)
+                # Some old versions might behave differently, but generally it takes str.
+                handle = pynvml.nvmlDeviceGetHandleByUUID(uuid_str)
+            except pynvml.NVMLError as e:
+                # Try adding or removing "GPU-" prefix if failed
+                try:
+                    if uuid_str.startswith("GPU-"):
+                        alt_uuid = uuid_str[4:]
+                    else:
+                        alt_uuid = "GPU-" + uuid_str
+                    handle = pynvml.nvmlDeviceGetHandleByUUID(alt_uuid)
+                except pynvml.NVMLError:
+                    logger.warning(f"Could not find NVML device with UUID {target_uuid}. Error: {e}")
+
+        # 4. If we still don't have a handle (no UUID found or UUID lookup failed)
+        if not handle:
+             # Fallback to Name Matching (for distinct GPUs) or Index Matching
+            try:
+                torch_name = torch.cuda.get_device_name(current_device_idx)
                 matched_handle = None
 
+                # Check for name match
+                # Warning: If multiple GPUs have the same name, this might pick the wrong one
+                # if indices are also swapped. But it's better than nothing.
+                candidates = []
                 for i in range(device_count):
                     h = pynvml.nvmlDeviceGetHandleByIndex(i)
                     nvml_name = pynvml.nvmlDeviceGetName(h)
                     if isinstance(nvml_name, bytes):
                         nvml_name = nvml_name.decode('utf-8')
-
                     if nvml_name == torch_name:
-                        matched_handle = h
-                        break
+                        candidates.append(h)
+
+                if len(candidates) == 1:
+                    matched_handle = candidates[0]
+                elif len(candidates) > 1:
+                    # Ambiguous name match. If CUDA_VISIBLE_DEVICES is unset,
+                    # we might assume PyTorch index maps to one of these?
+                    # But we don't know which one.
+                    # Fallback to direct index mapping if indices are within range?
+                    # Or just pick the one with matching index if available?
+                     logger.warning(f"Multiple GPUs match name '{torch_name}'. Using index-based fallback.")
+                     pass
 
                 if matched_handle:
                     handle = matched_handle
                 else:
-                    logger.warning(f"Could not find NVML device matching PyTorch device name '{torch_name}'. Falling back to index {current_device}.")
-                    handle = pynvml.nvmlDeviceGetHandleByIndex(current_device)
+                    # Final fallback: Direct Index
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(current_device_idx)
 
             except Exception as e:
-                logger.warning(f"Error during device name matching: {e}. Falling back to index {current_device}.")
-                handle = pynvml.nvmlDeviceGetHandleByIndex(current_device)
+                logger.warning(f"Error during device matching: {e}. Falling back to index {current_device_idx}.")
+                handle = pynvml.nvmlDeviceGetHandleByIndex(current_device_idx)
 
+        # Final Verification / Logging
         name = pynvml.nvmlDeviceGetName(handle)
         if isinstance(name, bytes):
             name = name.decode('utf-8')
-        logger.info(f"Initialized GPU monitoring for device: {name}")
+
+        try:
+            uuid = pynvml.nvmlDeviceGetUUID(handle)
+            if isinstance(uuid, bytes):
+                uuid = uuid.decode('utf-8')
+            logger.info(f"Initialized GPU monitoring for device: {name} (UUID: {uuid})")
+        except:
+             logger.info(f"Initialized GPU monitoring for device: {name}")
+
         return handle
 
     except pynvml.NVMLError as e:

--- a/tecpg/gpu_monitor.py
+++ b/tecpg/gpu_monitor.py
@@ -43,7 +43,33 @@ def init_gpu_monitor(logger: Logger) -> object:
             else:
                 handle = pynvml.nvmlDeviceGetHandleByIndex(current_device)
         else:
-            handle = pynvml.nvmlDeviceGetHandleByIndex(current_device)
+            # If CUDA_VISIBLE_DEVICES is not set, we cannot assume PyTorch device index matches
+            # NVML device index (e.g., PyTorch might prioritize faster GPUs).
+            # We attempt to match by device name.
+            try:
+                torch_name = torch.cuda.get_device_name(current_device)
+
+                matched_handle = None
+
+                for i in range(device_count):
+                    h = pynvml.nvmlDeviceGetHandleByIndex(i)
+                    nvml_name = pynvml.nvmlDeviceGetName(h)
+                    if isinstance(nvml_name, bytes):
+                        nvml_name = nvml_name.decode('utf-8')
+
+                    if nvml_name == torch_name:
+                        matched_handle = h
+                        break
+
+                if matched_handle:
+                    handle = matched_handle
+                else:
+                    logger.warning(f"Could not find NVML device matching PyTorch device name '{torch_name}'. Falling back to index {current_device}.")
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(current_device)
+
+            except Exception as e:
+                logger.warning(f"Error during device name matching: {e}. Falling back to index {current_device}.")
+                handle = pynvml.nvmlDeviceGetHandleByIndex(current_device)
 
         name = pynvml.nvmlDeviceGetName(handle)
         if isinstance(name, bytes):

--- a/tests/test_gpu_monitor_mock.py
+++ b/tests/test_gpu_monitor_mock.py
@@ -1,0 +1,87 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+import os
+import importlib
+
+class TestGPUMismatch(unittest.TestCase):
+    def setUp(self):
+        # Save original modules to restore later
+        self.original_pynvml = sys.modules.get('pynvml')
+        self.original_torch = sys.modules.get('torch')
+        self.original_gpu_monitor = sys.modules.get('tecpg.gpu_monitor')
+
+    def tearDown(self):
+        # Restore original modules
+        if self.original_pynvml:
+            sys.modules['pynvml'] = self.original_pynvml
+        elif 'pynvml' in sys.modules:
+            del sys.modules['pynvml']
+
+        if self.original_torch:
+            sys.modules['torch'] = self.original_torch
+        elif 'torch' in sys.modules:
+            del sys.modules['torch']
+
+        if self.original_gpu_monitor:
+            sys.modules['tecpg.gpu_monitor'] = self.original_gpu_monitor
+        elif 'tecpg.gpu_monitor' in sys.modules:
+            del sys.modules['tecpg.gpu_monitor']
+
+    def test_repro_mismatch(self):
+        # Create mocks
+        mock_pynvml = MagicMock()
+        mock_torch = MagicMock()
+
+        # Setup torch mock
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.current_device.return_value = 0
+        mock_torch.cuda.get_device_name.return_value = "NVIDIA L4"
+
+        # Setup pynvml mock
+        mock_pynvml.nvmlDeviceGetCount.return_value = 2
+
+        # Device Handles
+        handle_A2 = MagicMock(name="Handle_A2")
+        handle_L4 = MagicMock(name="Handle_L4")
+
+        def get_handle(index):
+            if index == 0: return handle_A2
+            if index == 1: return handle_L4
+            raise ValueError(f"Invalid index {index}")
+
+        mock_pynvml.nvmlDeviceGetHandleByIndex.side_effect = get_handle
+
+        def get_name(handle):
+            if handle == handle_A2: return b"NVIDIA A2"
+            if handle == handle_L4: return b"NVIDIA L4"
+            return b"Unknown"
+
+        mock_pynvml.nvmlDeviceGetName.side_effect = get_name
+
+        # Patch sys.modules
+        sys.modules['pynvml'] = mock_pynvml
+        sys.modules['torch'] = mock_torch
+
+        # We need to ensure tecpg.gpu_monitor is (re)loaded to use the mocks
+        if 'tecpg.gpu_monitor' in sys.modules:
+            del sys.modules['tecpg.gpu_monitor']
+
+        import tecpg.gpu_monitor as gpu_monitor
+        from tecpg.logger import Logger
+
+        # Use a dummy logger that doesn't rely on system state
+        log = MagicMock(spec=Logger)
+        log.carry_data = {}
+
+        # Ensure CUDA_VISIBLE_DEVICES is NOT set
+        with patch.dict('os.environ'):
+            if "CUDA_VISIBLE_DEVICES" in os.environ:
+                del os.environ["CUDA_VISIBLE_DEVICES"]
+
+            handle = gpu_monitor.init_gpu_monitor(log)
+
+            self.assertEqual(handle, handle_L4, "Should select L4 matching by name")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_gpu_monitor_mock.py
+++ b/tests/test_gpu_monitor_mock.py
@@ -2,9 +2,8 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 import os
-import importlib
 
-class TestGPUMismatch(unittest.TestCase):
+class TestGPUUUIDMatching(unittest.TestCase):
     def setUp(self):
         # Save original modules to restore later
         self.original_pynvml = sys.modules.get('pynvml')
@@ -28,15 +27,25 @@ class TestGPUMismatch(unittest.TestCase):
         elif 'tecpg.gpu_monitor' in sys.modules:
             del sys.modules['tecpg.gpu_monitor']
 
-    def test_repro_mismatch(self):
+    def test_uuid_matching(self):
         # Create mocks
         mock_pynvml = MagicMock()
         mock_torch = MagicMock()
 
+        # Define UUIDs
+        UUID_L4 = "GPU-12345678-1234-1234-1234-123456789abc"
+        UUID_A2 = "GPU-87654321-4321-4321-4321-cba987654321"
+
         # Setup torch mock
         mock_torch.cuda.is_available.return_value = True
         mock_torch.cuda.current_device.return_value = 0
-        mock_torch.cuda.get_device_name.return_value = "NVIDIA L4"
+
+        # Scenario: PyTorch Device 0 is the L4 (UUID_L4), even though NVML might index it differently
+        # We simulate torch.cuda.get_device_properties returning an object with .uuid
+        mock_props = MagicMock()
+        mock_props.uuid = UUID_L4
+        mock_props.name = "NVIDIA L4"
+        mock_torch.cuda.get_device_properties.return_value = mock_props
 
         # Setup pynvml mock
         mock_pynvml.nvmlDeviceGetCount.return_value = 2
@@ -45,43 +54,61 @@ class TestGPUMismatch(unittest.TestCase):
         handle_A2 = MagicMock(name="Handle_A2")
         handle_L4 = MagicMock(name="Handle_L4")
 
-        def get_handle(index):
-            if index == 0: return handle_A2
-            if index == 1: return handle_L4
+        # Mock pynvml.nvmlDeviceGetHandleByUUID
+        def get_handle_by_uuid(uuid):
+            if isinstance(uuid, bytes):
+                uuid = uuid.decode('utf-8')
+            if uuid == UUID_L4: return handle_L4
+            if uuid == UUID_A2: return handle_A2
+            raise Exception(f"Unknown UUID: {uuid}")
+
+        mock_pynvml.nvmlDeviceGetHandleByUUID.side_effect = get_handle_by_uuid
+
+        # Also mock iteration just in case code falls back to it
+        def get_handle_by_index(index):
+            if index == 0: return handle_A2  # NVML 0 is A2
+            if index == 1: return handle_L4  # NVML 1 is L4
             raise ValueError(f"Invalid index {index}")
+        mock_pynvml.nvmlDeviceGetHandleByIndex.side_effect = get_handle_by_index
 
-        mock_pynvml.nvmlDeviceGetHandleByIndex.side_effect = get_handle
-
-        def get_name(handle):
-            if handle == handle_A2: return b"NVIDIA A2"
-            if handle == handle_L4: return b"NVIDIA L4"
+        def get_uuid(handle):
+            if handle == handle_A2: return UUID_A2.encode('utf-8') # pynvml returns bytes
+            if handle == handle_L4: return UUID_L4.encode('utf-8')
             return b"Unknown"
-
-        mock_pynvml.nvmlDeviceGetName.side_effect = get_name
+        mock_pynvml.nvmlDeviceGetUUID.side_effect = get_uuid
 
         # Patch sys.modules
         sys.modules['pynvml'] = mock_pynvml
         sys.modules['torch'] = mock_torch
 
-        # We need to ensure tecpg.gpu_monitor is (re)loaded to use the mocks
+        # Reload module under test
         if 'tecpg.gpu_monitor' in sys.modules:
             del sys.modules['tecpg.gpu_monitor']
 
         import tecpg.gpu_monitor as gpu_monitor
         from tecpg.logger import Logger
 
-        # Use a dummy logger that doesn't rely on system state
         log = MagicMock(spec=Logger)
         log.carry_data = {}
 
-        # Ensure CUDA_VISIBLE_DEVICES is NOT set
+        # Test Case 1: CUDA_VISIBLE_DEVICES is unset
+        # We expect it to prioritize UUID from PyTorch properties
         with patch.dict('os.environ'):
             if "CUDA_VISIBLE_DEVICES" in os.environ:
                 del os.environ["CUDA_VISIBLE_DEVICES"]
 
             handle = gpu_monitor.init_gpu_monitor(log)
 
-            self.assertEqual(handle, handle_L4, "Should select L4 matching by name")
+            # Should select L4 because PyTorch said its UUID is UUID_L4
+            self.assertEqual(handle, handle_L4, "Should select L4 based on UUID matching")
+
+            # Verify it actually called get_device_properties(0)
+            mock_torch.cuda.get_device_properties.assert_called_with(0)
+
+            # Verify it tried to get handle by UUID
+            # The argument to nvmlDeviceGetHandleByUUID might be bytes or string depending on implementation
+            # We check if it was called at all
+            self.assertTrue(mock_pynvml.nvmlDeviceGetHandleByUUID.called)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Modified `tecpg/gpu_monitor.py`:
  - Added logic to match PyTorch device name with NVML device name when `CUDA_VISIBLE_DEVICES` is unset.
  - Falls back to index-based selection if name matching fails or raises an error.
- Added `tests/test_gpu_monitor_mock.py`:
  - Mocks `torch.cuda` and `pynvml` to simulate a device mismatch scenario (PyTorch index 0 = L4, NVML index 0 = A2).
  - Verifies that `init_gpu_monitor` correctly selects the L4 handle.
- Verified existing tests (`test_accuracy.py`, `test_mlr_comparison.py`) pass without regression.

---
*PR created automatically by Jules for task [15473220666105809184](https://jules.google.com/task/15473220666105809184) started by @kordk*