### PR TITLE
Add version reporting and unify version source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,20 @@ requirements_path = os.path.join(dir_path, requirements_file)
 with open(requirements_path, 'r') as file:
     requirements = [line.removesuffix('\n') for line in file.readlines()]
 
+version_file = 'tecpg/__init__.py'
+version_path = os.path.join(dir_path, version_file)
+with open(version_path, 'r') as file:
+    # Assuming the file contains a line like: __version__ = '1.2.6-dev'
+    for line in file:
+        if line.startswith('__version__'):
+            version = line.split('=')[1].strip().strip("'").strip('"')
+            break
+    else:
+        raise RuntimeError("Unable to find version string in tecpg/__init__.py")
+
 setup(
     name='tecpg',
-    version='1.2.6-dev',  # See tecpg/tecpg/__init__.py
+    version=version,
     description='Python eCpG mapper with CLI using pytorch',
     long_description=long_description,  # See tecpg/README.md
     python_requires='>=3.10',

--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -8,6 +8,7 @@ import pandas
 import psutil
 import torch
 
+from . import __version__
 from .config import (
     DEFAULT_CIS_DOWNSTREAM,
     DEFAULT_CIS_UPSTREAM,
@@ -41,6 +42,7 @@ from .tool import (
 
 
 @click.group()
+@click.version_option(version=__version__, message='tecpg version %(version)s')
 @click.option(
     '-r',
     '--root-path',
@@ -186,6 +188,7 @@ def cli(
 
     log_path = None if no_log_file else os.path.join(root_path, log_dir)
     logger = Logger(verbosity, debug, log_path)
+    logger.info('tecpg version {0}', __version__)
     using_gpu(**logger)
     if cpu_threads:
         torch.set_num_threads(cpu_threads)


### PR DESCRIPTION
Implemented version reporting as requested. 

1.  **Unified Version Source**: `setup.py` now parses `tecpg/__init__.py` to get the version, removing the need to manually update `setup.py` when the version changes.
2.  **CLI Flag**: Added `--version` flag to the `tecpg` command, which outputs `tecpg version X.Y.Z`.
3.  **Startup Logging**: The version is now logged at the `INFO` level when the CLI starts, providing visibility in logs.

---
*PR created automatically by Jules for task [16585423324570927614](https://jules.google.com/task/16585423324570927614) started by @kordk*