### PR TITLE
Decouple IG outputs and allow target covariate filtering

### DIFF
--- a/logs/20260311_194318_logfile.txt
+++ b/logs/20260311_194318_logfile.txt
@@ -1,0 +1,11 @@
+[37m[INFO] tecpg version 1.6.3-dev[0m
+[37m[INFO] CUDA GPU detected. This device does not support CUDA.[0m
+[37m[INFO] Creating directory /app/data...[0m
+[37m[INFO] Saving 3 dataframes...[0m
+[37m[INFOTIMER] Saving 1/3: M.csv[0m
+[37m[INFOTIMER] Saved 1/3 in 0.012 seconds[0m
+[37m[INFOTIMER] Saving 2/3: G.csv[0m
+[37m[INFOTIMER] Saved 2/3 in 0.0096 seconds[0m
+[37m[INFOTIMER] Saving 3/3: C.csv[0m
+[37m[INFOTIMER] Saved 3/3 in 0.0019 seconds[0m
+[37m[INFOTIMER] Finished saving 3 dataframes in 0.0237 seconds.[0m

--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -356,6 +356,18 @@ def corr(
     default='mean',
     help='Baseline for IG attribution (default: mean).',
 )
+@click.option(
+    '--ig-covariates',
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help='Output IG scores for all covariates.',
+)
+@click.option(
+    '--ig-covariates-list',
+    type=click.Path(exists=True, dir_okay=False),
+    help='Path to a text file containing covariates to output IG scores for (one per line).',
+)
 @click.pass_context
 def mlr(
     ctx: click.Context,
@@ -380,6 +392,8 @@ def mlr(
     compute_ig: bool,
     compute_ig_deep: bool,
     ig_baseline: str,
+    ig_covariates: bool,
+    ig_covariates_list: Optional[str],
 ) -> None:
     logger: Logger = ctx.obj['logger']
 
@@ -433,6 +447,20 @@ def mlr(
         logger.error(error)
         raise click.UsageError(error)
 
+    ig_covariates_filter = None
+    if ig_covariates_list:
+        with open(ig_covariates_list, 'r') as f:
+            target_covariates = [line.strip() for line in f if line.strip()]
+
+        missing_covariates = [covar for covar in target_covariates if covar not in C.columns]
+        if missing_covariates:
+            error = f"The following covariates from --ig-covariates-list are missing in the design matrix: {', '.join(missing_covariates)}"
+            logger.error(error)
+            raise click.UsageError(error)
+        ig_covariates_filter = target_covariates
+    elif ig_covariates:
+        ig_covariates_filter = 'all'
+
     methylation_only = not full_output
 
     kwargs = {
@@ -461,6 +489,7 @@ def mlr(
         'compute_ig': compute_ig,
         'compute_ig_deep': compute_ig_deep,
         'ig_baseline': ig_baseline,
+        'ig_covariates_filter': ig_covariates_filter,
     }
 
     logger.info(
@@ -491,6 +520,7 @@ def mlr(
         kwargs.pop('compute_ig', None)
         kwargs.pop('compute_ig_deep', None)
         kwargs.pop('ig_baseline', None)
+        kwargs.pop('ig_covariates_filter', None)
         output = regression_full(**kwargs, **logger)
     if not chunking:
         save_dataframes([output], output_path, [data['output_file']], **logger)

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -55,6 +55,7 @@ def tecpg_mlr_lstsq(
     compute_ig: bool = False,
     compute_ig_deep: bool = False,
     ig_baseline: str = 'mean',
+    ig_covariates_filter: Optional[list] | str = None,
     *,
     logger: Logger = Logger(),
 ) -> Optional[pandas.DataFrame]:
@@ -221,10 +222,21 @@ def tecpg_mlr_lstsq(
         ]
 
     # Add _ig columns if IG is computed
+    ig_col_indices = []
     if compute_ig or compute_ig_deep:
-        # Note: Intercept gets excluded from IG outputs
-        categories_for_ig = ['mt'] if methylation_only else ['mt'] + C.columns.to_list()
-        ig_columns = [col + '_ig' for col in categories_for_ig]
+        # Intercept gets excluded from IG outputs (index 0). Meth is index 1. Covariates start at index 2.
+        ig_categories = ['mt']
+        ig_col_indices = [0] # Relative index in the K-1 slice (without intercept)
+
+        if ig_covariates_filter == 'all':
+            ig_categories.extend(C.columns.to_list())
+            ig_col_indices.extend(range(1, len(C.columns) + 1))
+        elif isinstance(ig_covariates_filter, list):
+            for covar in ig_covariates_filter:
+                ig_categories.append(covar)
+                ig_col_indices.append(C.columns.get_loc(covar) + 1)
+
+        ig_columns = [col + '_ig' for col in ig_categories]
         columns.extend(ig_columns)
 
     # Create covariate tensor
@@ -485,6 +497,9 @@ def tecpg_mlr_lstsq(
                     # Skip the intercept index 0 of B
                     IG_analytical = X_diff_mean.unsqueeze(1) * B[:, :, 1:].abs()  # Shape: (M, G, K-1)
 
+                    # Keep only the requested covariates
+                    IG_analytical = IG_analytical[:, :, ig_col_indices]
+
                 # We need to flatten to (M*G, K) to apply filters efficiently?
                 # Or apply masks on the (M, G) grid.
 
@@ -545,7 +560,7 @@ def tecpg_mlr_lstsq(
                 P = P.permute(1, 0, 2).reshape(-1, num_coeffs)
 
                 if compute_ig:
-                    IG_analytical = IG_analytical.permute(1, 0, 2).reshape(-1, num_coeffs - 1)
+                    IG_analytical = IG_analytical.permute(1, 0, 2).reshape(-1, len(ig_col_indices))
 
                 if region != 'all':
                     # mask is (M, G).
@@ -573,8 +588,6 @@ def tecpg_mlr_lstsq(
                     S = S[:, 1:2]
                     T = T[:, 1:2]
                     P = P[:, 1:2]
-                    if compute_ig:
-                        IG_analytical = IG_analytical[:, 0:1] # Meth is index 0 of IG
 
                 if p_only:
                     current_results = P
@@ -753,8 +766,9 @@ def tecpg_mlr_lstsq(
 
                             # Remove the intercept (index 0)
                             hit_saliency = hit_saliency[1:]
-                            if methylation_only:
-                                hit_saliency = hit_saliency[0:1] # only the meth column
+
+                            # Keep only the requested covariates
+                            hit_saliency = hit_saliency[ig_col_indices]
 
                             deep_ig_scores.append(hit_saliency)
 
@@ -762,7 +776,7 @@ def tecpg_mlr_lstsq(
                         chunk_results = torch.cat((chunk_results, deep_ig_tensor), dim=1)
                     else:
                         # No significant hits, but we need to match the columns
-                        num_ig_cols = 1 if methylation_only else C.shape[1]  # intercept removed
+                        num_ig_cols = len(ig_col_indices)
                         empty_ig = torch.empty((0, num_ig_cols), device=device, dtype=dtype)
                         chunk_results = torch.cat((chunk_results, empty_ig), dim=1)
 


### PR DESCRIPTION
Added CLI arguments `--ig-covariates` and `--ig-covariates-list` to `tecpg/cli.py` to allow users to control which covariates get Integrated Gradient outputs independently from the standard `methylation_only` flag. Also updated the PyTorch indexing in `tecpg/processing.py` to correctly extract and format specific covariate dimensions for the IG tensor concatenation paths. Validated that incorrect covariate names throw explicit CLI `UsageError`s instead of failing mid-computation.

---
*PR created automatically by Jules for task [5412304224848607330](https://jules.google.com/task/5412304224848607330) started by @kordk*