### PR TITLE
perf(io): use ThreadPoolExecutor for async CSV saves to avoid fork-bomb RSS

### DIFF
--- a/tecpg/bootstrap.py
+++ b/tecpg/bootstrap.py
@@ -1,7 +1,6 @@
 import os
 import math
 import time
-from multiprocessing import Pool
 import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq

--- a/tecpg/pearson_full.py
+++ b/tecpg/pearson_full.py
@@ -1,6 +1,6 @@
 import math
 import os
-from multiprocessing import Pool
+from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
 import pandas
@@ -233,7 +233,8 @@ def pearson_chunk_save_tensor(
     logger.start_counter('info', '')
     chunks_elapsed = 0
     corr_pd = pandas.DataFrame()
-    with Pool() as pool:
+    futures = []
+    with ThreadPoolExecutor(max_workers=2) as pool:
         for i in range(0, len(M_t), chunk_rows):
             chunks_elapsed += 1
             if chunks_elapsed > save_chunks:
@@ -244,9 +245,9 @@ def pearson_chunk_save_tensor(
                 if flatten:
                     corr_pd = corr_pd.stack()
                     corr_pd.index.set_names(['mt_id', 'gt_id'], inplace=True)
-                pool.apply_async(
-                    save_dataframe_part, (corr_pd, file_path), dict(logger)
-                )
+                futures.append(pool.submit(
+                    save_dataframe_part, corr_pd, file_path, **dict(logger)
+                ))
                 del corr_pd
                 corr_pd = pandas.DataFrame()
 
@@ -282,11 +283,12 @@ def pearson_chunk_save_tensor(
         if flatten:
             corr_pd = corr_pd.stack()
             corr_pd.index.set_names(['mt_id', 'gt_id'], inplace=True)
-        pool.apply_async(
-            save_dataframe_part, (corr_pd, file_path), dict(logger)
-        )
+        futures.append(pool.submit(
+            save_dataframe_part, corr_pd, file_path, **dict(logger)
+        ))
 
-        pool.close()
-        pool.join()
+        for future in futures:
+            future.result()
+        pool.shutdown(wait=True)
 
     logger.time('Calculated pearson_chunk_tensor in {t} seconds')

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -1,7 +1,7 @@
 import math
 import os
 import time
-from multiprocessing import Pool
+from concurrent.futures import ThreadPoolExecutor
 from typing import Literal, Optional
 
 import numpy
@@ -285,8 +285,9 @@ def tecpg_mlr_lstsq(
 
     methylation_loop_start_time = time.time()
 
-    # Use the multiprocessing pool
-    with gpu_guardian(logger) as gpu_handle, Pool() as pool:
+    # Use the thread pool
+    futures = []
+    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=2) as pool:
         # Loop for methylation chunks or ran once with index 0 if no
         # methylation chunking
         for meth_chunk_index in range(meth_chunk_count):
@@ -850,11 +851,11 @@ def tecpg_mlr_lstsq(
                         'Saving part {i}/{0}',
                         gene_chunk_count,
                     )
-                    pool.apply_async(
+                    futures.append(pool.submit(
                         save_dataframe_part,
-                        (out, file_path, gene_chunk_index + 1),
-                        dict(mc_logger),
-                    )
+                        out, file_path, gene_chunk_index + 1,
+                        **dict(mc_logger),
+                    ))
                     del results[:]
 
                     # Force GC
@@ -907,11 +908,11 @@ def tecpg_mlr_lstsq(
                         meth_chunk_index + 1,
                         meth_chunk_count,
                     )
-                    pool.apply_async(
+                    futures.append(pool.submit(
                         save_dataframe_part,
-                        (out, file_path, meth_chunk_index + 1),
-                        dict(mc_logger),
-                    )
+                        out, file_path, meth_chunk_index + 1,
+                        **dict(mc_logger),
+                    ))
                     del results[:]
 
             completed_chunks = meth_chunk_index + 1
@@ -931,8 +932,9 @@ def tecpg_mlr_lstsq(
         # Wait for chunks
         if chunking:
             logger.time('Waiting for chunks to save...')
-            pool.close()
-            pool.join()
+            for future in futures:
+                future.result()
+            pool.shutdown(wait=True)
             logger.time('Finished waiting for chunks to save in {l} seconds')
 
         if do_reservoir and reservoir_processed > 0:

--- a/tecpg/regression_full.py
+++ b/tecpg/regression_full.py
@@ -1,7 +1,7 @@
 import math
 import os
 import time
-from multiprocessing import Pool
+from concurrent.futures import ThreadPoolExecutor
 from typing import Literal, Optional
 
 import numpy
@@ -272,8 +272,9 @@ def regression_full(
     mc_logger.info_color = colors.GREEN
     inner_logger = mc_logger.alias()
 
-    # Use the multiprocessing pool
-    with gpu_guardian(logger) as gpu_handle, Pool() as pool:
+    # Use the thread pool
+    futures = []
+    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=2) as pool:
         # Loop for methylation chunks or ran once with index 0 if no
         # methylation chunking
         for meth_chunk_index in (
@@ -499,16 +500,16 @@ def regression_full(
                         torch.cuda.empty_cache()
                         mc_logger.memory_check('regression_full')
 
-                    # Save output with multiprocessing pool
+                    # Save output with thread pool
                     mc_logger.count(
                         'Saving part {i}/{0}',
                         chunk_count,
                     )
-                    pool.apply_async(
+                    futures.append(pool.submit(
                         save_dataframe_part,
-                        (out, file_path, mc_logger.current_count),
-                        dict(mc_logger),
-                    )
+                        out, file_path, mc_logger.current_count,
+                        **dict(mc_logger),
+                    ))
 
                     # Report gene chunk time
                     inner_logger.time(
@@ -586,11 +587,11 @@ def regression_full(
                         meth_chunk_index + 1,
                         meth_chunk_count,
                     )
-                    pool.apply_async(
+                    futures.append(pool.submit(
                         save_dataframe_part,
-                        (out, file_path, meth_chunk_index + 1),
-                        dict(mc_logger),
-                    )
+                        out, file_path, meth_chunk_index + 1,
+                        **dict(mc_logger),
+                    ))
 
                     inner_logger.time(
                         (
@@ -611,8 +612,9 @@ def regression_full(
         # Wait for chunks to save
         if chunking:
             logger.time('Waiting for chunks to save...')
-            pool.close()
-            pool.join()
+            for future in futures:
+                future.result()
+            pool.shutdown(wait=True)
             logger.time('Finished waiting for chunks to save in {l} seconds')
 
         logger.time(

--- a/tecpg/regression_single.py
+++ b/tecpg/regression_single.py
@@ -1,7 +1,7 @@
 import os
 import time
 from contextlib import nullcontext
-from multiprocessing import Pool
+from concurrent.futures import ThreadPoolExecutor
 from typing import Literal, Optional, Tuple
 
 import numpy
@@ -188,7 +188,8 @@ def regression_single(
     inner_logger.start_timer('info', 'Calculating chunks...')
     i = 0
     last_time = time.time()
-    with gpu_guardian(logger) as gpu_handle, Pool() if regressions_per_chunk else nullcontext() as pool:
+    futures = []
+    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=2) if regressions_per_chunk else nullcontext() as pool:
         for (gene_site, G_row) in G.iterrows():
             throttle_if_needed(gpu_handle, thermal_threshold, thermal_wait, logger)
 
@@ -269,11 +270,11 @@ def regression_single(
                             + ('' if filter_p else '/{0}'),
                             regressions // regressions_per_chunk,
                         )
-                        pool.apply_async(
+                        futures.append(pool.submit(
                             save_dataframe_part,
-                            (out_df, file_path),
-                            dict(logger),
-                        )
+                            out_df, file_path,
+                            **dict(logger),
+                        ))
 
                         del out_df
                         out_df = pandas.DataFrame(
@@ -303,15 +304,16 @@ def regression_single(
                 'Saving part {i}' + ('' if filter_p else '/{0}'),
                 regressions // regressions_per_chunk,
             )
-            pool.apply_async(
+            futures.append(pool.submit(
                 save_dataframe_part,
-                (out_df, file_path),
-                dict(logger),
-            )
+                out_df, file_path,
+                **dict(logger),
+            ))
 
         if regressions_per_chunk:
-            pool.close()
-            pool.join()
+            for future in futures:
+                future.result()
+            pool.shutdown(wait=True)
 
     logger.time('Calculated regression_single in {t} seconds')
     if regressions_per_chunk == 0:


### PR DESCRIPTION
Replaced multiprocessing.Pool with concurrent.futures.ThreadPoolExecutor to prevent out of memory issues caused by copy-on-write failing on Linux forked processes during CSV serialization. Included proper Future capturing to ensure errors are propagated.

---
*PR created automatically by Jules for task [4281997904487101552](https://jules.google.com/task/4281997904487101552) started by @kordk*