### PR TITLE
Fix sample ID mismatch and add logging to estimateCellProportions.R

### DIFF
--- a/tools/estimateCellProportions.R
+++ b/tools/estimateCellProportions.R
@@ -26,11 +26,15 @@ library(EpiDISH)
 # Load data
 cat(paste("Loading methylation data from", meth_file, "\n"))
 # Assuming CpGs as rows, samples as columns for EpiDISH based on standard input
-beta_matrix <- read.csv(meth_file, row.names=1)
+beta_matrix <- read.csv(meth_file, row.names=1, check.names=FALSE)
+cat("Methylation matrix first 5 column names (sample IDs):\n")
+print(head(colnames(beta_matrix), 5))
 
 cat(paste("Loading covariate data from", cov_file, "\n"))
 # Assuming samples as rows for covariate matrix
-cov_matrix <- read.csv(cov_file, row.names=1)
+cov_matrix <- read.csv(cov_file, row.names=1, check.names=FALSE)
+cat("Covariate matrix first 5 row names (sample IDs):\n")
+print(head(rownames(cov_matrix), 5))
 
 # Load reference panel
 data(centDHSbloodDMC.m)
@@ -41,6 +45,8 @@ out.l <- epidish(beta.m = as.matrix(beta_matrix), ref.m = centDHSbloodDMC.m, met
 
 # Extract fractions
 cell_fractions <- as.data.frame(out.l$estF)
+cat("Cell fractions first 5 row names (sample IDs) before merge:\n")
+print(head(rownames(cell_fractions), 5))
 
 # Merge based on row names
 # EpiDISH returns sample IDs as row names in cell_fractions


### PR DESCRIPTION
This commit addresses an issue in `tools/estimateCellProportions.R` where the script failed to correctly assign computed cell type scores back to the covariate data, resulting in `NA` values.

The root cause was that `read.csv` was automatically prepending an 'X' to numeric sample IDs in the column names of the methylation matrix. By passing `check.names=FALSE` to `read.csv`, we prevent this automatic conversion. Additionally, logging statements were added to output the first 5 IDs at each step to aid in debugging.

---
*PR created automatically by Jules for task [5676593578214087324](https://jules.google.com/task/5676593578214087324) started by @kordk*