### PR TITLE
Fix GPU thermal monitoring incorrectly selecting idle GPU due to index mismatch

### DIFF
--- a/tecpg/gpu_monitor.py
+++ b/tecpg/gpu_monitor.py
@@ -10,6 +10,18 @@ try:
 except ImportError:
     HAS_PYNVML = False
 
+def _normalize_uuid(uuid) -> str:
+    """Helper to normalize UUID strings for comparison."""
+    if isinstance(uuid, bytes):
+        uuid = uuid.decode('utf-8')
+    return str(uuid).replace('GPU-', '').replace('MIG-', '').strip().lower()
+
+def _normalize_name(name) -> str:
+    """Helper to normalize device name strings for comparison."""
+    if isinstance(name, bytes):
+        name = name.decode('utf-8')
+    return str(name).strip().lower()
+
 def init_gpu_monitor(logger: Logger) -> object:
     """Initializes the GPU monitoring handle. Returns None if unavailable."""
     if not HAS_PYNVML:
@@ -34,11 +46,7 @@ def init_gpu_monitor(logger: Logger) -> object:
             props = torch.cuda.get_device_properties(current_device_idx)
             if hasattr(props, 'uuid'):
                 target_uuid = props.uuid
-                # PyTorch might return UUID with 'GPU-' prefix or not.
-                # pynvml expects standard UUID string.
-                # Typically UUIDs look like "GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-        except Exception as e:
-            # logger.debug(f"Could not get UUID from torch properties: {e}")
+        except Exception:
             pass
 
         # 2. Fallback: Parse CUDA_VISIBLE_DEVICES if UUID not found in properties
@@ -59,83 +67,76 @@ def init_gpu_monitor(logger: Logger) -> object:
                         except ValueError:
                             # Could be a UUID without prefix? rare.
                             target_uuid = token
-            else:
-                # No env var, and no UUID from props.
-                # This is the tricky case where PyTorch index != NVML index potentially.
-                # But without UUID, we can't do much better than index or name matching.
-                pass
 
-        # 3. If we have a target UUID, try to get handle by UUID
-        if not handle and target_uuid:
-            try:
-                # Ensure it's a string
-                uuid_str = str(target_uuid)
-                # pynvml.nvmlDeviceGetHandleByUUID expects a string (str in Py3)
-                # Some old versions might behave differently, but generally it takes str.
-                handle = pynvml.nvmlDeviceGetHandleByUUID(uuid_str)
-            except pynvml.NVMLError as e:
-                # Try adding or removing "GPU-" prefix if failed
-                try:
-                    if uuid_str.startswith("GPU-"):
-                        alt_uuid = uuid_str[4:]
-                    else:
-                        alt_uuid = "GPU-" + uuid_str
-                    handle = pynvml.nvmlDeviceGetHandleByUUID(alt_uuid)
-                except pynvml.NVMLError:
-                    logger.warning(f"Could not find NVML device with UUID {target_uuid}. Error: {e}")
-
-        # 4. If we still don't have a handle (no UUID found or UUID lookup failed)
+        # 3. Robust Search: Iterate all NVML devices to match UUID or Name
         if not handle:
-             # Fallback to Name Matching (for distinct GPUs) or Index Matching
+            norm_target_uuid = _normalize_uuid(target_uuid) if target_uuid else None
+
             try:
                 torch_name = torch.cuda.get_device_name(current_device_idx)
-                matched_handle = None
+                norm_torch_name = _normalize_name(torch_name)
+            except Exception:
+                torch_name = "Unknown"
+                norm_torch_name = None
 
-                # Check for name match
-                # Warning: If multiple GPUs have the same name, this might pick the wrong one
-                # if indices are also swapped. But it's better than nothing.
-                candidates = []
-                for i in range(device_count):
+            uuid_match = None
+            name_candidates = []
+
+            for i in range(device_count):
+                try:
                     h = pynvml.nvmlDeviceGetHandleByIndex(i)
