### PR TITLE
fix(profiling): correct S_val assignment to fix TypeError during GPU monitoring

### DIFF
--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -935,7 +935,7 @@ def _tecpg_mlr_lstsq_inner(
                         M_c = len(M_chunk)
                         G_c = chunk_len
                         K_val = K
-                        S_val = S
+                        S_val = nrows
                         gflops = (2 * M_c * (K_val**2) * S_val + 2 * M_c * K_val * G_c * S_val) / 1e9 / max(prof_gpu_time, 1e-9)
                         reg_sec = (M_c * G_c) / max(prof_total, 1e-9)
 


### PR DESCRIPTION
Fixes a formatting crash in `tecpg/processing.py` when profiling mode is enabled. 
The number of samples (`S_val`) used in the GFLOPs calculation was erroneously mapped to the PyTorch standard error tensor `S` rather than the sample count (`nrows`). This converts the `gflops` variable into a tensor, causing an `unsupported format string passed to Tensor.__format__` crash in the logging function.
Replacing `S_val = S` with `S_val = nrows` resolves the bug.

---
*PR created automatically by Jules for task [13961975824973279251](https://jules.google.com/task/13961975824973279251) started by @kordk*