### PR TITLE
Apply floor to zero and log2(x+1) transformation to Gene Expression during prep

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -177,7 +177,7 @@ if [ -s "$DATA_DIR/C.csv" ]; then
     log "C.csv already exists. Skipping Residualization and PCA generation."
 else
     log "Running Expression Residualization & PCA..."
-    ./tools/residualize_pca.sh "$DATA_DIR/G.csv" "$DATA_DIR/C_post_cellTypes.csv" "$DATA_DIR/G_PCs.csv" "Exp_PC" --log2-transform
+    ./tools/residualize_pca.sh "$DATA_DIR/G.csv" "$DATA_DIR/C_post_cellTypes.csv" "$DATA_DIR/G_PCs.csv" "Exp_PC"
 
     log "Running Methylation Residualization & PCA..."
     ./tools/residualize_pca.sh "$DATA_DIR/M.csv" "$DATA_DIR/C_post_cellTypes.csv" "$DATA_DIR/M_PCs.csv" "Meth_PC"

--- a/tecpg/gtp.py
+++ b/tecpg/gtp.py
@@ -187,6 +187,11 @@ def process_gtp(
 
     C['Sex'] = C['Sex'].replace({'Male': 0, 'Female': 1}).astype(int)
 
+    logger.info('Applying floor to zero and log2(x + 1) transformation to Gene Expression (G)')
+    import numpy as np
+    G = G.clip(lower=0)
+    G = np.log2(G + 1)
+
     logger.info('Sorting columns')
     M = M.reindex(sorted(M.columns, key=int), axis=1)
     G = G.reindex(sorted(G.columns, key=int), axis=1)

--- a/tecpg/mesa.py
+++ b/tecpg/mesa.py
@@ -189,6 +189,11 @@ def process_mesa(
     M.drop(columns=list(M_drop_from_C), inplace=True)
     G.drop(columns=list(G_drop_from_C), inplace=True)
 
+    logger.info('Applying floor to zero and log2(x + 1) transformation to Gene Expression (G)')
+    import numpy as np
+    G = G.clip(lower=0)
+    G = np.log2(G + 1)
+
     logger.info('Sorting columns')
     M = M.reindex(sorted(M.columns, key=int), axis=1)
     G = G.reindex(sorted(G.columns, key=int), axis=1)


### PR DESCRIPTION
Applied requested mathematical transformation for the Gene Expression datasets. Removed duplicate implementation from `pipeline.sh` calls so it behaves consistently across both GTP and MESA.

---
*PR created automatically by Jules for task [14960797325163063392](https://jules.google.com/task/14960797325163063392) started by @kordk*