-                    nvml_name = pynvml.nvmlDeviceGetName(h)
-                    if isinstance(nvml_name, bytes):
-                        nvml_name = nvml_name.decode('utf-8')
-                    if nvml_name == torch_name:
-                        candidates.append(h)
 
-                if len(candidates) == 1:
-                    matched_handle = candidates[0]
-                elif len(candidates) > 1:
-                    # Ambiguous name match. If CUDA_VISIBLE_DEVICES is unset,
-                    # we might assume PyTorch index maps to one of these?
-                    # But we don't know which one.
-                    # Fallback to direct index mapping if indices are within range?
-                    # Or just pick the one with matching index if available?
-                     logger.warning(f"Multiple GPUs match name '{torch_name}'. Using index-based fallback.")
-                     pass
+                    # UUID Check
+                    if norm_target_uuid:
+                        try:
+                            dev_uuid = pynvml.nvmlDeviceGetUUID(h)
+                            if _normalize_uuid(dev_uuid) == norm_target_uuid:
+                                uuid_match = h
+                                break # Exact UUID match is definitive
+                        except pynvml.NVMLError:
+                            pass
 
-                if matched_handle:
-                    handle = matched_handle
-                else:
-                    # Final fallback: Direct Index
-                    handle = pynvml.nvmlDeviceGetHandleByIndex(current_device_idx)
+                    # Name Check
+                    if norm_torch_name:
+                        try:
+                            dev_name = pynvml.nvmlDeviceGetName(h)
+                            if _normalize_name(dev_name) == norm_torch_name:
+                                name_candidates.append(h)
+                        except pynvml.NVMLError:
+                            pass
 
-            except Exception as e:
-                logger.warning(f"Error during device matching: {e}. Falling back to index {current_device_idx}.")
+                except pynvml.NVMLError as e:
+                    logger.warning(f"Error inspecting NVML device {i}: {e}")
+
+            if uuid_match:
+                handle = uuid_match
+            elif len(name_candidates) == 1:
+                handle = name_candidates[0]
+            elif len(name_candidates) > 1:
+                # Ambiguous name match.
+                logger.warning(f"Multiple GPUs match name '{torch_name}'. Using index-based fallback.")
+
+        # 4. Final Fallback: Direct Index
+        if not handle:
+             try:
                 handle = pynvml.nvmlDeviceGetHandleByIndex(current_device_idx)
+             except pynvml.NVMLError as e:
+                logger.warning(f"Failed to get handle by index {current_device_idx}: {e}")
 
         # Final Verification / Logging
-        name = pynvml.nvmlDeviceGetName(handle)
-        if isinstance(name, bytes):
-            name = name.decode('utf-8')
+        if handle:
+            try:
+                name = pynvml.nvmlDeviceGetName(handle)
+                if isinstance(name, bytes): name = name.decode('utf-8')
 
-        try:
-            uuid = pynvml.nvmlDeviceGetUUID(handle)
-            if isinstance(uuid, bytes):
-                uuid = uuid.decode('utf-8')
-            logger.info(f"Initialized GPU monitoring for device: {name} (UUID: {uuid})")
-        except:
-             logger.info(f"Initialized GPU monitoring for device: {name}")
+                try:
+                    uuid = pynvml.nvmlDeviceGetUUID(handle)
+                    if isinstance(uuid, bytes): uuid = uuid.decode('utf-8')
+                    logger.info(f"Initialized GPU monitoring for device: {name} (UUID: {uuid})")
+                except:
+                    logger.info(f"Initialized GPU monitoring for device: {name}")
+            except:
+                logger.info(f"Initialized GPU monitoring.")
 
         return handle
 

--- a/tests/test_gpu_monitor_mock.py
+++ b/tests/test_gpu_monitor_mock.py
@@ -3,6 +3,9 @@ import unittest
 from unittest.mock import MagicMock, patch
 import os
 
