### PR TITLE
Integrate exploreOmics.py into pipeline.sh

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -162,6 +162,11 @@ else
     python3 tools/exclude_blacklisted_probes.py "$DATA_DIR/M_orig.csv" "$DATA_DIR/epic_probes_blacklist.csv" "$DATA_DIR/M.csv"
 fi
 
+# Data Exploration
+log "Exploring Omics data..."
+python3 tools/exploreOmics.py --input "$DATA_DIR/M.csv" --data-type methylation --output-dir "$DATA_DIR/qc"
+python3 tools/exploreOmics.py --input "$DATA_DIR/G.csv" --data-type expression --output-dir "$DATA_DIR/qc"
+
 # Stage 1.5: Estimate Immune Cell Proportions
 log "[1.5/9] Estimating immune cell proportions using EpiDISH..."
 if [ -s "$DATA_DIR/C_post_cellTypes.csv" ]; then

--- a/tools/exploreOmics.py
+++ b/tools/exploreOmics.py
@@ -11,14 +11,40 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 import argparse
+import logging
+import random
 
-# Add src to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
+def setup_logger(name, level='INFO'):
+    logger = logging.getLogger(name)
+    logger.setLevel(getattr(logging, level.upper()))
+    if not logger.handlers:
+        ch = logging.StreamHandler()
+        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
+    return logger
 
-from src.config import load_config
-from src.utils import set_random_seed, ensure_dir
-from src.logging_utils import setup_logger, log_dataframe_info
-from src.data_utils import load_omics_data
+def set_random_seed(seed):
+    random.seed(seed)
+    np.random.seed(seed)
+
+def ensure_dir(dir_path):
+    p = Path(dir_path)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+def load_omics_data(filepath, transpose=False):
+    # Load data with first column as index (Sample IDs)
+    df = pd.read_csv(filepath, index_col=0)
+    if transpose:
+        df = df.T
+    return df
+
+def log_dataframe_info(logger, df, name):
+    logger.info(f"{name} info:")
+    logger.info(f"  Shape: {df.shape}")
+    logger.info(f"  Memory usage: {df.memory_usage(deep=True).sum() / 1e6:.2f} MB")
+
 
 
 def calculate_qc_metrics(df: pd.DataFrame, logger) -> dict:
@@ -236,7 +262,6 @@ def main():
     args = parser.parse_args()
     
     # Setup
-    config = load_config()
     set_random_seed(args.seed)
     logger = setup_logger('explore_omics', level='INFO')
     


### PR DESCRIPTION
Refactored `tools/exploreOmics.py` to use standard Python features instead of relying on a missing `src` module. Added the Omics data exploration execution step to `pipeline.sh` for both `M.csv` and `G.csv` files, and directed output to the requested `qc` subdirectory within the data folder.

---
*PR created automatically by Jules for task [17639041729786182340](https://jules.google.com/task/17639041729786182340) started by @kordk*