### PR TITLE
Auto-scale save_threads and remove per-chunk torch.cuda.empty_cache() calls

### DIFF
--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -4,6 +4,10 @@ import os
 from typing import Any, List, Optional
 
 import click
+
+def _auto_save_threads(physical_cores: int, ram_gb: float) -> int:
+    return max(2, min(16, min(physical_cores // 4, int(ram_gb // 8))))
+
 import pandas
 import psutil
 import torch
@@ -153,10 +157,10 @@ from .tool import (
 @click.option(
     '--save-threads',
     show_default=True,
-    default=2,
+    default=None,
     envvar='TECPG_SAVE_THREADS',
     type=int,
-    help='Number of threads used for saving data. Warning: increasing this value can result in an increase in performance with the cost of a large increase in CPU memory, use caution when increasing.',
+    help='Number of writer processes for saving output. If unset, auto-scales based on physical CPU count and available RAM. Set explicitly (or via TECPG_SAVE_THREADS) to override.',
 )
 @click.option(
     '--blas-threads',
@@ -218,9 +222,14 @@ def cli(
     if save_threads is not None:
         if save_threads > 2:
             logger.warning('Warning: increasing save threads can result in an increase in performance with the cost of a large increase in CPU memory, use caution when increasing.')
+        logger.info('User-supplied save_threads: {0}', save_threads)
         logger.carry_data['save_threads'] = save_threads
     else:
-        logger.carry_data['save_threads'] = 2
+        physical = psutil.cpu_count(logical=False) or os.cpu_count() or 2
+        ram_gb = psutil.virtual_memory().total / (1024**3)
+        auto_threads = _auto_save_threads(physical, ram_gb)
+        logger.info('Auto-scaled save_threads to {0}', auto_threads)
+        logger.carry_data['save_threads'] = auto_threads
 
     if blas_threads and blas_threads > 0:
         env_omp = os.environ.get('OMP_NUM_THREADS')
@@ -439,6 +448,13 @@ def corr(
     type=int,
     help='Number of chunks to prefetch to the GPU to overlap with compute (default 0).',
 )
+@click.option(
+    '--aggressive-gc',
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help='Call torch.cuda.empty_cache() after every gene chunk. Default is to only empty the cache under memory pressure (> 85% allocated). Useful on memory-constrained GPUs.',
+)
 @click.pass_context
 def mlr(
     ctx: click.Context,
@@ -470,6 +486,7 @@ def mlr(
     bootstrap_iterations: int,
     bootstrap_batch_size: int,
     prefetch_chunks: int,
+    aggressive_gc: bool,
 ) -> None:
     logger: Logger = ctx.obj['logger']
 
@@ -567,6 +584,7 @@ def mlr(
         'ig_baseline': ig_baseline,
         'ig_covariates_filter': ig_covariates_filter,
         'prefetch_chunks': prefetch_chunks,
+        'aggressive_gc': aggressive_gc,
     }
 
     logger.info(

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -8,6 +8,8 @@ from typing import Literal, Optional
 
 import numpy
 import pandas
+
+HIGH_WATER = 0.85
 import torch
 from colorama import Fore as colors
 
@@ -59,6 +61,7 @@ def tecpg_mlr_lstsq(
     ig_baseline: str = 'mean',
     ig_covariates_filter: Optional[list] | str = None,
     prefetch_chunks: int = 0,
+    aggressive_gc: bool = False,
     *,
     logger: Logger = Logger(),
 ) -> Optional[pandas.DataFrame]:
@@ -81,7 +84,7 @@ def tecpg_mlr_lstsq(
             methylation_only, p_only, logit_transform, thermal_threshold, thermal_wait,
             file_format, reservoir_count, subsample_mt_count, subsample_g_count, seed,
             permute_label_test, compute_ig, compute_ig_deep, ig_baseline,
-            ig_covariates_filter, prefetch_chunks, pool, max_workers, logger=logger, chunking=chunking
+            ig_covariates_filter, prefetch_chunks, aggressive_gc, pool, max_workers, logger=logger, chunking=chunking
         )
 
 def _tecpg_mlr_lstsq_inner(
@@ -114,6 +117,7 @@ def _tecpg_mlr_lstsq_inner(
     ig_baseline: str = 'mean',
     ig_covariates_filter: Optional[list] | str = None,
     prefetch_chunks: int = 0,
+    aggressive_gc: bool = False,
     pool: ProcessPoolExecutor = None,
     max_workers: int = 2,
     *,
@@ -1065,7 +1069,9 @@ def _tecpg_mlr_lstsq_inner(
 
                     # Force GC
                     if allocated_memory:
-                         torch.cuda.empty_cache()
+                        total_memory = torch.cuda.get_device_properties(0).total_memory if torch.cuda.is_available() else 0
+                        if aggressive_gc or (total_memory and torch.cuda.memory_allocated() / total_memory > HIGH_WATER):
+                            torch.cuda.empty_cache()
 
             del Q, R_inv, XtXi_diag_sqrt
 

--- a/tecpg/regression_full.py
+++ b/tecpg/regression_full.py
@@ -8,6 +8,8 @@ from typing import Literal, Optional
 
 import numpy
 import pandas
+
+HIGH_WATER = 0.85
 import torch
 from colorama import Fore as colors
 
@@ -67,6 +69,7 @@ def regression_full(
     thermal_threshold: int = 80,
     thermal_wait: int = 30,
     file_format: str = '{meth_chunk}-{gene_chunk}.csv',
+    aggressive_gc: bool = False,
     *,
     logger: Logger = Logger(),
 ) -> Optional[pandas.DataFrame]:
@@ -148,7 +151,7 @@ def regression_full(
             M, G, C, M_annot, G_annot, region, window_base, downstream, upstream,
             gene_loci_per_chunk, meth_loci_per_chunk, p_thresh, output_dir,
             methylation_only, p_only, logit_transform, thermal_threshold, thermal_wait,
-            file_format, pool, max_workers, logger=logger, chunking=chunking
+            file_format, aggressive_gc, pool, max_workers, logger=logger, chunking=chunking
         )
 
 
@@ -172,6 +175,7 @@ def _regression_full_inner(
     thermal_threshold: int = 80,
     thermal_wait: int = 30,
     file_format: str = '{meth_chunk}-{gene_chunk}.csv',
+    aggressive_gc: bool = False,
     pool: ProcessPoolExecutor = None,
     max_workers: int = 2,
     *,
@@ -405,7 +409,9 @@ def _regression_full_inner(
 
             mc_logger.memory_check('regression_full')
             if allocated_memory := torch.cuda.memory_allocated() if torch.cuda.is_available() else 0:
-                torch.cuda.empty_cache()
+                total_memory = torch.cuda.get_device_properties(0).total_memory if torch.cuda.is_available() else 0
+                if aggressive_gc or (total_memory and torch.cuda.memory_allocated() / total_memory > HIGH_WATER):
+                    torch.cuda.empty_cache()
 
             # Inner loop over each gene expression locus
             last_index = 0
@@ -548,7 +554,8 @@ def _regression_full_inner(
 
                     # CUDA memory notice
                     if index == gene_loci_per_chunk and allocated_memory:
-                        torch.cuda.empty_cache()
+                        if aggressive_gc or (total_memory and torch.cuda.memory_allocated() / total_memory > HIGH_WATER):
+                            torch.cuda.empty_cache()
                         mc_logger.memory_check('regression_full')
 
                     # Save output with thread pool

--- a/tests/test_auto_scale.py
+++ b/tests/test_auto_scale.py
@@ -1,0 +1,14 @@
+from tecpg.cli import _auto_save_threads
+
+def test_auto_save_threads():
+    # 16 GB / 8 physical cores -> 2
+    assert _auto_save_threads(8, 16.0) == 2
+
+    # 512 GB / 32 physical cores -> 8
+    assert _auto_save_threads(32, 512.0) == 8
+
+    # 1 TB / 128 physical cores -> 16 (capped)
+    assert _auto_save_threads(128, 1024.0) == 16
+
+    # 8 GB / 4 physical cores -> 2 (floor)
+    assert _auto_save_threads(4, 8.0) == 2


### PR DESCRIPTION
This PR implements auto-scaling for save_threads based on physical CPU count and available RAM. It replaces the unconditional `torch.cuda.empty_cache()` calls with a conditional pressure-gated call to reduce overhead on high-resource machines. An `--aggressive-gc` flag has been added to restore the original behavior. Test cases in `tests/test_auto_scale.py` were added to verify auto-scaling boundaries.

---
*PR created automatically by Jules for task [7741939623884660561](https://jules.google.com/task/7741939623884660561) started by @kordk*