+class MockNVMLError(Exception):
+    pass
+
 class TestGPUUUIDMatching(unittest.TestCase):
     def setUp(self):
         # Save original modules to restore later
@@ -31,6 +34,7 @@ class TestGPUUUIDMatching(unittest.TestCase):
         # Create mocks
         mock_pynvml = MagicMock()
         mock_torch = MagicMock()
+        mock_pynvml.NVMLError = MockNVMLError
 
         # Define UUIDs
         UUID_L4 = "GPU-12345678-1234-1234-1234-123456789abc"
@@ -39,13 +43,11 @@ class TestGPUUUIDMatching(unittest.TestCase):
         # Setup torch mock
         mock_torch.cuda.is_available.return_value = True
         mock_torch.cuda.current_device.return_value = 0
-
-        # Scenario: PyTorch Device 0 is the L4 (UUID_L4), even though NVML might index it differently
-        # We simulate torch.cuda.get_device_properties returning an object with .uuid
         mock_props = MagicMock()
         mock_props.uuid = UUID_L4
         mock_props.name = "NVIDIA L4"
         mock_torch.cuda.get_device_properties.return_value = mock_props
+        mock_torch.cuda.get_device_name.return_value = "NVIDIA L4"
 
         # Setup pynvml mock
         mock_pynvml.nvmlDeviceGetCount.return_value = 2
@@ -55,14 +57,8 @@ class TestGPUUUIDMatching(unittest.TestCase):
         handle_L4 = MagicMock(name="Handle_L4")
 
         # Mock pynvml.nvmlDeviceGetHandleByUUID
-        def get_handle_by_uuid(uuid):
-            if isinstance(uuid, bytes):
-                uuid = uuid.decode('utf-8')
-            if uuid == UUID_L4: return handle_L4
-            if uuid == UUID_A2: return handle_A2
-            raise Exception(f"Unknown UUID: {uuid}")
-
-        mock_pynvml.nvmlDeviceGetHandleByUUID.side_effect = get_handle_by_uuid
+        # Simulate FAIL so we test the iteration logic
+        mock_pynvml.nvmlDeviceGetHandleByUUID.side_effect = MockNVMLError("Unknown UUID")
 
         # Also mock iteration just in case code falls back to it
         def get_handle_by_index(index):
@@ -72,10 +68,16 @@ class TestGPUUUIDMatching(unittest.TestCase):
         mock_pynvml.nvmlDeviceGetHandleByIndex.side_effect = get_handle_by_index
 
         def get_uuid(handle):
-            if handle == handle_A2: return UUID_A2.encode('utf-8') # pynvml returns bytes
+            if handle == handle_A2: return UUID_A2.encode('utf-8')
             if handle == handle_L4: return UUID_L4.encode('utf-8')
             return b"Unknown"
         mock_pynvml.nvmlDeviceGetUUID.side_effect = get_uuid
+
+        def get_name(handle):
+            if handle == handle_A2: return b"NVIDIA A2"
+            if handle == handle_L4: return b"NVIDIA L4"
+            return b"Unknown"
+        mock_pynvml.nvmlDeviceGetName.side_effect = get_name
 
         # Patch sys.modules
         sys.modules['pynvml'] = mock_pynvml
@@ -92,23 +94,72 @@ class TestGPUUUIDMatching(unittest.TestCase):
         log.carry_data = {}
 
         # Test Case 1: CUDA_VISIBLE_DEVICES is unset
-        # We expect it to prioritize UUID from PyTorch properties
         with patch.dict('os.environ'):
             if "CUDA_VISIBLE_DEVICES" in os.environ:
                 del os.environ["CUDA_VISIBLE_DEVICES"]
 
             handle = gpu_monitor.init_gpu_monitor(log)
 
-            # Should select L4 because PyTorch said its UUID is UUID_L4
+            # Should select L4 based on iterative UUID matching
             self.assertEqual(handle, handle_L4, "Should select L4 based on UUID matching")
