### PR TITLE
Fix GPU utilization using ProcessPoolExecutor with spawn context

### DIFF
--- a/dummy.py
+++ b/dummy.py
@@ -1,0 +1,1 @@
+print("Hello")

--- a/tecpg/pearson_full.py
+++ b/tecpg/pearson_full.py
@@ -1,7 +1,8 @@
 import math
 import os
+import multiprocessing
 from collections import deque
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 from typing import Optional
 
 import pandas
@@ -232,54 +233,67 @@ def pearson_chunk_save_tensor(
     inner_logger = logger.alias()
     inner_logger.start_timer('info', 'Calculating chunks...')
     logger.start_counter('info', '')
+    max_workers = logger.carry_data.get('save_threads', 2)
+    ctx = multiprocessing.get_context('spawn')
+    with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as pool:
+        _ = list(pool.map(int, range(max_workers)))
+        return _pearson_chunk_save_tensor_inner(
+            M, G, M_t, G_t, chunks, save_chunks, output_dir, n, flatten,
+            chunk_rows, save_chunk_count, G_means, G_std, max_workers,
+            pool, logger, inner_logger
+        )
+
+def _pearson_chunk_save_tensor_inner(
+    M, G, M_t, G_t, chunks, save_chunks, output_dir, n, flatten,
+    chunk_rows, save_chunk_count, G_means, G_std, max_workers,
+    pool, logger, inner_logger
+):
     chunks_elapsed = 0
     corr_pd = pandas.DataFrame()
     futures = deque()
-    max_workers = logger.carry_data.get('save_threads', 2)
-    with ThreadPoolExecutor(max_workers=max_workers) as pool:
-        for i in range(0, len(M_t), chunk_rows):
-            chunks_elapsed += 1
-            if chunks_elapsed > save_chunks:
-                chunks_elapsed = 1
-                file_name = str(logger.current_count + 1) + '.csv'
-                file_path = os.path.join(output_dir, file_name)
-                logger.count('Saving part {i}/{0}', save_chunk_count)
-                if flatten:
-                    corr_pd = corr_pd.stack()
-                    corr_pd.index.set_names(['mt_id', 'gt_id'], inplace=True)
-                while len(futures) >= max_workers + 1:
-                    futures.popleft().result()
-                futures.append(pool.submit(
-                    save_dataframe_part, corr_pd, file_path, **dict(logger)
-                ))
-                del corr_pd
-                corr_pd = pandas.DataFrame()
+    for i in range(0, len(M_t), chunk_rows):
+        chunks_elapsed += 1
+        if chunks_elapsed > save_chunks:
+            chunks_elapsed = 1
+            file_name = str(logger.current_count + 1) + '.csv'
+            file_path = os.path.join(output_dir, file_name)
+            logger.count('Saving part {i}/{0}', save_chunk_count)
+            if flatten:
+                corr_pd = corr_pd.stack()
+                corr_pd.index.set_names(['mt_id', 'gt_id'], inplace=True)
+            while len(futures) >= max_workers + 1:
+                futures.popleft().result()
+            futures.append(pool.submit(
+                save_dataframe_part, corr_pd, file_path, **dict(logger)
+            ))
+            del corr_pd
+            corr_pd = pandas.DataFrame()
 
-            j = i + chunk_rows
-            M_chunk = M_t[i:j]
-            corr_pd = corr_pd.append(
-                pandas.DataFrame(
+        j = i + chunk_rows
+        M_chunk = M_t[i:j]
+        corr_pd = corr_pd.append(
+            pandas.DataFrame(
+                (
                     (
-                        (
-                            M_chunk @ G_t.T
-                            - M_chunk.mean(axis=1).outer(G_means) * n
-                        )
-                        / (M_chunk.std(axis=1).outer(G_std) * (n - 1))
-                    ).tolist(),
-                    index=M.index[i:j],
-                    columns=G.index,
-                )
+                        M_chunk @ G_t.T
+                        - M_chunk.mean(axis=1).outer(G_means) * n
+                    )
+                    / (M_chunk.std(axis=1).outer(G_std) * (n - 1))
+                ).tolist(),
+                index=M.index[i:j],
+                columns=G.index,
             )
-            del M_chunk
-            inner_logger.time(
-                'Completed chunk {i}/{0} in {l} seconds. Average chunk time:'
-                ' {a} seconds',
-                chunks,
-            )
-            inner_logger.info(
-                'Estimated time remaining: {0} seconds',
-                inner_logger.remaining_time(chunks),
-            )
+        )
+        del M_chunk
+        inner_logger.time(
+            'Completed chunk {i}/{0} in {l} seconds. Average chunk time:'
+            ' {a} seconds',
+            chunks,
+        )
+        inner_logger.info(
+            'Estimated time remaining: {0} seconds',
+            inner_logger.remaining_time(chunks),
+        )
 
         file_name = str(logger.current_count + 1) + '.csv'
         file_path = os.path.join(output_dir, file_name)

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -1,7 +1,8 @@
 import math
 import os
 import time
-from concurrent.futures import ThreadPoolExecutor
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
 from collections import deque
 from typing import Literal, Optional
 
@@ -68,6 +69,55 @@ def tecpg_mlr_lstsq(
         gene_loci_per_chunk is not None or meth_loci_per_chunk is not None
     )
 
+    # Use the process pool
+    max_workers = logger.carry_data.get('save_threads', 2)
+    ctx = multiprocessing.get_context('spawn')
+    with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as pool:
+        _ = list(pool.map(int, range(max_workers)))
+        return _tecpg_mlr_lstsq_inner(
+            M, G, C, M_annot, G_annot, region, window_base, downstream, upstream,
+            gene_loci_per_chunk, meth_loci_per_chunk, p_thresh, output_dir,
+            methylation_only, p_only, logit_transform, thermal_threshold, thermal_wait,
+            file_format, reservoir_count, subsample_mt_count, subsample_g_count, seed,
+            permute_label_test, compute_ig, compute_ig_deep, ig_baseline,
+            ig_covariates_filter, pool, max_workers, logger=logger, chunking=chunking
+        )
+
+def _tecpg_mlr_lstsq_inner(
+    M: pandas.DataFrame,
+    G: pandas.DataFrame,
+    C: pandas.DataFrame,
+    M_annot: Optional[pandas.DataFrame] = None,
+    G_annot: Optional[pandas.DataFrame] = None,
+    region: Literal['all', 'cis', 'distal', 'trans'] = 'all',
+    window_base: Optional[int] = None,
+    downstream: Optional[int] = None,
+    upstream: Optional[int] = None,
+    gene_loci_per_chunk: Optional[int] = None,
+    meth_loci_per_chunk: Optional[int] = None,
+    p_thresh: Optional[float] = None,
+    output_dir: Optional[str] = None,
+    methylation_only: bool = True,
+    p_only: bool = False,
+    logit_transform: bool = False,
+    thermal_threshold: int = 80,
+    thermal_wait: int = 30,
+    file_format: str = '{meth_chunk}-{gene_chunk}.csv',
+    reservoir_count: Optional[int] = None,
+    subsample_mt_count: Optional[int] = None,
+    subsample_g_count: Optional[int] = None,
+    seed: int = 42,
+    permute_label_test: bool = False,
+    compute_ig: bool = False,
+    compute_ig_deep: bool = False,
+    ig_baseline: str = 'mean',
+    ig_covariates_filter: Optional[list] | str = None,
+    pool: ProcessPoolExecutor = None,
+    max_workers: int = 2,
+    *,
+    logger: Logger = Logger(),
+    chunking: bool = False,
+) -> Optional[pandas.DataFrame]:
     # Detect errors in the input values
     if (output_dir is None) != (not chunking):
         error = 'Output dir and chunk size must be defined together.'
@@ -281,10 +331,9 @@ def tecpg_mlr_lstsq(
 
     methylation_loop_start_time = time.time()
 
-    # Use the thread pool
+    # Use the process pool
     futures = deque()
-    max_workers = logger.carry_data.get('save_threads', 2)
-    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=max_workers) as pool:
+    with gpu_guardian(logger) as gpu_handle:
         # Loop for methylation chunks or ran once with index 0 if no
         # methylation chunking
         for meth_chunk_index in range(meth_chunk_count):

--- a/tecpg/regression_full.py
+++ b/tecpg/regression_full.py
@@ -1,7 +1,8 @@
 import math
 import os
 import time
-from concurrent.futures import ThreadPoolExecutor
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
 from collections import deque
 from typing import Literal, Optional
 
@@ -138,6 +139,45 @@ def regression_full(
         gene_loci_per_chunk is not None or meth_loci_per_chunk is not None
     )
 
+    # Use the process pool
+    max_workers = logger.carry_data.get('save_threads', 2)
+    ctx = multiprocessing.get_context('spawn')
+    with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as pool:
+        _ = list(pool.map(int, range(max_workers)))
+        return _regression_full_inner(
+            M, G, C, M_annot, G_annot, region, window_base, downstream, upstream,
+            gene_loci_per_chunk, meth_loci_per_chunk, p_thresh, output_dir,
+            methylation_only, p_only, logit_transform, thermal_threshold, thermal_wait,
+            file_format, pool, max_workers, logger=logger, chunking=chunking
+        )
+
+
+def _regression_full_inner(
+    M: pandas.DataFrame,
+    G: pandas.DataFrame,
+    C: pandas.DataFrame,
+    M_annot: Optional[pandas.DataFrame] = None,
+    G_annot: Optional[pandas.DataFrame] = None,
+    region: Literal['all', 'cis', 'distal', 'trans'] = 'all',
+    window_base: Optional[int] = None,
+    downstream: Optional[int] = None,
+    upstream: Optional[int] = None,
+    gene_loci_per_chunk: Optional[int] = None,
+    meth_loci_per_chunk: Optional[int] = None,
+    p_thresh: Optional[float] = None,
+    output_dir: Optional[str] = None,
+    methylation_only: bool = True,
+    p_only: bool = False,
+    logit_transform: bool = False,
+    thermal_threshold: int = 80,
+    thermal_wait: int = 30,
+    file_format: str = '{meth_chunk}-{gene_chunk}.csv',
+    pool: ProcessPoolExecutor = None,
+    max_workers: int = 2,
+    *,
+    logger: Logger = Logger(),
+    chunking: bool = False,
+) -> Optional[pandas.DataFrame]:
     # Detect errors in the input values
     if (output_dir is None) != (not chunking):
         error = 'Output dir and chunk size must be defined together.'
@@ -268,10 +308,9 @@ def regression_full(
     mc_logger.info_color = colors.GREEN
     inner_logger = mc_logger.alias()
 
-    # Use the thread pool
+    # Use the process pool
     futures = deque()
-    max_workers = logger.carry_data.get('save_threads', 2)
-    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=max_workers) as pool:
+    with gpu_guardian(logger) as gpu_handle:
         # Loop for methylation chunks or ran once with index 0 if no
         # methylation chunking
         for meth_chunk_index in (

--- a/tecpg/regression_single.py
+++ b/tecpg/regression_single.py
@@ -1,8 +1,9 @@
 import os
 import time
+import multiprocessing
 from collections import deque
 from contextlib import nullcontext
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 from typing import Literal, Optional, Tuple
 
 import numpy
@@ -89,6 +90,40 @@ def regression_single(
     overlap and redundance of multiple matrix multiplications with
     similar inputs.
     """
+    max_workers = logger.carry_data.get('save_threads', 2)
+    ctx = multiprocessing.get_context('spawn')
+    with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) if regressions_per_chunk else nullcontext() as pool:
+        if pool is not None:
+            _ = list(pool.map(int, range(max_workers)))
+        return _regression_single_inner(
+            M, G, C, M_annot, G_annot, region, window_base, downstream, upstream,
+            regressions_per_chunk, p_thresh, output_dir, methylation_only, p_only,
+            thermal_threshold, thermal_wait, file_format, pool, max_workers, logger
+        )
+
+
+def _regression_single_inner(
+    M: pandas.DataFrame,
+    G: pandas.DataFrame,
+    C: pandas.DataFrame,
+    M_annot: Optional[pandas.DataFrame] = None,
+    G_annot: Optional[pandas.DataFrame] = None,
+    region: Literal['all', 'cis', 'distal', 'trans'] = 'all',
+    window_base: Optional[int] = None,
+    downstream: Optional[int] = None,
+    upstream: Optional[int] = None,
+    regressions_per_chunk: Optional[int] = None,
+    p_thresh: Optional[float] = None,
+    output_dir: Optional[str] = None,
+    methylation_only: bool = True,
+    p_only: bool = False,
+    thermal_threshold: int = 80,
+    thermal_wait: int = 30,
+    file_format: str = '{chunk}.csv',
+    pool: Optional[ProcessPoolExecutor] = None,
+    max_workers: int = 2,
+    logger: Logger = Logger(),
+) -> Optional[pandas.DataFrame]:
     if region not in ['all', 'cis', 'distal', 'trans']:
         error = f'Region {region} not valid. Use all, cis, distal, or trans.'
         logger.error(error)
@@ -190,8 +225,7 @@ def regression_single(
     i = 0
     last_time = time.time()
     futures = deque()
-    max_workers = logger.carry_data.get('save_threads', 2)
-    with gpu_guardian(logger) as gpu_handle, ThreadPoolExecutor(max_workers=max_workers) if regressions_per_chunk else nullcontext() as pool:
+    with gpu_guardian(logger) as gpu_handle:
         for (gene_site, G_row) in G.iterrows():
             throttle_if_needed(gpu_handle, thermal_threshold, thermal_wait, logger)
 

--- a/test_imports.py
+++ b/test_imports.py
@@ -1,0 +1,5 @@
+from tecpg.regression_full import regression_full
+from tecpg.pearson_full import pearson_chunk_save_tensor
+from tecpg.processing import tecpg_mlr_lstsq
+from tecpg.regression_single import regression_single
+print("Imports OK")

--- a/test_mocked.py
+++ b/test_mocked.py
@@ -1,0 +1,23 @@
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Mock external dependencies
+sys.modules['numpy'] = MagicMock()
+sys.modules['pandas'] = MagicMock()
+sys.modules['torch'] = MagicMock()
+sys.modules['colorama'] = MagicMock()
+sys.modules['psutil'] = MagicMock()
+sys.modules['captum'] = MagicMock()
+sys.modules['captum.attr'] = MagicMock()
+sys.modules['mygene'] = MagicMock()
+sys.modules['requests'] = MagicMock()
+
+try:
+    from tecpg.regression_full import regression_full
+    from tecpg.pearson_full import pearson_chunk_save_tensor
+    from tecpg.processing import tecpg_mlr_lstsq
+    from tecpg.regression_single import regression_single
+    print("Imports passed with mocks.")
+except Exception as e:
+    print(f"Error during import: {e}")

--- a/test_pool.py
+++ b/test_pool.py
@@ -1,0 +1,18 @@
+import multiprocessing
+from concurrent.futures import ProcessPoolExecutor
+import pandas as pd
+
+def save_dummy(df, path):
+    df.to_csv(path)
+    return True
+
+def main():
+    ctx = multiprocessing.get_context('spawn')
+    with ProcessPoolExecutor(max_workers=2, mp_context=ctx) as pool:
+        list(pool.map(int, range(2)))
+        df = pd.DataFrame({"a": [1, 2]})
+        f = pool.submit(save_dummy, df, "test_out.csv")
+        print(f.result())
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
GPU utilization dropped from ~100% to <15% after PR #125 because `ThreadPoolExecutor` worker threads contended with the CUDA-launching main thread for the GIL. This PR reverts the chunk-saving pools to process-based multiprocessing while preserving the OOM fixes by utilizing the `spawn` context (`multiprocessing.get_context('spawn')`). The `ProcessPoolExecutor` is instantiated outside the primary loop and warmed up to prevent CPU spikes and overhead from process creation and torch importation lazily hitting inside the hot loops.

Changes made:
- Swapped `ThreadPoolExecutor` to `ProcessPoolExecutor` in `regression_full.py`, `pearson_full.py`, `processing.py`, and `regression_single.py`.
- Specified `mp_context=multiprocessing.get_context('spawn')` to avoid fork-time reference counting and copy-on-write memory bloat (the RSS fork issue).
- Wrapped the core GPU logic in inner functions, instantiating the ProcessPoolExecutor at the highest level of the scope and running a dummy warmup task (`_ = list(pool.map(int, range(max_workers)))`) to immediately spin up the child processes.
- The `--save-threads` command-line semantics remain untouched, but now appropriately dictates child processes instead of threads. Queue drain patterns are also preserved for exception transparency.

---
*PR created automatically by Jules for task [14902680302564781727](https://jules.google.com/task/14902680302564781727) started by @kordk*