### PR TITLE
Log pre-merge dataset overlap counts in Kennedy benchmark

### DIFF
--- a/tools/benchmark_kennedy.py
+++ b/tools/benchmark_kennedy.py
@@ -65,6 +65,15 @@ def main():
     if cpg_col in df_kennedy.columns and query_col in df_kennedy.columns:
         logging.info(f"Sample of Kennedy key columns before merge (first 5 rows):\n{df_kennedy[[cpg_col, query_col]].head().to_string()}")
 
+    # Calculate overlaps before merging
+    if 'mt_id' in df_tecpg.columns and cpg_col in df_kennedy.columns:
+        loci_overlap = len(set(df_tecpg['mt_id'].dropna()).intersection(set(df_kennedy[cpg_col].dropna())))
+        logging.info(f"Overlapping distinct CpG loci: {loci_overlap}")
+
+    if 'gt_id' in df_tecpg.columns and query_col in df_kennedy.columns:
+        genes_overlap = len(set(df_tecpg['gt_id'].dropna()).intersection(set(df_kennedy[query_col].dropna())))
+        logging.info(f"Overlapping distinct genes: {genes_overlap}")
+
     logging.info("Merging datasets...")
     # Inner join on CpG and Gene
     df_merged = pd.merge(


### PR DESCRIPTION
- Calculated the intersection of distinct methylation loci using the respective key columns.
- Calculated the intersection of distinct genes using the respective key columns.
- Logged both overlap counts directly before the inner join of the dataframes.

---
*PR created automatically by Jules for task [1788533337735964990](https://jules.google.com/task/1788533337735964990) started by @kordk*