### PR TITLE
Fix undefined variable `meth_count` and test paths

### DIFF
--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -190,7 +190,7 @@ def tecpg_mlr_lstsq(
     do_reservoir = reservoir_count is not None and reservoir_count > 0
     if do_reservoir:
         expected_items = (
-            int(meth_count * gene_count)
+            len(M) * len(G)
             if region == 'all'
             else "unknown (region filtration applied)"
         )

--- a/tests/test_merge_tool.py
+++ b/tests/test_merge_tool.py
@@ -8,7 +8,7 @@ import numpy as np
 
 # Adjust path to import the tool if needed, but we will run it as a subprocess
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-TOOL_PATH = os.path.join(REPO_ROOT, 'tecpg', 'tools', 'mergeOutputs.py')
+TOOL_PATH = os.path.join(REPO_ROOT, 'tools', 'mergeOutputs.py')
 
 class TestMergeTool(unittest.TestCase):
     def setUp(self):

--- a/tests/test_recalculate_pvalues.py
+++ b/tests/test_recalculate_pvalues.py
@@ -43,7 +43,7 @@ class TestRecalculatePValues(unittest.TestCase):
         # Using sys.executable ensures we use the same python interpreter
         cmd = [
             sys.executable,
-            'tecpg/tools/recalculate_pvalues.py',
+            'tools/recalculate_pvalues.py',
             self.input_file,
             '--n-patients', str(n_patients),
             '--n-covariates', str(n_covariates),
@@ -92,7 +92,7 @@ class TestRecalculatePValues(unittest.TestCase):
         # Run the script without --output-file
         cmd = [
             sys.executable,
-            'tecpg/tools/recalculate_pvalues.py',
+            'tools/recalculate_pvalues.py',
             self.input_file,
             '--n-patients', str(n_patients),
             '--n-covariates', str(n_covariates)


### PR DESCRIPTION
This PR fixes a `NameError` ("name 'meth_count' is not defined") that crashes the application during the initialization of regression variables in the reservoir sampling logic. Additionally, it updates broken tests caused by moving tooling scripts to a base `tools/` directory.

---
*PR created automatically by Jules for task [8714698520202358035](https://jules.google.com/task/8714698520202358035) started by @kordk*