### PR TITLE
perf(memory): backpressure save queue, stream to_csv, free per-chunk refs

### DIFF
--- a/tecpg/import_data.py
+++ b/tecpg/import_data.py
@@ -132,4 +132,5 @@ def save_dataframe_part(
         ),
         mode=mode,
         header=first,
+        chunksize=logger.carry_data.get('csv_chunksize', 100_000),
     )

--- a/tecpg/pearson_full.py
+++ b/tecpg/pearson_full.py
@@ -1,5 +1,6 @@
 import math
 import os
+from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
@@ -233,8 +234,9 @@ def pearson_chunk_save_tensor(
     logger.start_counter('info', '')
     chunks_elapsed = 0
     corr_pd = pandas.DataFrame()
-    futures = []
-    with ThreadPoolExecutor(max_workers=logger.carry_data.get('save_threads', 2)) as pool:
+    futures = deque()
+    max_workers = logger.carry_data.get('save_threads', 2)
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
         for i in range(0, len(M_t), chunk_rows):
             chunks_elapsed += 1
             if chunks_elapsed > save_chunks:
@@ -245,6 +247,8 @@ def pearson_chunk_save_tensor(
                 if flatten:
                     corr_pd = corr_pd.stack()
                     corr_pd.index.set_names(['mt_id', 'gt_id'], inplace=True)
+                while len(futures) >= max_workers + 1:
+                    futures.popleft().result()
                 futures.append(pool.submit(
                     save_dataframe_part, corr_pd, file_path, **dict(logger)
                 ))
@@ -283,12 +287,15 @@ def pearson_chunk_save_tensor(
         if flatten:
             corr_pd = corr_pd.stack()
             corr_pd.index.set_names(['mt_id', 'gt_id'], inplace=True)
+        while len(futures) >= max_workers + 1:
+            futures.popleft().result()
         futures.append(pool.submit(
             save_dataframe_part, corr_pd, file_path, **dict(logger)
         ))
+        del corr_pd
 
-        for future in futures:
-            future.result()
+        while futures:
+            futures.popleft().result()
         pool.shutdown(wait=True)
 
     logger.time('Calculated pearson_chunk_tensor in {t} seconds')

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -2,6 +2,7 @@ import math
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor
+from collections import deque
 from typing import Literal, Optional
 
 import numpy
@@ -281,8 +282,9 @@ def tecpg_mlr_lstsq(
     methylation_loop_start_time = time.time()
 
     # Use the thread pool
-    futures = []
-    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=logger.carry_data.get('save_threads', 2)) as pool:
+    futures = deque()
+    max_workers = logger.carry_data.get('save_threads', 2)
+    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=max_workers) as pool:
         # Loop for methylation chunks or ran once with index 0 if no
         # methylation chunking
         for meth_chunk_index in range(meth_chunk_count):
@@ -842,11 +844,15 @@ def tecpg_mlr_lstsq(
                         'Saving part {i}/{0}',
                         gene_chunk_count,
                     )
+                    # Backpressure: keep at most max_workers + 1 tasks in flight
+                    while len(futures) >= max_workers + 1:
+                        futures.popleft().result()
                     futures.append(pool.submit(
                         save_dataframe_part,
                         out, file_path, gene_chunk_index + 1,
                         **dict(mc_logger),
                     ))
+                    del out, gt_sites, mt_sites, index_chunk
                     del results[:]
 
                     # Force GC
@@ -899,11 +905,15 @@ def tecpg_mlr_lstsq(
                         meth_chunk_index + 1,
                         meth_chunk_count,
                     )
+                    # Backpressure: keep at most max_workers + 1 tasks in flight
+                    while len(futures) >= max_workers + 1:
+                        futures.popleft().result()
                     futures.append(pool.submit(
                         save_dataframe_part,
                         out, file_path, meth_chunk_index + 1,
                         **dict(mc_logger),
                     ))
+                    del out, gt_sites, mt_sites, index_chunk
                     del results[:]
 
             completed_chunks = meth_chunk_index + 1
@@ -923,8 +933,8 @@ def tecpg_mlr_lstsq(
         # Wait for chunks
         if chunking:
             logger.time('Waiting for chunks to save...')
-            for future in futures:
-                future.result()
+            while futures:
+                futures.popleft().result()
             pool.shutdown(wait=True)
             logger.time('Finished waiting for chunks to save in {l} seconds')
 

--- a/tecpg/regression_full.py
+++ b/tecpg/regression_full.py
@@ -2,6 +2,7 @@ import math
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor
+from collections import deque
 from typing import Literal, Optional
 
 import numpy
@@ -268,8 +269,9 @@ def regression_full(
     inner_logger = mc_logger.alias()
 
     # Use the thread pool
-    futures = []
-    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=logger.carry_data.get('save_threads', 2)) as pool:
+    futures = deque()
+    max_workers = logger.carry_data.get('save_threads', 2)
+    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=max_workers) as pool:
         # Loop for methylation chunks or ran once with index 0 if no
         # methylation chunking
         for meth_chunk_index in (
@@ -499,11 +501,14 @@ def regression_full(
                         'Saving part {i}/{0}',
                         chunk_count,
                     )
+                    while len(futures) >= max_workers + 1:
+                        futures.popleft().result()
                     futures.append(pool.submit(
                         save_dataframe_part,
                         out, file_path, mc_logger.current_count,
                         **dict(mc_logger),
                     ))
+                    del out, gt_sites, mt_sites, index_chunk
 
                     # Report gene chunk time
                     inner_logger.time(
@@ -581,11 +586,14 @@ def regression_full(
                         meth_chunk_index + 1,
                         meth_chunk_count,
                     )
+                    while len(futures) >= max_workers + 1:
+                        futures.popleft().result()
                     futures.append(pool.submit(
                         save_dataframe_part,
                         out, file_path, meth_chunk_index + 1,
                         **dict(mc_logger),
                     ))
+                    del out, gt_sites, mt_sites, index_chunk
 
                     inner_logger.time(
                         (
@@ -606,8 +614,8 @@ def regression_full(
         # Wait for chunks to save
         if chunking:
             logger.time('Waiting for chunks to save...')
-            for future in futures:
-                future.result()
+            while futures:
+                futures.popleft().result()
             pool.shutdown(wait=True)
             logger.time('Finished waiting for chunks to save in {l} seconds')
 

--- a/tecpg/regression_single.py
+++ b/tecpg/regression_single.py
@@ -1,5 +1,6 @@
 import os
 import time
+from collections import deque
 from contextlib import nullcontext
 from concurrent.futures import ThreadPoolExecutor
 from typing import Literal, Optional, Tuple
@@ -188,8 +189,9 @@ def regression_single(
     inner_logger.start_timer('info', 'Calculating chunks...')
     i = 0
     last_time = time.time()
-    futures = []
-    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=logger.carry_data.get('save_threads', 2)) if regressions_per_chunk else nullcontext() as pool:
+    futures = deque()
+    max_workers = logger.carry_data.get('save_threads', 2)
+    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=max_workers) if regressions_per_chunk else nullcontext() as pool:
         for (gene_site, G_row) in G.iterrows():
             throttle_if_needed(gpu_handle, thermal_threshold, thermal_wait, logger)
 
@@ -270,6 +272,8 @@ def regression_single(
                             + ('' if filter_p else '/{0}'),
                             regressions // regressions_per_chunk,
                         )
+                        while len(futures) >= max_workers + 1:
+                            futures.popleft().result()
                         futures.append(pool.submit(
                             save_dataframe_part,
                             out_df, file_path,
@@ -304,15 +308,18 @@ def regression_single(
                 'Saving part {i}' + ('' if filter_p else '/{0}'),
                 regressions // regressions_per_chunk,
             )
+            while len(futures) >= max_workers + 1:
+                futures.popleft().result()
             futures.append(pool.submit(
                 save_dataframe_part,
                 out_df, file_path,
                 **dict(logger),
             ))
+            del out_df
 
         if regressions_per_chunk:
-            for future in futures:
-                future.result()
+            while futures:
+                futures.popleft().result()
             pool.shutdown(wait=True)
 
     logger.time('Calculated regression_single in {t} seconds')


### PR DESCRIPTION
This PR reduces the memory footprint for CPU output processing in `tecpg` when running on large chunks.

Three primary fixes are applied:
1. **Backpressure the save queue:** Implemented an active deque to block the producer thread when more than `max_workers + 1` saving tasks are in-flight, preventing infinite queueing while workers catch up.
2. **Stream `to_csv`:** In `tecpg/import_data.py`, passed `chunksize=logger.carry_data.get('csv_chunksize', 100_000)` so that pandas stream writes to disk rather than allocating the entire output string in memory.
3. **Explicitly free references:** We now immediately `del` output dataframe and indexing variables after calling `pool.submit()`, accelerating GC without waiting for the loop iteration to finish.

The changes consistently apply to all MLR logic endpoints: `tecpg/processing.py`, `tecpg/regression_full.py`, `tecpg/regression_single.py`, and `tecpg/pearson_full.py`. Output is unmodified and remains byte-identical.

---
*PR created automatically by Jules for task [18193623142291471442](https://jules.google.com/task/18193623142291471442) started by @kordk*