### PR TITLE
fix: prevent PyArrow serialization crash on mixed type index

### DIFF
--- a/tecpg/helper.py
+++ b/tecpg/helper.py
@@ -71,7 +71,14 @@ def read_csv(
         file_name,
         '[tab]' if sep == '\t' else sep,
     )
-    return pandas.read_csv(file_name, sep=sep, index_col=[0])
+    df = pandas.read_csv(file_name, sep=sep, index_col=[0])
+    if df.index.dtype == 'object':
+        logger.info(
+            'The index for file {0} was loaded as an object type. '
+            'This may indicate mixed types (e.g. integers and strings).',
+            file_name,
+        )
+    return df
 
 
 def trim_dataframes(

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -276,6 +276,10 @@ def _tecpg_mlr_lstsq_inner(
 
     gt_count = len(G)
     gt_site_names = numpy.array(G.index.values)
+    if gt_site_names.dtype == object:
+        logger.info('Gene (G) index array was inferred as object. Enforcing string type to prevent serialization errors.')
+        gt_site_names = gt_site_names.astype(str)
+
     df = nrows - ncols - 1
     logger.info(
         'Statistical Power Audit: df = {0} (calculated as {1} subjects - {2} covariates - 1 methylation - 1 intercept)',
@@ -424,6 +428,10 @@ def _tecpg_mlr_lstsq_inner(
             mt_count = len(M_chunk)
             Ct = Ct_base.expand(mt_count, -1, -1)
             mt_site_names = numpy.array(M_chunk.index.values)
+            if mt_site_names.dtype == object:
+                logger.info('Methylation (M) chunk index array was inferred as object. Enforcing string type to prevent serialization errors.')
+                mt_site_names = mt_site_names.astype(str)
+
             if region == 'all' and p_thresh is None:
                 # If no filtration, output size is constant per gene chunk
                 pass # Calculated later


### PR DESCRIPTION
Fixes a crash when running the pipeline with `mesa` dataset (which has mixed type index identifiers) where `pyarrow` throws `ArrowTypeError: Expected bytes, got a 'int' object`. It also adds proactive diagnostic logging for similar data type mismatches.

---
*PR created automatically by Jules for task [5639185818183563504](https://jules.google.com/task/5639185818183563504) started by @kordk*