### PR TITLE
feat: Add `--permute-label-test` for lstsq method

### DIFF
--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -332,6 +332,14 @@ def corr(
     type=int,
     help='Seed for random subsampling',
 )
+@click.option(
+    '--permute-label-test',
+    is_flag=True,
+    show_default=True,
+    default=False,
+    type=bool,
+    help='Whether to perform a permutation (Negative Control) test by shuffling subject IDs in G (only for lstsq method)',
+)
 @click.pass_context
 def mlr(
     ctx: click.Context,
@@ -352,6 +360,7 @@ def mlr(
     subsample_mt_count: Optional[int],
     subsample_g_count: Optional[int],
     seed: int,
+    permute_label_test: bool,
 ) -> None:
     logger: Logger = ctx.obj['logger']
 
@@ -419,6 +428,7 @@ def mlr(
         'subsample_mt_count': subsample_mt_count,
         'subsample_g_count': subsample_g_count,
         'seed': seed,
+        'permute_label_test': permute_label_test,
     }
 
     logger.info(
@@ -441,6 +451,9 @@ def mlr(
     else:
         if reservoir_count is not None:
             logger.warning('--reservoir-count is only supported for mlr-method lstsq')
+        if permute_label_test:
+            logger.warning('--permute-label-test is only supported for mlr-method lstsq')
+        kwargs.pop('permute_label_test', None)
         output = regression_full(**kwargs, **logger)
     if not chunking:
         save_dataframes([output], output_path, [data['output_file']], **logger)

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -51,6 +51,7 @@ def tecpg_mlr_lstsq(
     subsample_mt_count: Optional[int] = None,
     subsample_g_count: Optional[int] = None,
     seed: int = 42,
+    permute_label_test: bool = False,
     *,
     logger: Logger = Logger(),
 ) -> Optional[pandas.DataFrame]:
@@ -169,6 +170,13 @@ def tecpg_mlr_lstsq(
 
     nrows, ncols = C.shape[0], C.shape[1] + 1
     G_np = G.to_numpy()
+
+    if permute_label_test:
+        logger.info('Permuting label test active: Shuffling subject IDs in G to create negative control')
+        rng_permute = numpy.random.default_rng(seed)
+        permutation = rng_permute.permutation(len(G.columns))
+        G_np = G_np[:, permutation]
+
     gt_count = len(G)
     gt_site_names = numpy.array(G.index.values)
     df = nrows - ncols - 1


### PR DESCRIPTION
Add `--permute-label-test` flag as a negative control for lstsq method by randomly shuffling the subject IDs in the expression data (G) and leaving everything else intact.

---
*PR created automatically by Jules for task [12975210919037323846](https://jules.google.com/task/12975210919037323846) started by @kordk*