### PR TITLE
Fix NaN handling and pipeline transforms for MESA and GTP datasets

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -82,6 +82,11 @@ if [ -n "${TECPG_G_CHUNK:-}" ]; then
     MLR_CHUNK_ARGS+=(--gene-loci-per-chunk "$TECPG_G_CHUNK")
 fi
 
+# Determine whether to apply logit transformation based on dataset
+if [ "$DATASET" = "gtp" ]; then
+    MLR_CHUNK_ARGS+=(--logit-transform)
+fi
+
 log "======================================"
 log "Starting eQTM Pipeline for: $DATASET (Mapping: $MAPPING)"
 if [ "${#MLR_CHUNK_ARGS[@]}" -gt 0 ]; then

--- a/tecpg/gtp.py
+++ b/tecpg/gtp.py
@@ -148,23 +148,37 @@ def process_gtp(
     M.drop(M_drop, axis=1, inplace=True)
     G.drop(G_drop, axis=1, inplace=True)
 
+    logger.info('Data diagnostics for Gene Expression (G):')
+    logger.info(f'  Min: {G.min().min():.4f}, Max: {G.max().max():.4f}')
+    logger.info('Data diagnostics for Methylation (M):')
+    logger.info(f'  Min: {M.min().min():.4f}, Max: {M.max().max():.4f}')
+
     if drop_na:
         G_start = len(G)
-        G.dropna(axis=0, inplace=True)
+        G_na = G.isna().any(axis=1)
+        G.drop(G[G_na].index, inplace=True)
         G_end = len(G)
-        logger.info(
-            'Dropped {0} rows of G with missing values ({1}% remaining)',
-            G_start - G_end,
-            round(G_end / G_start * 100, 4),
-        )
+        dropped_G = G_start - G_end
+        if dropped_G == 0:
+            logger.info('No NaNs found in G.')
+        else:
+            logger.info(
+                f'Excluded {dropped_G} gene expression loci due to missing data '
+                f'({round(G_end / G_start * 100, 4)}% remaining)'
+            )
+
         M_start = len(M)
-        M.dropna(axis=0, inplace=True)
+        M_na = M.isna().any(axis=1)
+        M.drop(M[M_na].index, inplace=True)
         M_end = len(M)
-        logger.info(
-            'Dropped {0} rows of M with missing values ({1}% remaining)',
-            M_start - M_end,
-            round(M_end / M_start * 100, 4),
-        )
+        dropped_M = M_start - M_end
+        if dropped_M == 0:
+            logger.info('No NaNs found in M.')
+        else:
+            logger.info(
+                f'Excluded {dropped_M} methylation loci due to missing data '
+                f'({round(M_end / M_start * 100, 4)}% remaining)'
+            )
 
     C_drop = set(C.index) - set(M.columns)
     C.drop(C_drop, axis=0, inplace=True)

--- a/tecpg/mesa.py
+++ b/tecpg/mesa.py
@@ -148,23 +148,37 @@ def process_mesa(
     M.drop(M_drop, axis=1, inplace=True)
     G.drop(G_drop, axis=1, inplace=True)
 
+    logger.info('Data diagnostics for Gene Expression (G):')
+    logger.info(f'  Min: {G.min().min():.4f}, Max: {G.max().max():.4f}')
+    logger.info('Data diagnostics for Methylation (M):')
+    logger.info(f'  Min: {M.min().min():.4f}, Max: {M.max().max():.4f}')
+
     if drop_na:
         G_start = len(G)
-        G.dropna(axis=0, inplace=True)
+        G_na = G.isna().any(axis=1)
+        G.drop(G[G_na].index, inplace=True)
         G_end = len(G)
-        logger.info(
-            'Dropped {0} rows of G with missing values ({1}% remaining)',
-            G_start - G_end,
-            round(G_end / G_start * 100, 4),
-        )
+        dropped_G = G_start - G_end
+        if dropped_G == 0:
+            logger.info('No NaNs found in G.')
+        else:
+            logger.info(
+                f'Excluded {dropped_G} gene expression loci due to missing data '
+                f'({round(G_end / G_start * 100, 4)}% remaining)'
+            )
+
         M_start = len(M)
-        M.dropna(axis=0, inplace=True)
+        M_na = M.isna().any(axis=1)
+        M.drop(M[M_na].index, inplace=True)
         M_end = len(M)
-        logger.info(
-            'Dropped {0} rows of M with missing values ({1}% remaining)',
-            M_start - M_end,
-            round(M_end / M_start * 100, 4),
-        )
+        dropped_M = M_start - M_end
+        if dropped_M == 0:
+            logger.info('No NaNs found in M.')
+        else:
+            logger.info(
+                f'Excluded {dropped_M} methylation loci due to missing data '
+                f'({round(M_end / M_start * 100, 4)}% remaining)'
+            )
 
     C_drop = set(C.index) - set(M.columns)
     C.drop(C_drop, axis=0, inplace=True)

--- a/tools/residualize_pca.py
+++ b/tools/residualize_pca.py
@@ -53,7 +53,12 @@ def main():
 
     if args.log2_transform:
         logger.info("Applying log2(x + 1) transformation to the input matrix.")
-        M = np.log2(M.astype(float) + 1)
+        float_M = M.astype(float)
+        if (float_M <= -1).any().any():
+            logger.error("Negative values <= -1 found in input matrix before log2 transform. Cannot apply log2(x + 1) to values <= -1.")
+            import sys
+            sys.exit(1)
+        M = np.log2(float_M + 1)
 
     logger.info(f"Loading base covariates from {args.covar_file}")
     C = pd.read_csv(args.covar_file, dtype={0: str})


### PR DESCRIPTION
Includes diagnostics on missing data in `process_mesa` and `process_gtp`, proper formatting of `NaN` drop counts ("Excluded N loci due to missing data"), validation against negative values during PCA residualization to avoid generating NaNs, and appropriate MLR configuration in `pipeline.sh` regarding logit transformation.

---
*PR created automatically by Jules for task [7405269031372729730](https://jules.google.com/task/7405269031372729730) started by @kordk*