### PR TITLE
fix: prevent profiling.sh from aborting on missing grep matches

### DIFF
--- a/profiling.sh
+++ b/profiling.sh
@@ -284,7 +284,7 @@ extract_metrics() {
             else if(a[1]=="idle") idle=val
         }
         print prep, h2d, gpu, d2h, post, write, idle
-    }' > "$tsv_file"
+    }' > "$tsv_file" || true
 
     if [ ! -s "$tsv_file" ]; then
         echo "No PROFILE lines found in log." > "$sum_file"
@@ -478,6 +478,8 @@ run_workload() {
         log "tecpg timed out after $cap_duration seconds as expected."
     elif [ $tecpg_exit -ne 0 ]; then
         log "Warning: tecpg exited with code $tecpg_exit"
+        log "Last 20 lines of tecpg.log:"
+        tail -n 20 "$cell_dir/tecpg.log" 2>/dev/null || true
     fi
 
     kill $top_pid 2>/dev/null || true
@@ -528,15 +530,19 @@ if [ "$RUN_MATRIX" -eq 1 ]; then
     ln -s "baseline/chunk_profile_summary.txt" "$OUT_DIR/chunk_profile_summary.txt" 2>/dev/null || true
     ln -s "baseline/nvidia-smi-query.csv" "$OUT_DIR/nvidia-smi-query.csv" 2>/dev/null || true
     ln -s "baseline/pidstat.csv" "$OUT_DIR/pidstat.csv" 2>/dev/null || true
-    VERDICT=$(tail -n 1 "$OUT_DIR/baseline/chunk_profile_summary.txt" | grep "Verdict:" | sed 's/Verdict: //')
+    VERDICT=$(tail -n 1 "$OUT_DIR/baseline/chunk_profile_summary.txt" | grep "Verdict:" | sed 's/Verdict: //' || true)
 
 else
     log "Running single workload..."
     VERDICT_ROW=$(run_workload "run" "" "" 1 "$DURATION")
-    VERDICT=$(tail -n 1 "$OUT_DIR/run/chunk_profile_summary.txt" | grep "Verdict:" | sed 's/Verdict: //')
+    VERDICT=$(tail -n 1 "$OUT_DIR/run/chunk_profile_summary.txt" | grep "Verdict:" | sed 's/Verdict: //' || true)
     ln -s "run/chunk_profile_summary.txt" "$OUT_DIR/chunk_profile_summary.txt" 2>/dev/null || true
     ln -s "run/nvidia-smi-query.csv" "$OUT_DIR/nvidia-smi-query.csv" 2>/dev/null || true
     ln -s "run/pidstat.csv" "$OUT_DIR/pidstat.csv" 2>/dev/null || true
+fi
+
+if [ -z "${VERDICT:-}" ]; then
+    VERDICT="Failed to extract verdict (no PROFILE lines found)"
 fi
 
 tarball="${OUT_DIR}.tar.gz"


### PR DESCRIPTION
Fix an issue where `profiling.sh` abruptly terminates with no error output besides a non-zero exit code. This occurs because `set -euo pipefail` causes the pipeline to abort if `grep` fails to find matches in log files (which happens when the underlying tecpg process crashes). Added `|| true` to these pipelines and also added logic to print the last 20 lines of `tecpg.log` to help the user diagnose exactly what failed.

---
*PR created automatically by Jules for task [5775701684138414754](https://jules.google.com/task/5775701684138414754) started by @kordk*