### PR TITLE
Fix profiling script log deletion by tecpg

### DIFF
--- a/profiling.sh
+++ b/profiling.sh
@@ -415,7 +415,7 @@ run_workload() {
     if [ -n "$BLAS_THREADS" ]; then tecpg_args+=" --blas-threads $BLAS_THREADS"; fi
     tecpg_args+=" $extra_args"
 
-    local base_cmd="tecpg --debug -i data_${DATASET} -a annot_${DATASET} -o $cell_dir $tecpg_args"
+    local base_cmd="tecpg --debug -i data_${DATASET} -a annot_${DATASET} -o $cell_dir/tecpg_out $tecpg_args"
 
     local env_cmd="env TECPG_PROFILE=1 CUDA_LAUNCH_BLOCKING=${TECPG_PROFILING_BLOCKING:-0} $extra_env"
 
@@ -494,7 +494,7 @@ run_workload() {
     stop_samplers
 
     if [ "$KEEP_OUTPUT" -eq 0 ]; then
-        rm -f "$cell_dir"/*.csv "$cell_dir"/*.parquet 2>/dev/null || true
+        rm -rf "$cell_dir/tecpg_out" 2>/dev/null || true
     fi
 
     local row


### PR DESCRIPTION
Fixed the issue where `profiling.sh` output files were disappearing. The script writes log files to the cell's directory and then executes `tecpg` setting that same directory as its output directory. The `tecpg` tool's behavior is to completely erase and recreate its output directory when it starts up. This clears all the profiler background logs and the main `tecpg.log` leading to the "Failed to extract verdict" error. I modified `profiling.sh` to have `tecpg` output its data to a subdirectory (`tecpg_out`) so it doesn't collide with and delete the profiler's trace files. I also updated the post-run cleanup function to wipe `tecpg_out`. Tested locally and it successfully retained the logs.

---
*PR created automatically by Jules for task [4112826654679129838](https://jules.google.com/task/4112826654679129838) started by @kordk*