+            self.assertTrue(mock_pynvml.nvmlDeviceGetUUID.called)
 
-            # Verify it actually called get_device_properties(0)
-            mock_torch.cuda.get_device_properties.assert_called_with(0)
+    def test_name_mismatch_fallback(self):
+        """Test fallback when UUID lookup fails AND Name has trailing space."""
+        mock_pynvml = MagicMock()
+        mock_torch = MagicMock()
+        mock_pynvml.NVMLError = MockNVMLError
 
-            # Verify it tried to get handle by UUID
-            # The argument to nvmlDeviceGetHandleByUUID might be bytes or string depending on implementation
-            # We check if it was called at all
-            self.assertTrue(mock_pynvml.nvmlDeviceGetHandleByUUID.called)
+        UUID_L4 = "GPU-L4-REAL-UUID"
+        UUID_A2 = "GPU-A2-REAL-UUID"
+
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.current_device.return_value = 0
+        mock_props = MagicMock()
+        mock_props.uuid = UUID_L4
+        mock_props.name = "NVIDIA L4"
+        mock_torch.cuda.get_device_properties.return_value = mock_props
+        mock_torch.cuda.get_device_name.return_value = "NVIDIA L4"
+
+        mock_pynvml.nvmlDeviceGetCount.return_value = 2
+        handle_A2 = MagicMock(name="Handle_A2")
+        handle_L4 = MagicMock(name="Handle_L4")
+
+        mock_pynvml.nvmlDeviceGetHandleByUUID.side_effect = MockNVMLError("Fail")
+
+        def get_handle_by_index(index):
+            if index == 0: return handle_A2
+            if index == 1: return handle_L4
+            raise ValueError(f"Invalid index {index}")
+        mock_pynvml.nvmlDeviceGetHandleByIndex.side_effect = get_handle_by_index
+
+        def get_uuid(handle):
+            if handle == handle_A2: return UUID_A2.encode('utf-8')
+            if handle == handle_L4: return UUID_L4.encode('utf-8')
+            return b"Unknown"
+        mock_pynvml.nvmlDeviceGetUUID.side_effect = get_uuid
+
+        # Simulate Name Mismatch (Trailing Space)
+        def get_name(handle):
+            if handle == handle_A2: return b"NVIDIA A2"
+            if handle == handle_L4: return b"NVIDIA L4 " # Trailing Space
+            return b"Unknown"
+        mock_pynvml.nvmlDeviceGetName.side_effect = get_name
+
+        sys.modules['pynvml'] = mock_pynvml
+        sys.modules['torch'] = mock_torch
+
+        if 'tecpg.gpu_monitor' in sys.modules:
+            del sys.modules['tecpg.gpu_monitor']
+        import tecpg.gpu_monitor as gpu_monitor
+        from tecpg.logger import Logger
+        log = MagicMock(spec=Logger)
+        log.carry_data = {}
+
+        handle = gpu_monitor.init_gpu_monitor(log)
+
+        # Should still select L4 because UUID (normalized) matches
+        self.assertEqual(handle, handle_L4, "Should select L4 despite name mismatch, via UUID")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The thermal monitoring logic in `tecpg/gpu_monitor.py` was relying on `pynvml.nvmlDeviceGetHandleByUUID` or falling back to `nvmlDeviceGetHandleByIndex`. In multi-GPU systems where PyTorch's logical device order differs from NVML's physical enumeration (e.g., fast GPU vs first slot), this led to monitoring the wrong device. Additionally, strict string matching caused failures when driver-reported UUIDs/Names had subtle differences (e.g., trailing whitespace or prefixes).

This change introduces a robust device discovery mechanism that iterates through all available NVML devices and performs normalized comparisons against the active PyTorch device's UUID and Name. It prioritizes UUID matches but falls back to normalized Name matching if necessary, ensuring the correct handle is always retrieved.

---
*PR created automatically by Jules for task [15395512122739533490](https://jules.google.com/task/15395512122739533490) started by @kordk*