### PR TITLE
Apply log2 transform to expression data before PCA residualization

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -154,7 +154,7 @@ if [ -s "$DATA_DIR/C.csv" ]; then
     log "C.csv already exists. Skipping Residualization and PCA generation."
 else
     log "Running Expression Residualization & PCA..."
-    ./tools/residualize_pca.sh "$DATA_DIR/G.csv" "$DATA_DIR/C_post_cellTypes.csv" "$DATA_DIR/G_PCs.csv" "Exp_PC"
+    ./tools/residualize_pca.sh "$DATA_DIR/G.csv" "$DATA_DIR/C_post_cellTypes.csv" "$DATA_DIR/G_PCs.csv" "Exp_PC" --log2-transform
 
     log "Running Methylation Residualization & PCA..."
     ./tools/residualize_pca.sh "$DATA_DIR/M.csv" "$DATA_DIR/C_post_cellTypes.csv" "$DATA_DIR/M_PCs.csv" "Meth_PC"

--- a/tools/residualize_pca.py
+++ b/tools/residualize_pca.py
@@ -21,6 +21,7 @@ def main():
     parser.add_argument("-n", "--n-components", type=int, default=5, help="Number of top principal components to extract. Default is 5.")
     parser.add_argument("--transpose", action="store_true", help="Transpose input matrix before processing. Use if input has samples as rows.")
     parser.add_argument("-D", "--debug", action="store_true", help="Enable debug logging.")
+    parser.add_argument("--log2-transform", action="store_true", help="Apply log2(x + 1) transform to the input matrix before residualization.")
 
     args = parser.parse_args()
 
@@ -49,6 +50,10 @@ def main():
         M = M_raw.transpose()
     else:
         M = M_raw
+
+    if args.log2_transform:
+        logger.info("Applying log2(x + 1) transformation to the input matrix.")
+        M = np.log2(M.astype(float) + 1)
 
     logger.info(f"Loading base covariates from {args.covar_file}")
     C = pd.read_csv(args.covar_file, dtype={0: str})

--- a/tools/residualize_pca.sh
+++ b/tools/residualize_pca.sh
@@ -12,8 +12,9 @@ INPUT_FILE="$1"
 COV_FILE="$2"
 OUT_FILE="$3"
 PREFIX="$4"
+shift 4
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PYTHON_SCRIPT="$DIR/residualize_pca.py"
 
-python3 "$PYTHON_SCRIPT" -i "$INPUT_FILE" -c "$COV_FILE" -o "$OUT_FILE" -p "$PREFIX" -n 5
+python3 "$PYTHON_SCRIPT" -i "$INPUT_FILE" -c "$COV_FILE" -o "$OUT_FILE" -p "$PREFIX" -n 5 "$@"


### PR DESCRIPTION
Adds `--log2-transform` flag to residualize_pca and applies it in pipeline.sh for expression data.

---
*PR created automatically by Jules for task [1241357249328512272](https://jules.google.com/task/1241357249328512272) started by @kordk*