### PR TITLE
Fix pearson process pool lifecycle

### DIFF
--- a/tecpg/pearson_full.py
+++ b/tecpg/pearson_full.py
@@ -349,8 +349,6 @@ def _pearson_chunk_save_tensor_inner(
         ))
         del corr_pd
 
-        while futures:
-            futures.popleft().result()
-        pool.shutdown(wait=True)
-
+    while futures:
+        futures.popleft().result()
     logger.time('Calculated pearson_chunk_tensor in {t} seconds')

--- a/tests/test_pearson_pool_lifecycle.py
+++ b/tests/test_pearson_pool_lifecycle.py
@@ -1,0 +1,37 @@
+import ast
+from pathlib import Path
+import unittest
+
+
+def _find_function(module, name):
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found")
+
+
+class PearsonPoolLifecycleTests(unittest.TestCase):
+    def test_chunk_save_inner_does_not_shutdown_pool_inside_loop(self):
+        source = Path("tecpg/pearson_full.py").read_text()
+        module = ast.parse(source)
+        function = _find_function(module, "_pearson_chunk_save_tensor_inner")
+
+        for node in ast.walk(function):
+            if not isinstance(node, ast.For):
+                continue
+
+            for child in ast.walk(node):
+                if not isinstance(child, ast.Call):
+                    continue
+                func = child.func
+                if (
+                    isinstance(func, ast.Attribute)
+                    and func.attr == "shutdown"
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "pool"
+                ):
+                    self.fail("pool.shutdown() must not run inside the chunk loop")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Fork working source of truth
The active working baseline for this effort is now the fork-only branch:

`dryheatwindbag/torch-ecpg:fork-only/pr130-cleanup-plus-pearson-lifecycle`

That fork branch combines the PR #130 scratch cleanup with this `pearson_full.py` lifecycle fix. Upstream `kordk:dev` should not be treated as changed unless maintainers merge the upstream review PRs.

## Summary
- Fixes the `pearson_full.py` process-pool lifecycle defect by removing explicit `pool.shutdown()` from inside the chunk loop.
- Lets the `ProcessPoolExecutor` context manager own shutdown after pending futures are drained after the loop.
- Adds a focused static regression test for `_pearson_chunk_save_tensor_inner` to ensure `pool.shutdown()` is not called inside the chunk loop.

## Scope
This PR is retargeted directly against clean upstream `kordk:dev` and is separate from #150.

It does not remove the PR #130 scratch files; that cleanup remains tracked by #150. Suggested upstream order remains: merge #150 first, then #152.

It does not claim GPU/performance recovery; that still requires real GPU/performance evidence or explicit maintainer acceptance of the remaining validation gap.

## Validation
- `python3 -m unittest tests.test_pearson_pool_lifecycle`
- `python3 -m compileall -q tecpg/pearson_full.py tests/test_pearson_pool_lifecycle.py`
- `git diff --check origin/dev...HEAD`

## Notes
This PR remains an upstream maintainer-review item. It does not claim upstream merge, upstream acceptance, or closeout.
