### PR TITLE
Integrate EpiDISH for Immune Cell Proportion Estimation

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -121,13 +121,22 @@ else
     fi
 fi
 
+# Stage 1.5: Estimate Immune Cell Proportions
+log "[1.5/9] Estimating immune cell proportions using EpiDISH..."
+if [ -s "$DATA_DIR/C_with_celltypes.csv" ]; then
+    log "C_with_celltypes.csv already exists. Skipping cell proportion estimation."
+else
+    log "Running EpiDISH to estimate cell proportions..."
+    ./tools/estimateCellProportions.sh "$DATA_DIR/M.csv" "$DATA_DIR/C_orig.csv" "$DATA_DIR/C_with_celltypes.csv"
+fi
+
 # Stage 2: Preprocess PCA Covariates
 log "[2/9] Preprocessing PCA Covariates..."
 if [ -s "$DATA_DIR/C.csv" ]; then
     log "C.csv already exists. Skipping PCA covariate preprocessing."
 else
     log "Running PCA to append top $NUM_PCS components from gene expression data to covariates..."
-    python3 tools/preprocessPcaCovariates.py -g "$DATA_DIR/G.csv" -c "$DATA_DIR/C_orig.csv" -o "$DATA_DIR/C.csv" -n "$NUM_PCS"
+    python3 tools/preprocessPcaCovariates.py -g "$DATA_DIR/G.csv" -c "$DATA_DIR/C_with_celltypes.csv" -o "$DATA_DIR/C.csv" -n "$NUM_PCS"
 fi
 
 # Determine Degrees of Freedom for P-value calculation

--- a/tools/estimateCellProportions.R
+++ b/tools/estimateCellProportions.R
@@ -1,0 +1,56 @@
+#!/usr/bin/env Rscript
+
+args <- commandArgs(trailingOnly=TRUE)
+if (length(args) != 3) {
+  stop("Usage: Rscript estimateCellProportions.R <methylation_file.csv> <covariates_file.csv> <output_file.csv>")
+}
+
+meth_file <- args[1]
+cov_file <- args[2]
+out_file <- args[3]
+
+# Install BiocManager if not present
+if (!requireNamespace("BiocManager", quietly = TRUE)) {
+    cat("Installing BiocManager...\n")
+    install.packages("BiocManager", repos = "https://cloud.r-project.org")
+}
+
+# Install EpiDISH if not present
+if (!requireNamespace("EpiDISH", quietly = TRUE)) {
+    cat("Installing EpiDISH...\n")
+    BiocManager::install("EpiDISH", ask = FALSE, update = FALSE)
+}
+
+library(EpiDISH)
+
+# Load data
+cat(paste("Loading methylation data from", meth_file, "\n"))
+# Assuming CpGs as rows, samples as columns for EpiDISH based on standard input
+beta_matrix <- read.csv(meth_file, row.names=1)
+
+cat(paste("Loading covariate data from", cov_file, "\n"))
+# Assuming samples as rows for covariate matrix
+cov_matrix <- read.csv(cov_file, row.names=1)
+
+# Load reference panel
+data(centDHSbloodDMC.m)
+
+# Run EpiDISH
+cat("Running EpiDISH (RPC method)...\n")
+out.l <- epidish(beta.m = as.matrix(beta_matrix), ref.m = centDHSbloodDMC.m, method = "RPC")
+
+# Extract fractions
+cell_fractions <- as.data.frame(out.l$estF)
+
+# Merge based on row names
+# EpiDISH returns sample IDs as row names in cell_fractions
+cat("Merging cell fractions with covariates...\n")
+merged_cov <- merge(cov_matrix, cell_fractions, by="row.names", all.x=TRUE)
+
+# Restore row names and remove the temporary 'Row.names' column
+rownames(merged_cov) <- merged_cov$Row.names
+merged_cov$Row.names <- NULL
+
+cat(paste("Saving updated covariates to", out_file, "\n"))
+write.csv(merged_cov, out_file, row.names=TRUE)
+cat("Done.\n")

--- a/tools/estimateCellProportions.sh
+++ b/tools/estimateCellProportions.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# estimateCellProportions.sh
+# Wrapper to run the EpiDISH R script for cell proportion estimation.
+
+if [ "$#" -ne 3 ]; then
+    echo "Usage: ./estimateCellProportions.sh <methylation_file.csv> <covariates_file.csv> <output_file.csv>"
+    exit 1
+fi
+
+METH_FILE="$1"
+COV_FILE="$2"
+OUT_FILE="$3"
+
+# Check if Rscript is available
+if ! command -v Rscript &> /dev/null; then
+    echo "Error: Rscript is not installed or not in PATH."
+    echo "Please ensure R is installed in your environment to run EpiDISH."
+    exit 1
+fi
+
+# Run the R script, assuming it's in the same directory as this wrapper
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+RSCRIPT_PATH="$DIR/estimateCellProportions.R"
+
+Rscript "$RSCRIPT_PATH" "$METH_FILE" "$COV_FILE" "$OUT_FILE"


### PR DESCRIPTION
This change integrates the EpiDISH R package into the data processing pipeline to mathematically estimate 7 immune cell fractions from the methylation Beta matrix (`M.csv`). These estimates are then merged into the existing covariate matrix (`C_orig.csv`).

Because the environment might not have R pre-installed, an R script and a Bash wrapper are provided. The bash wrapper is called during the pipeline execution (Stage 1.5) to produce `C_with_celltypes.csv`, which is then used in the subsequent PCA step (Stage 2) instead of the original covariates file. The R script also dynamically handles the installation of `BiocManager` and `EpiDISH` if they are missing.

---
*PR created automatically by Jules for task [11979101377545861497](https://jules.google.com/task/11979101377545861497) started by @kordk*