### PR TITLE
Fix Pandas 3.0 ChainedAssignmentError in GTP preprocessing

### DIFF
--- a/tecpg/gtp.py
+++ b/tecpg/gtp.py
@@ -171,8 +171,7 @@ def process_gtp(
     C.drop('tissue', axis=1, inplace=True, errors='ignore')
     C.drop('race/ethnicity', axis=1, inplace=True, errors='ignore')
 
-    C['Sex'].replace('Male', 0, inplace=True)
-    C['Sex'].replace('Female', 1, inplace=True)
+    C['Sex'] = C['Sex'].replace({'Male': 0, 'Female': 1}).astype(int)
 
     logger.info('Sorting columns')
     M = M.reindex(sorted(M.columns, key=int), axis=1)


### PR DESCRIPTION
Resolves Issue #163. Updated `tecpg/gtp.py` to fix how the `Sex` column string values are replaced. The Copy-on-Write mechanism in Pandas 3.0 was preventing `inplace=True` chained assignments from updating the core dataframe, resulting in `np.object` formatting errors downstream during `torch.tensor` creation. This uses direct assignment and `.astype(int)` to fix it.

---
*PR created automatically by Jules for task [14323172245683031020](https://jules.google.com/task/14323172245683031020) started by @kordk*