### PR TITLE
Fix GPU memory reporting and track peak usage

### DIFF
--- a/tecpg/logger.py
+++ b/tecpg/logger.py
@@ -328,18 +328,31 @@ class Logger(PassAsKwarg):
         process = psutil.Process(os.getpid())
         ram_usage = process.memory_info().rss / 1024 ** 2
         if torch.cuda.is_available():
-            gpu_usage = torch.cuda.memory_allocated() / 1024 ** 2
+            gpu_allocated = torch.cuda.memory_allocated() / 1024 ** 2
+            gpu_reserved = torch.cuda.memory_reserved() / 1024 ** 2
         else:
-            gpu_usage = 0
+            gpu_allocated = 0
+            gpu_reserved = 0
 
-        self.info(
-            '[{0}] RAM: {1:.2f} MB, GPU: {2:.2f} MB',
-            function_name,
-            ram_usage,
-            gpu_usage,
-            *args,
-            **kwargs,
-        )
+        if torch.cuda.is_available():
+            self.info(
+                '[{0}] RAM: {1:.2f} MB, GPU: {2:.2f} MB Allocated, {3:.2f} MB Reserved',
+                function_name,
+                ram_usage,
+                gpu_allocated,
+                gpu_reserved,
+                *args,
+                **kwargs,
+            )
+        else:
+            self.info(
+                '[{0}] RAM: {1:.2f} MB, GPU: {2:.2f} MB',
+                function_name,
+                ram_usage,
+                gpu_allocated,
+                *args,
+                **kwargs,
+            )
 
     def save(
         self, log_dir: Optional[str] = None, file_name: Optional[str] = None

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -347,15 +347,18 @@ def tecpg_mlr_lstsq(
                 # We want B to match M_chunk dim.
                 # So expand Y to (M_chunk, S, G_chunk).
                 Y_expanded = Y.unsqueeze(0).expand(mt_count, -1, -1)
+                inner_logger.memory_check('tecpg_mlr_lstsq - target expanded')
 
                 # Coefficients B
                 lstsq_result = torch.linalg.lstsq(X, Y_expanded)
+                inner_logger.memory_check('tecpg_mlr_lstsq - lstsq result')
                 B = lstsq_result.solution # (M_chunk, K, G_chunk)
 
                 # Calculate Residuals E = Y - X B
                 # X: (M, S, K). B: (M, K, G).
                 # X @ B -> (M, S, G).
                 E = Y_expanded - X.matmul(B)
+                inner_logger.memory_check('tecpg_mlr_lstsq - residuals')
 
                 # RSS = sum(E^2, dim=1) -> (M, G)
                 RSS = E.pow(2).sum(dim=1)
@@ -392,6 +395,7 @@ def tecpg_mlr_lstsq(
                 S = S.permute(0, 2, 1)
                 T = B / S
                 P = normal_p(T)
+                inner_logger.memory_check('tecpg_mlr_lstsq - pvals')
 
                 # Now we have tensors of shape (M, G, K).
                 # We need to flatten to (M*G, K) to apply filters efficiently?


### PR DESCRIPTION
Fixes an issue where GPU memory usage is severely under-reported because it only logs the currently allocated tensor memory instead of the actual memory reserved by PyTorch's caching allocator from the OS. It resolves discrepancies with external tools like `nvitop`. Additionally, strategic memory checks have been inserted directly into the `tecpg_mlr_lstsq` calculation loops to better observe peak memory consumption.

---
*PR created automatically by Jules for task [9163709786737680985](https://jules.google.com/task/9163709786737680985) started by @kordk*