### PR TITLE
Add configurable save threads flag to CLI

### DIFF
--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -150,6 +150,13 @@ from .tool import (
     default=DEFAULT_FLOAT_FORMAT,
     type=str,
 )
+@click.option(
+    '--save-threads',
+    show_default=True,
+    default=2,
+    type=int,
+    help='Number of threads used for saving data. Warning: increasing this value can result in an increase in performance with the cost of a large increase in CPU memory, use caution when increasing.',
+)
 @click.pass_context
 def cli(
     ctx: Optional[click.Context] = None,
@@ -169,6 +176,7 @@ def cli(
     log_dir: Optional[str] = None,
     no_log_file: Optional[bool] = None,
     float_format: Optional[str] = None,
+    save_threads: Optional[int] = None,
     obj: Optional[dict] = None,
 ) -> None:
     """The root cli group"""
@@ -197,6 +205,12 @@ def cli(
     logger.carry_data['float_format'] = (
         DEFAULT_FLOAT_FORMAT if float_format is None else float_format
     )
+    if save_threads is not None:
+        if save_threads > 2:
+            logger.warning('Warning: increasing save threads can result in an increase in performance with the cost of a large increase in CPU memory, use caution when increasing.')
+        logger.carry_data['save_threads'] = save_threads
+    else:
+        logger.carry_data['save_threads'] = 2
     ctx.obj['logger'] = logger
 
 

--- a/tecpg/pearson_full.py
+++ b/tecpg/pearson_full.py
@@ -234,7 +234,7 @@ def pearson_chunk_save_tensor(
     chunks_elapsed = 0
     corr_pd = pandas.DataFrame()
     futures = []
-    with ThreadPoolExecutor(max_workers=2) as pool:
+    with ThreadPoolExecutor(max_workers=logger.carry_data.get('save_threads', 2)) as pool:
         for i in range(0, len(M_t), chunk_rows):
             chunks_elapsed += 1
             if chunks_elapsed > save_chunks:

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -287,7 +287,7 @@ def tecpg_mlr_lstsq(
 
     # Use the thread pool
     futures = []
-    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=2) as pool:
+    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=logger.carry_data.get('save_threads', 2)) as pool:
         # Loop for methylation chunks or ran once with index 0 if no
         # methylation chunking
         for meth_chunk_index in range(meth_chunk_count):

--- a/tecpg/regression_full.py
+++ b/tecpg/regression_full.py
@@ -274,7 +274,7 @@ def regression_full(
 
     # Use the thread pool
     futures = []
-    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=2) as pool:
+    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=logger.carry_data.get('save_threads', 2)) as pool:
         # Loop for methylation chunks or ran once with index 0 if no
         # methylation chunking
         for meth_chunk_index in (

--- a/tecpg/regression_single.py
+++ b/tecpg/regression_single.py
@@ -189,7 +189,7 @@ def regression_single(
     i = 0
     last_time = time.time()
     futures = []
-    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=2) if regressions_per_chunk else nullcontext() as pool:
+    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=logger.carry_data.get('save_threads', 2)) if regressions_per_chunk else nullcontext() as pool:
         for (gene_site, G_row) in G.iterrows():
             throttle_if_needed(gpu_handle, thermal_threshold, thermal_wait, logger)
 


### PR DESCRIPTION
Add user configurable option `--save-threads` to increase the count for `ThreadPoolExecutor`, along with a warning about its impact on memory usage.

---
*PR created automatically by Jules for task [2983920981917309369](https://jules.google.com/task/2983920981917309369) started by @kordk*