### PR TITLE
Fix ENCODE DNase download URL

### DIFF
--- a/tools/summarizeOutput_parquet.py
+++ b/tools/summarizeOutput_parquet.py
@@ -74,7 +74,7 @@ def download_encode_files(target_dir):
     urls = {
         "ChromHMM": "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeBroadHmm/wgEncodeBroadHmmGm12878HMM.bed.gz",
         "H3K27ac": "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeBroadHistone/wgEncodeBroadHistoneGm12878H3k27acStdPk.broadPeak.gz",
-        "DNase": "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeAwgDnaseUniform/wgEncodeAwgDnaseUwcdGm12878UniPk.narrowPeak.gz"
+        "DNase": "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeAwgDnaseUniform/wgEncodeAwgDnaseUwdukeGm12878UniPk.narrowPeak.gz"
     }
 
     files_present = True
@@ -652,7 +652,7 @@ Outputs and Metrics Calculated:
         encode_files = {
             "ChromHMM": os.path.join(args.encode_bed_dir, "wgEncodeBroadHmmGm12878HMM.bed"),
             "H3K27ac": os.path.join(args.encode_bed_dir, "wgEncodeBroadHistoneGm12878H3k27acStdPk.broadPeak"),
-            "DNase": os.path.join(args.encode_bed_dir, "wgEncodeAwgDnaseUwcdGm12878UniPk.narrowPeak")
+            "DNase": os.path.join(args.encode_bed_dir, "wgEncodeAwgDnaseUwdukeGm12878UniPk.narrowPeak")
         }
 
         # Check if all files exist


### PR DESCRIPTION
The previous URL was trying to download a file named `wgEncodeAwgDnaseUwcdGm12878UniPk.narrowPeak.gz` which doesn't exist on the server, causing an HTTP 404 error during the `summarizeOutput_parquet.py` script execution. The correct file name uses `Uwduke` instead of `Uwcd`. This fixes both the URL and the corresponding references to the downloaded file.

---
*PR created automatically by Jules for task [13238179378211977785](https://jules.google.com/task/13238179378211977785) started by @kordk*