### PR TITLE
Replace SVA analysis with residualized PCA covariates

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -94,14 +94,14 @@ else
     if [ "$DATASET" == "dummy" ]; then
         # Generate small synthetic data for testing
         log "Generating synthetic dummy data..."
-        echo "10" | tecpg data dummy -s 100 -m 1000 -g 1000
+        echo "10" | python3 -m tecpg data dummy -s 100 -m 1000 -g 1000
         mv data/* "$DATA_DIR/"
         mv annot/* "$ANNOT_DIR/"
         rmdir data annot
         mv "$DATA_DIR/C.csv" "$DATA_DIR/C_orig.csv"
     elif [ "$DATASET" == "gtp" ]; then
         log "Downloading GTP data..."
-        echo "y" | tecpg data gtp --yes
+        echo "y" | python3 -m tecpg data gtp --yes
         mv data/* "$DATA_DIR/"
         mv "$DATA_DIR/C.csv" "$DATA_DIR/C_orig.csv"
         # For GTP, assuming the demo annots are used
@@ -110,7 +110,7 @@ else
         rmdir data
     elif [ "$DATASET" == "mesa" ]; then
         log "Downloading MESA data..."
-        echo "y" | tecpg data mesa
+        echo "y" | python3 -m tecpg data mesa
         mv data/* "$DATA_DIR/"
         mv "$DATA_DIR/C.csv" "$DATA_DIR/C_orig.csv"
         # For MESA, assuming appropriate demo annots are used if available
@@ -123,20 +123,39 @@ fi
 
 # Stage 1.5: Estimate Immune Cell Proportions
 log "[1.5/9] Estimating immune cell proportions using EpiDISH..."
-if [ -s "$DATA_DIR/C_with_celltypes.csv" ]; then
+if [ "$DATASET" == "mesa" ]; then
+    log "Skipping cell proportion estimation for MESA dataset."
+    cp "$DATA_DIR/C_orig.csv" "$DATA_DIR/C_with_celltypes.csv"
+elif [ -s "$DATA_DIR/C_with_celltypes.csv" ]; then
     log "C_with_celltypes.csv already exists. Skipping cell proportion estimation."
 else
     log "Running EpiDISH to estimate cell proportions..."
     ./tools/estimateCellProportions.sh "$DATA_DIR/M.csv" "$DATA_DIR/C_orig.csv" "$DATA_DIR/C_with_celltypes.csv"
 fi
 
-# Stage 2: Generate SVA Factors with Known Biological Covariates
-log "[2/9] Generating SVA Factors..."
+# Stage 2: Residualization & PCA
+log "[2/9] Generating Expression and Methylation PCs..."
 if [ -s "$DATA_DIR/C.csv" ]; then
-    log "C.csv already exists. Skipping SVA factor generation."
+    log "C.csv already exists. Skipping Residualization and PCA generation."
 else
-    log "Running SVA to append hidden surrogate variables from gene expression data to covariates..."
-    ./tools/generateSvaFactors.sh "$DATA_DIR/G.csv" "$DATA_DIR/C_with_celltypes.csv" "$DATA_DIR/C.csv"
+    log "Running Expression Residualization & PCA..."
+    ./tools/residualize_pca.sh "$DATA_DIR/G.csv" "$DATA_DIR/C_with_celltypes.csv" "$DATA_DIR/G_PCs.csv" "Exp_PC"
+
+    log "Running Methylation Residualization & PCA..."
+    ./tools/residualize_pca.sh "$DATA_DIR/M.csv" "$DATA_DIR/C_with_celltypes.csv" "$DATA_DIR/M_PCs.csv" "Meth_PC"
+
+    log "Merging Covariates with PCs..."
+    python3 -c "
+import pandas as pd
+C = pd.read_csv('$DATA_DIR/C_with_celltypes.csv', dtype={0: str})
+C.set_index(C.columns[0], inplace=True)
+G_PCs = pd.read_csv('$DATA_DIR/G_PCs.csv', dtype={0: str})
+G_PCs.set_index(G_PCs.columns[0], inplace=True)
+M_PCs = pd.read_csv('$DATA_DIR/M_PCs.csv', dtype={0: str})
+M_PCs.set_index(M_PCs.columns[0], inplace=True)
+C_final = pd.concat([C, G_PCs, M_PCs], axis=1)
+C_final.to_csv('$DATA_DIR/C.csv')
+"
 fi
 
 # Determine Degrees of Freedom for P-value calculation
@@ -154,7 +173,7 @@ log "Calculated Degrees of Freedom (DF): $DF (SAMPLES=$SAMPLES, COVARS=$COVARS)"
 log "[3/9] Performing eQTM Mapping (lstsq + IG)..."
 log "This stage runs the multiple linear regression (mlr) model and computes Integrated Gradients (IG)."
 log "Using chunks: M_CHUNK=$M_CHUNK, G_CHUNK=$G_CHUNK. Input: $DATA_DIR, Annotations: $ANNOT_DIR, Output: $OUT_DIR"
-tecpg -i "$DATA_DIR" -a "$ANNOT_DIR" -o "$OUT_DIR" run mlr --mlr-method lstsq --$MAPPING -m "$M_CHUNK" -g "$G_CHUNK" --compute-ig
+python3 -m tecpg -i "$DATA_DIR" -a "$ANNOT_DIR" -o "$OUT_DIR" run mlr --mlr-method lstsq --$MAPPING -m "$M_CHUNK" -g "$G_CHUNK" --compute-ig
 
 # Stage 4: Merge chunked outputs
 log "[4/9] Merging chunked outputs to Parquet..."
@@ -202,7 +221,7 @@ python3 tools/createBootstrapList.py --input "$SUMMARIZED_PARQUET" --output "$BO
 log "[9/9] Bootstrapping top hits..."
 log "Running bootstrap analysis on the top candidates to validate association robustness."
 log "Pairs File: $BOOTSTRAP_LIST, Master Parquet: $SUMMARIZED_PARQUET"
-tecpg -i "$DATA_DIR" -a "$ANNOT_DIR" -o "$OUT_DIR" run mlr --mlr-method lstsq_bootstrap --pairs-file "$BOOTSTRAP_LIST" --master-parquet "$SUMMARIZED_PARQUET" --bootstrap-iterations 100 --bootstrap-batch-size 10 --compute-ig
+python3 -m tecpg -i "$DATA_DIR" -a "$ANNOT_DIR" -o "$OUT_DIR" run mlr --mlr-method lstsq_bootstrap --pairs-file "$BOOTSTRAP_LIST" --master-parquet "$SUMMARIZED_PARQUET" --bootstrap-iterations 100 --bootstrap-batch-size 10 --compute-ig
 
 log "======================================"
 log "Pipeline completed successfully!"

--- a/tools/residualize_pca.py
+++ b/tools/residualize_pca.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+import logging
+import pandas as pd
+import numpy as np
+from sklearn.linear_model import LinearRegression
+from sklearn.decomposition import PCA
+import patsy
+
+logger = logging.getLogger(__name__)
+
+def main():
+    parser = argparse.ArgumentParser(description="Residualize matrix on covariates and extract PCA components.")
+
+    parser.add_argument("-i", "--input-matrix", required=True, help="Path to input matrix (M.csv or G.csv). Expected format: loci in rows, samples in columns by default.")
+    parser.add_argument("-c", "--covar-file", required=True, help="Path to the base covariates file (CSV). Expected format: samples in rows.")
+    parser.add_argument("-o", "--output-file", required=True, help="Output filepath for the PCA CSV.")
+    parser.add_argument("-p", "--prefix", required=True, help="Prefix for the PCA columns (e.g. Exp_PC, Meth_PC).")
+    parser.add_argument("-n", "--n-components", type=int, default=5, help="Number of top principal components to extract. Default is 5.")
+    parser.add_argument("--transpose", action="store_true", help="Transpose input matrix before processing. Use if input has samples as rows.")
+    parser.add_argument("-D", "--debug", action="store_true", help="Enable debug logging.")
+
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    logging.basicConfig(level=log_level, format='%(message)s')
+
+    if not os.path.exists(args.input_matrix):
+        logger.error(f"Input matrix file not found: {args.input_matrix}")
+        return
+    if not os.path.exists(args.covar_file):
+        logger.error(f"Base covariates file not found: {args.covar_file}")
+        return
+
+    logger.info(f"Loading input matrix from {args.input_matrix}")
+    # Read without index_col first, then cast to string, then set index to preserve leading zeros
+    M_raw = pd.read_csv(args.input_matrix, dtype={0: str})
+    M_raw.set_index(M_raw.columns[0], inplace=True)
+
+    # Drop loci with missing data
+    if args.transpose:
+        M_raw = M_raw.dropna(axis=1)
+    else:
+        M_raw = M_raw.dropna(axis=0)
+
+    if not args.transpose:
+        M = M_raw.transpose()
+    else:
+        M = M_raw
+
+    logger.info(f"Loading base covariates from {args.covar_file}")
+    C = pd.read_csv(args.covar_file, dtype={0: str})
+    C.set_index(C.columns[0], inplace=True)
+
+    # Ensure sample IDs align correctly using inner join on index
+    M.index = M.index.astype(str)
+    C.index = C.index.astype(str)
+    merged_indices = M.index.intersection(C.index)
+
+    if len(merged_indices) == 0:
+        logger.error("No matching samples found between input matrix and base covariates.")
+        return
+
+    M_aligned = M.loc[merged_indices]
+    C_aligned = C.loc[merged_indices]
+
+    logger.info(f"Aligned {len(merged_indices)} samples.")
+
+    # Generate design matrix for covariates using patsy
+    # All columns in C_aligned are treated as fixed effects.
+    # Convert column names to valid python identifiers for patsy, or use Q()
+    formula = "~ " + " + ".join([f"Q('{c}')" for c in C_aligned.columns])
+    logger.info(f"Using formula: {formula}")
+
+    design_matrix = patsy.dmatrix(formula, data=C_aligned, return_type='dataframe')
+
+    # Residualization
+    logger.info("Running residualization (Linear Regression)...")
+    reg = LinearRegression(fit_intercept=False) # patsy adds intercept
+    reg.fit(design_matrix, M_aligned)
+    preds = reg.predict(design_matrix)
+    residuals = M_aligned - preds
+
+    logger.info("Running PCA on residuals...")
+    n_components = min(args.n_components, residuals.shape[0], residuals.shape[1])
+    pca = PCA(n_components=n_components)
+    pca_features = pca.fit_transform(residuals)
+
+    explained_variance = sum(pca.explained_variance_ratio_) * 100
+    logger.info(f"Explained variance by top {n_components} PCs: {explained_variance:.2f}%")
+
+    pc_columns = [f"{args.prefix}{i+1}" for i in range(n_components)]
+    pca_df = pd.DataFrame(pca_features, index=merged_indices, columns=pc_columns)
+
+    logger.info(f"Saving PCA components to {args.output_file}")
+    pca_df.to_csv(args.output_file)
+
+if __name__ == "__main__":
+    main()

--- a/tools/residualize_pca.sh
+++ b/tools/residualize_pca.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# residualize_pca.sh
+# Wrapper to run the Python residualization and PCA script.
+
+if [ "$#" -lt 4 ]; then
+    echo "Usage: $0 <input_matrix.csv> <covariates_file.csv> <output_file.csv> <prefix>"
+    exit 1
+fi
+
+INPUT_FILE="$1"
+COV_FILE="$2"
+OUT_FILE="$3"
+PREFIX="$4"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PYTHON_SCRIPT="$DIR/residualize_pca.py"
+
+python3 "$PYTHON_SCRIPT" -i "$INPUT_FILE" -c "$COV_FILE" -o "$OUT_FILE" -p "$PREFIX" -n 5


### PR DESCRIPTION
Replaces the R-based PEER SVA components generation (`generateSvaFactors`) with a python-based PCA residualization feature (`tools/residualize_pca.py`).
It regresses the gene expression and methylation matrices over a given set of covariates using `patsy` + `sklearn` and then extracts their top PCs to add to the analysis design matrix.
It updates `pipeline.sh` appropriately to orchestrate the new flow, and avoids running `epidish` cell type proportionalization when `--dataset` is mesa.

---
*PR created automatically by Jules for task [15145211699314729006](https://jules.google.com/task/15145211699314729006) started by @kordk*