### PR TITLE
feat: add verify_alignment to assignRegionToEcpg_parquet.py

### DIFF
--- a/tools/assignRegionToEcpg_parquet.py
+++ b/tools/assignRegionToEcpg_parquet.py
@@ -450,6 +450,117 @@ def assignRegion(my_ecpgDataFile, gH, mH, pval_col, outFileName, chunk_size):
     logger.info(f"[assignRegion] eCpgs Counts by Region: {my_typeCountH}")
     return assigned_total
 
+
+#### Verify alignment of annotation files #######################################
+def verify_alignment(geneH, methylH, ecpgDataFile):
+    logger.info("[verify_alignment] Starting alignment verification...")
+
+    # 1. Chromosome Nomenclature Test
+    gene_chroms = [str(info["chrom"]) for key, info in list(geneH.items())[:50]]
+    methyl_chroms = [str(info["chrom"]) for key, info in list(methylH.items())[:50]]
+
+    gene_has_chr = any(c.startswith("chr") for c in gene_chroms)
+    methyl_has_chr = any(c.startswith("chr") for c in methyl_chroms)
+
+    if gene_has_chr != methyl_has_chr:
+        logger.critical("[CRITICAL WARNING] Chromosome nomenclature mismatch detected between gene and methylation annotations. One uses 'chr' prefix and the other does not.")
+        if gene_has_chr:
+            logger.info("[verify_alignment] Normalizing methylation annotations to include 'chr' prefix.")
+            for key, info in methylH.items():
+                if not str(info["chrom"]).startswith("chr"):
+                    info["chrom"] = "chr" + str(info["chrom"])
+        else:
+            logger.info("[verify_alignment] Normalizing methylation annotations to strip 'chr' prefix.")
+            for key, info in methylH.items():
+                if str(info["chrom"]).startswith("chr"):
+                    info["chrom"] = str(info["chrom"])[3:]
+            logger.info("[verify_alignment] Normalizing gene annotations to strip 'chr' prefix.")
+            for key, info in geneH.items():
+                if str(info["chrom"]).startswith("chr"):
+                    info["chrom"] = str(info["chrom"])[3:]
+
+    # Read first chunk of parquet file to check Ensembl ID and top 10 associations
+    try:
+        parquet_file = pq.ParquetFile(ecpgDataFile)
+        schema = pq.read_schema(ecpgDataFile)
+        columns = schema.names
+        if "precise_mt_p" in columns:
+            pval_col = "precise_mt_p"
+        elif "mt_p" in columns:
+            pval_col = "mt_p"
+        else:
+            logger.error("[verify_alignment] Neither 'precise_mt_p' nor 'mt_p' found in input Parquet file.")
+            sys.exit(1)
+
+        batch = next(parquet_file.iter_batches(batch_size=1000, columns=['gt_id', 'mt_id', pval_col]))
+        df = batch.to_pandas()
+    except Exception as e:
+        logger.error(f"[verify_alignment] Error reading parquet file for verification: {e}")
+        sys.exit(1)
+
+    # 2. Ensembl ID Suffix Check
+    first_few_genes = df['gt_id'].dropna().head(50).astype(str).tolist()
+    versioned_in_geneH = any('.' in k for k in list(geneH.keys())[:100])
+    versionless_in_parquet = first_few_genes and not any('.' in g for g in first_few_genes)
+
+    if versioned_in_geneH and versionless_in_parquet:
+        logger.info("[verify_alignment] Ensembl ID version mismatch detected. GTF uses versioned IDs while Parquet uses versionless. Normalizing GTF IDs by stripping version (.split('.')[0]).")
+        new_geneH = {}
+        for key, value in geneH.items():
+            new_key = key.split('.')[0]
+            # Avoid overwriting if multiple transcripts map to same versionless gene
+            if new_key not in new_geneH:
+                new_geneH[new_key] = value
+        geneH.clear()
+        geneH.update(new_geneH)
+
+
+    # 2.5 Data Type Verification
+    logger.info("[verify_alignment] Verifying and enforcing integer types for all coordinates...")
+    for key, info in methylH.items():
+        if not isinstance(info["chromStart"], int):
+            try:
+                info["chromStart"] = int(info["chromStart"])
+            except ValueError:
+                logger.error(f"[verify_alignment] Failed to cast chromStart '{info['chromStart']}' to int for {key}")
+
+    for key, info in geneH.items():
+        if not isinstance(info["chromStart"], int):
+            try:
+                info["chromStart"] = int(info["chromStart"])
+            except ValueError:
+                logger.error(f"[verify_alignment] Failed to cast chromStart '{info['chromStart']}' to int for {key}")
+        if not isinstance(info["chromEnd"], int):
+            try:
+                info["chromEnd"] = int(info["chromEnd"])
+            except ValueError:
+                logger.error(f"[verify_alignment] Failed to cast chromEnd '{info['chromEnd']}' to int for {key}")
+
+    # 3. Coordinate "Sanity" Sample
+    logger.info("[verify_alignment] Top 10 Coordinate Sanity Sample (Log Dump):")
+    df_sorted = df.sort_values(by=pval_col)
+    top_10 = df_sorted.head(10)
+
+    for index, row in top_10.iterrows():
+        gt_id = str(row['gt_id'])
+        mt_id = str(row['mt_id'])
+
+        cpg_chr, cpg_pos = "N/A", "N/A"
+        gene_chr, gene_start, gene_end = "N/A", "N/A", "N/A"
+
+        if mt_id in methylH:
+            cpg_chr = methylH[mt_id]["chrom"]
+            cpg_pos = methylH[mt_id]["chromStart"]
+
+        if gt_id in geneH:
+            gene_chr = geneH[gt_id]["chrom"]
+            gene_start = geneH[gt_id]["chromStart"]
+            gene_end = geneH[gt_id]["chromEnd"]
+
+        logger.info(f"[verify_alignment] Pair Sample -> cpg_id: {mt_id}, cpg_chr: {cpg_chr}, cpg_pos: {cpg_pos} | gene_id: {gt_id}, gene_chr: {gene_chr}, gene_start: {gene_start}")
+
+    logger.info("[verify_alignment] Alignment verification complete.")
+
 def main():
     parser = argparse.ArgumentParser(description="assignRegionToEcpg_parquet.py - assign a region class to eCpGs")
     parser.add_argument("-d", "--ecpgDataFile", required=True, help="<tecpg eQTM output parquet file>")
@@ -493,6 +604,9 @@ def main():
 
     ## Read in the methylation annotation file to a dictionary
     methylH = readAnnotationFileToDict(methylAnnotFile)
+
+        ## Verify alignment before processing
+    verify_alignment(geneH, methylH, ecpgDataFile)
 
     ## Determine which p-value column to use
     try:


### PR DESCRIPTION
Closes the issue where 100% of eQTMs were being misclassified as "trans" due to upstream annotation mismatching. 

- Added `verify_alignment(geneH, methylH, ecpgDataFile)` which compares the first 50 keys and values from the annotation dictionaries against the first batch of the Parquet dataset.
- Added logic to automatically modify the dictionaries in-memory (stripping Ensembl versions and aligning chromosome prefixes) based on the discovered format.
- Added comprehensive data-type casting for `chromStart` and `chromEnd` across all items.
- Added logging of the top 10 associations by `precise_mt_p`/`mt_p` to verify correct positional ranges.

---
*PR created automatically by Jules for task [11577821111282455372](https://jules.google.com/task/11577821111282455372) started by @kordk*