### PR TITLE
Add Kennedy et al. 2018 eCpG datasets to GTP and MESA

### DIFF
--- a/tecpg/gtp.py
+++ b/tecpg/gtp.py
@@ -9,6 +9,12 @@ from .helper import download_files, initialize_dir, read_csv
 from .import_data import save_dataframes
 from .logger import Logger
 
+
+GTP_KENNEDY_URL = (
+    'eCpGs_Kennedy2018_GTP.txt',
+    'https://static-content.springer.com/esm/art%3A10.1186%2Fs12864-018-4842-3/MediaObjects/12864_2018_4842_MOESM1_ESM.txt'
+)
+
 GTP_FILE_URLS = [
     (
         'CovariateMatrix.txt.gz',
@@ -54,6 +60,9 @@ def download_gtp_raw(
     logger.info('Downloading GTP raw data (this could take a very long time)')
     download_files(gtp_path, GTP_FILE_URLS, **kwargs, **logger)
 
+    logger.info('Downloading eCpG-transcript pairs from Kennedy et al. 2018 study (PubMed ID 29914364; DOI: 10.1186/s12864-018-4842-3)')
+    download_files(gtp_path, [GTP_KENNEDY_URL], **kwargs, **logger)
+
 
 def get_gtp_dataframes(
     gtp_path: str, *, logger: Logger = Logger()
@@ -93,7 +102,7 @@ def gtp_raw_clean(gtp_path: str, *, logger: Logger = Logger()) -> bool:
         return False
 
     files = os.listdir(gtp_path)
-    target_files = [file for file, _ in GTP_FILE_URLS]
+    target_files = [file for file, _ in GTP_FILE_URLS] + [GTP_KENNEDY_URL[0]]
     for file in files:
         if file not in target_files:
             logger.warning(f'{file} is being removed from {gtp_path}')
@@ -104,7 +113,7 @@ def gtp_raw_clean(gtp_path: str, *, logger: Logger = Logger()) -> bool:
                 os.remove(file_path)
 
     remaining = len(os.listdir(gtp_path))
-    return remaining == 4
+    return remaining == len(target_files)
 
 
 def process_gtp(
@@ -240,6 +249,14 @@ def save_gtp_data(
         save_dataframes(data, data_path, **logger)
     else:
         save_dataframes(data, data_path, file_names, **logger)
+
+    kennedy_filename = GTP_KENNEDY_URL[0]
+    kennedy_src = os.path.join(gtp_path, kennedy_filename)
+    kennedy_dst = os.path.join(data_path, kennedy_filename)
+    if os.path.exists(kennedy_src):
+        shutil.copyfile(kennedy_src, kennedy_dst)
+        logger.info('Copied {0} to {1}', kennedy_filename, data_path)
+
     logger.warning(
         'GTP methylation, gene expression, and covariates downloaded. If you'
         ' would like to use region filtration, please manually copy the'

--- a/tecpg/mesa.py
+++ b/tecpg/mesa.py
@@ -9,6 +9,12 @@ from .helper import download_files, initialize_dir, read_csv
 from .import_data import save_dataframes
 from .logger import Logger
 
+
+MESA_KENNEDY_URL = (
+    'eCpGs_Kennedy2018_MESA.txt',
+    'https://static-content.springer.com/esm/art%3A10.1186%2Fs12864-018-4842-3/MediaObjects/12864_2018_4842_MOESM2_ESM.txt'
+)
+
 MESA_FILE_URLS = [
     (
         'CovariateMatrix.txt.gz',
@@ -35,6 +41,9 @@ def download_mesa_raw(
     initialize_dir(mesa_path, **logger)
     logger.info('Downloading MESA raw data (this could take a very long time)')
     download_files(mesa_path, MESA_FILE_URLS, **kwargs, **logger)
+
+    logger.info('Downloading eCpG-transcript pairs from Kennedy et al. 2018 study (PubMed ID 29914364; DOI: 10.1186/s12864-018-4842-3)')
+    download_files(mesa_path, [MESA_KENNEDY_URL], **kwargs, **logger)
 
 
 def get_mesa_dataframes(
@@ -72,7 +81,7 @@ def mesa_raw_clean(mesa_path: str, *, logger: Logger = Logger()) -> bool:
         return False
 
     files = os.listdir(mesa_path)
-    target_files = [file for file, _ in MESA_FILE_URLS]
+    target_files = [file for file, _ in MESA_FILE_URLS] + [MESA_KENNEDY_URL[0]]
     for file in files:
         if file not in target_files:
             logger.warning(f'{file} is being removed from {mesa_path}')
@@ -244,6 +253,14 @@ def save_mesa_data(
         save_dataframes(data, data_path, **logger)
     else:
         save_dataframes(data, data_path, file_names, **logger)
+
+    kennedy_filename = MESA_KENNEDY_URL[0]
+    kennedy_src = os.path.join(mesa_path, kennedy_filename)
+    kennedy_dst = os.path.join(data_path, kennedy_filename)
+    if os.path.exists(kennedy_src):
+        shutil.copyfile(kennedy_src, kennedy_dst)
+        logger.info('Copied {0} to {1}', kennedy_filename, data_path)
+
     logger.warning(
         'MESA methylation, gene expression, and covariates downloaded. If you'
         ' would like to use region filtration, please manually copy the'


### PR DESCRIPTION
Added the eCpG dataset from Kennedy et al. 2018 for the GTP and MESA downloads. This patch ensures the datasets are fetched properly when using `tecpg data gtp` and `tecpg data mesa` and copies them to the respective output directories, along with adding proper reference attribution.

---
*PR created automatically by Jules for task [8414241670855260537](https://jules.google.com/task/8414241670855260537) started by @kordk*