### PR TITLE
Add EPIC probe blacklist filtering to data preparation pipeline

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -83,11 +83,15 @@ mkdir -p "$OUT_DIR" "$DATA_DIR" "$ANNOT_DIR"
 log "[1/9] Preparing data..."
 log "Checking if dataset files already exist in $DATA_DIR..."
 
-if [ -s "$DATA_DIR/M.csv" ] && [ -s "$DATA_DIR/G.csv" ] && ( [ -s "$DATA_DIR/C_orig.csv" ] || [ -s "$DATA_DIR/C.csv" ] ); then
-    log "Data files (M.csv, G.csv, and C_orig.csv/C.csv) already exist and are not empty. Skipping download/generation."
+if ( [ -s "$DATA_DIR/M_orig.csv" ] || [ -s "$DATA_DIR/M.csv" ] ) && [ -s "$DATA_DIR/G.csv" ] && ( [ -s "$DATA_DIR/C_orig.csv" ] || [ -s "$DATA_DIR/C.csv" ] ); then
+    log "Data files (M_orig.csv/M.csv, G.csv, and C_orig.csv/C.csv) already exist and are not empty. Skipping download/generation."
     if [ -s "$DATA_DIR/C.csv" ] && [ ! -s "$DATA_DIR/C_orig.csv" ]; then
         log "Found C.csv but not C_orig.csv. Renaming C.csv to C_orig.csv for backwards compatibility."
         mv "$DATA_DIR/C.csv" "$DATA_DIR/C_orig.csv"
+    fi
+    if [ -s "$DATA_DIR/M.csv" ] && [ ! -s "$DATA_DIR/M_orig.csv" ]; then
+        log "Found M.csv but not M_orig.csv. Renaming M.csv to M_orig.csv for backwards compatibility."
+        mv "$DATA_DIR/M.csv" "$DATA_DIR/M_orig.csv"
     fi
 else
     log "Data files not found or empty. Proceeding with data generation/download for $DATASET..."
@@ -99,11 +103,13 @@ else
         mv annot/* "$ANNOT_DIR/"
         rmdir data annot
         mv "$DATA_DIR/C.csv" "$DATA_DIR/C_orig.csv"
+        mv "$DATA_DIR/M.csv" "$DATA_DIR/M_orig.csv"
     elif [ "$DATASET" == "gtp" ]; then
         log "Downloading GTP data..."
         echo "y" | python3 -m tecpg data gtp --yes
         mv data/* "$DATA_DIR/"
         mv "$DATA_DIR/C.csv" "$DATA_DIR/C_orig.csv"
+        mv "$DATA_DIR/M.csv" "$DATA_DIR/M_orig.csv"
         # For GTP, assuming the demo annots are used
         cp demo/annoEPIC.hg19.bed6 "$ANNOT_DIR/M.bed6"
         cp demo/annoHT12.hg19.bed6 "$ANNOT_DIR/G.bed6"
@@ -113,12 +119,24 @@ else
         echo "y" | python3 -m tecpg data mesa
         mv data/* "$DATA_DIR/"
         mv "$DATA_DIR/C.csv" "$DATA_DIR/C_orig.csv"
+        mv "$DATA_DIR/M.csv" "$DATA_DIR/M_orig.csv"
         # For MESA, assuming appropriate demo annots are used if available
         # Or fall back to EPIC/HT12 for now
         cp demo/annoEPIC.hg19.bed6 "$ANNOT_DIR/M.bed6" 2>/dev/null || true
         cp demo/annoHT12.hg19.bed6 "$ANNOT_DIR/G.bed6" 2>/dev/null || true
         rmdir data
     fi
+fi
+
+# Apply EPIC probe blacklist filter
+if [ -s "$DATA_DIR/M.csv" ]; then
+    log "M.csv already exists. Skipping probe blacklist filtering."
+else
+    log "Generating EPIC probe blacklist..."
+    ./tools/generateEpicProbeBlacklist.sh "$DATA_DIR"
+
+    log "Applying blacklist filter to M_orig.csv..."
+    python3 tools/exclude_blacklisted_probes.py "$DATA_DIR/M_orig.csv" "$DATA_DIR/epic_probes_blacklist.csv" "$DATA_DIR/M.csv"
 fi
 
 # Stage 1.5: Estimate Immune Cell Proportions

--- a/tools/exclude_blacklisted_probes.py
+++ b/tools/exclude_blacklisted_probes.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import pandas as pd
+import argparse
+import sys
+
+def main():
+    parser = argparse.ArgumentParser(description="Exclude blacklisted probes from methylation data.")
+    parser.add_argument("m_orig_file", help="Path to M_orig.csv file")
+    parser.add_argument("blacklist_file", help="Path to epic_probes_blacklist.csv file")
+    parser.add_argument("m_out_file", help="Path to output M.csv file")
+    args = parser.parse_args()
+
+    print(f"Loading {args.m_orig_file}...")
+    try:
+        M_orig = pd.read_csv(args.m_orig_file, index_col=0)
+    except Exception as e:
+        print(f"Error loading {args.m_orig_file}: {e}")
+        sys.exit(1)
+
+    print(f"Original M rows: {len(M_orig)}")
+
+    try:
+        blacklist = pd.read_csv(args.blacklist_file)
+        # Assume the first column contains the probe IDs
+        blacklist_probes = set(blacklist.iloc[:, 0].astype(str))
+    except Exception as e:
+        print(f"Error loading {args.blacklist_file}: {e}")
+        sys.exit(1)
+
+    print(f"Loaded {len(blacklist_probes)} probes to exclude.")
+
+    # M_orig index contains probe IDs
+    probes_to_keep = [p for p in M_orig.index if str(p) not in blacklist_probes]
+    M_new = M_orig.loc[probes_to_keep]
+
+    excluded_count = len(M_orig) - len(M_new)
+    print(f"New M rows: {len(M_new)} (Excluded {excluded_count} probes)")
+
+    try:
+        M_new.to_csv(args.m_out_file)
+        print(f"Saved filtered data to {args.m_out_file}")
+    except Exception as e:
+        print(f"Error saving to {args.m_out_file}: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tools/generateEpicProbeBlacklist.sh
+++ b/tools/generateEpicProbeBlacklist.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Wrapper to run the R script for generating the EPIC probe blacklist
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ./generateEpicProbeBlacklist.sh <output_dir>"
+    exit 1
+fi
+
+OUT_DIR="$1"
+
+# Check if Rscript is available
+if ! command -v Rscript &> /dev/null; then
+    echo "Error: Rscript is not installed or not in PATH."
+    exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+RSCRIPT_PATH="$DIR/generateEpicProbeBlacklist_v2.R"
+
+# Run the script in the specified output directory to save the file there
+(cd "$OUT_DIR" && Rscript "$RSCRIPT_PATH")


### PR DESCRIPTION
Adds the execution of `generateEpicProbeBlacklist_v2.R` into the `pipeline.sh` data preparation stage to filter out SNP-affected and cross-reactive methylation probes. 

Changes include:
- Renaming the originally downloaded/generated `M.csv` to `M_orig.csv`.
- Adding backward compatibility checks for existing pipeline runs.
- Introducing a Python script to perform the blacklist filtering securely.

---
*PR created automatically by Jules for task [61288939328503007](https://jules.google.com/task/61288939328503007) started by @kordk*