### PR TITLE
Add R dependencies installation script

### DIFF
--- a/tools/install_dependencies.R
+++ b/tools/install_dependencies.R
@@ -1,0 +1,54 @@
+#!/usr/bin/env Rscript
+
+# install_dependencies.R
+# This script installs all necessary R packages required by the tecpg pipeline tools.
+
+# Set CRAN mirror if not set to avoid interactive prompts
+local({
+  r <- getOption("repos")
+  if (identical(r["CRAN"], "@CRAN@") || is.null(r["CRAN"]) || is.na(r["CRAN"])) {
+    r["CRAN"] <- "https://cloud.r-project.org"
+    options(repos = r)
+  }
+})
+
+# Install BiocManager if not already installed
+if (!requireNamespace("BiocManager", quietly = TRUE)) {
+  cat("Installing BiocManager...\n")
+  install.packages("BiocManager")
+}
+
+# CRAN packages
+cran_packages <- c(
+  "pheatmap"
+)
+
+# Bioconductor packages
+bioc_packages <- c(
+  "EpiDISH",
+  "sva",
+  "IlluminaHumanMethylationEPICanno.ilm10b4.hg19",
+  "ExperimentHub"
+)
+
+cat("Installing CRAN dependencies...\n")
+for (pkg in cran_packages) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+    cat(sprintf("Installing %s...\n", pkg))
+    install.packages(pkg)
+  } else {
+    cat(sprintf("%s is already installed.\n", pkg))
+  }
+}
+
+cat("Installing Bioconductor dependencies...\n")
+for (pkg in bioc_packages) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+    cat(sprintf("Installing %s...\n", pkg))
+    BiocManager::install(pkg, update = FALSE, ask = FALSE)
+  } else {
+    cat(sprintf("%s is already installed.\n", pkg))
+  }
+}
+
+cat("All dependencies installed successfully.\n")


### PR DESCRIPTION
Created an R script `tools/install_dependencies.R` to automate the installation of all necessary R libraries used throughout the project's tools. The script efficiently handles both CRAN and Bioconductor packages, establishing a reliable local environment for running R-based analyses in the repository.

---
*PR created automatically by Jules for task [6979968726530124223](https://jules.google.com/task/6979968726530124223) started by @kordk*