### PR TITLE
Fix profiling script failing to extract metrics

### DIFF
--- a/profiling.sh
+++ b/profiling.sh
@@ -402,7 +402,7 @@ run_workload() {
 
     log "Running cell: $cell_name"
 
-    local tecpg_args="run mlr --mlr-method lstsq --$MAPPING --compute-ig --profile-equivalent"
+    local tecpg_args="run mlr --mlr-method lstsq --$MAPPING --compute-ig"
     if [ -n "$S_CHUNK" ]; then tecpg_args+=" -m $S_CHUNK"; fi
     if [ -n "$G_CHUNK" ]; then tecpg_args+=" -g $G_CHUNK"; fi
     if [ -n "$PREFETCH_CHUNKS" ] && [ "$PREFETCH_CHUNKS" -ne 0 ]; then tecpg_args+=" --prefetch-chunks $PREFETCH_CHUNKS"; fi
@@ -411,7 +411,7 @@ run_workload() {
 
     local base_cmd="tecpg --debug -i data_${DATASET} -a annot_${DATASET} -o $cell_dir $tecpg_args"
 
-    local env_cmd="env CUDA_LAUNCH_BLOCKING=${TECPG_PROFILING_BLOCKING:-0} $extra_env"
+    local env_cmd="env TECPG_PROFILE=1 CUDA_LAUNCH_BLOCKING=${TECPG_PROFILING_BLOCKING:-0} $extra_env"
 
     echo "Cell: $cell_name" > "$cell_dir/cell.txt"
     echo "Env: $env_cmd" >> "$cell_dir/cell.txt"


### PR DESCRIPTION
Fix profiling script failing to extract metrics

The `profiling.sh` script previously passed an invalid flag `--profile-equivalent` to the `tecpg` executable, causing it to crash or exit without doing work, resulting in no profiling metrics being captured.

This commit updates `profiling.sh` to correctly enable profiling outputs by using the `TECPG_PROFILE=1` environment variable, which enables the generation of `PROFILE chunk` log lines.

---
*PR created automatically by Jules for task [10530273070971381021](https://jules.google.com/task/10530273070971381021) started by @kordk*