### PR TITLE
feat: Add Cytoscape Bipartite Network Exporter

### DIFF
--- a/tests/test_export_cytoscape.py
+++ b/tests/test_export_cytoscape.py
@@ -1,0 +1,163 @@
+import os
+import sys
+import tempfile
+import unittest
+import pandas as pd
+from unittest.mock import patch
+import io
+
+# Add the tools directory to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from tools import export_cytoscape
+
+class TestExportCytoscape(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.input_file = os.path.join(self.temp_dir.name, "input.parquet")
+        self.out_prefix = os.path.join(self.temp_dir.name, "cytoscape")
+        self.out_edges = f"{self.out_prefix}_edges.csv"
+        self.out_nodes = f"{self.out_prefix}_nodes.csv"
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def create_dummy_parquet(self, data, filename):
+        df = pd.DataFrame(data)
+        df.to_parquet(filename)
+
+    def test_basic_success_with_mt_ig(self):
+        data = {
+            'mt_id': ['cpg1', 'cpg2'],
+            'mt_chrom': ['chr1', 'chr2'],
+            'mt_chromStart': [100, 200],
+            'mt_strand': ['+', '-'],
+            'gt_id': ['geneA', 'geneB'],
+            'gt_chrom': ['chr1', 'chr2'],
+            'gt_chromStart': [500, 600],
+            'gt_strand': ['+', '-'],
+            'mt_est': [0.5, -0.3],
+            'mt_p': [0.01, 0.05],
+            'region': ['PROMOTER', 'DISTAL'],
+            'mt_ig': [1.5, 2.5],  # cpg2 should sort first
+            'age_ig': [0.1, 0.2]
+        }
+        self.create_dummy_parquet(data, self.input_file)
+
+        test_args = ['export_cytoscape.py', '-i', self.input_file, '-o', self.out_prefix, '--top-k', '10']
+        with patch('sys.argv', test_args):
+            export_cytoscape.main()
+
+        self.assertTrue(os.path.exists(self.out_edges))
+        self.assertTrue(os.path.exists(self.out_nodes))
+
+        edges_df = pd.read_csv(self.out_edges)
+        nodes_df = pd.read_csv(self.out_nodes)
+
+        # Check edge df columns
+        expected_edge_cols = ['Source', 'Target', 'Interaction', 'mt_est', 'mt_p', 'mt_ig', 'age_ig']
+        for col in expected_edge_cols:
+            self.assertIn(col, edges_df.columns)
+
+        # cpg2 should be first due to mt_ig sorting
+        self.assertEqual(edges_df.iloc[0]['Source'], 'cpg2')
+
+        # Check nodes
+        self.assertEqual(len(nodes_df), 4) # 2 cpgs + 2 genes
+        expected_node_cols = ['Node_ID', 'Chrom', 'Start', 'Strand', 'Node_Type']
+        for col in expected_node_cols:
+            self.assertIn(col, nodes_df.columns)
+
+    def test_fallback_mt_t_generates_abs_t(self):
+        data = {
+            'mt_id': ['cpg1', 'cpg2'],
+            'mt_chrom': ['chr1', 'chr2'],
+            'mt_chromStart': [100, 200],
+            'mt_strand': ['+', '-'],
+            'gt_id': ['geneA', 'geneB'],
+            'gt_chrom': ['chr1', 'chr2'],
+            'gt_chromStart': [500, 600],
+            'gt_strand': ['+', '-'],
+            'mt_est': [0.5, -0.3],
+            'mt_p': [0.01, 0.05],
+            'region': ['PROMOTER', 'DISTAL'],
+            'mt_t': [-5.0, 2.0] # cpg1 abs_t is 5.0, should be first
+        }
+        self.create_dummy_parquet(data, self.input_file)
+
+        test_args = ['export_cytoscape.py', '-i', self.input_file, '-o', self.out_prefix]
+        with patch('sys.argv', test_args):
+            export_cytoscape.main()
+
+        edges_df = pd.read_csv(self.out_edges)
+
+        self.assertIn('mt_t', edges_df.columns)
+        self.assertIn('abs_t', edges_df.columns)
+
+        # cpg1 should be first
+        self.assertEqual(edges_df.iloc[0]['Source'], 'cpg1')
+        self.assertEqual(edges_df.iloc[0]['abs_t'], 5.0)
+
+    def test_missing_node_cols(self):
+        # Missing gt_chrom
+        data = {
+            'mt_id': ['cpg1'], 'mt_chrom': ['chr1'], 'mt_chromStart': [100], 'mt_strand': ['+'],
+            'gt_id': ['geneA'], 'gt_chromStart': [500], 'gt_strand': ['+'],
+            'mt_est': [0.5], 'mt_p': [0.01], 'mt_ig': [1.5]
+        }
+        self.create_dummy_parquet(data, self.input_file)
+
+        test_args = ['export_cytoscape.py', '-i', self.input_file, '-o', self.out_prefix]
+        with patch('sys.argv', test_args):
+            with self.assertRaises(SystemExit) as cm:
+                export_cytoscape.main()
+            self.assertEqual(cm.exception.code, 1)
+
+    def test_missing_edge_cols(self):
+        # Missing mt_p
+        data = {
+            'mt_id': ['cpg1'], 'mt_chrom': ['chr1'], 'mt_chromStart': [100], 'mt_strand': ['+'],
+            'gt_id': ['geneA'], 'gt_chrom': ['chr1'], 'gt_chromStart': [500], 'gt_strand': ['+'],
+            'mt_est': [0.5], 'mt_ig': [1.5]
+        }
+        self.create_dummy_parquet(data, self.input_file)
+
+        test_args = ['export_cytoscape.py', '-i', self.input_file, '-o', self.out_prefix]
+        with patch('sys.argv', test_args):
+            with self.assertRaises(SystemExit) as cm:
+                export_cytoscape.main()
+            self.assertEqual(cm.exception.code, 1)
+
+    def test_missing_mt_ig_and_mt_t(self):
+        # No mt_ig, no mt_t
+        data = {
+            'mt_id': ['cpg1'], 'mt_chrom': ['chr1'], 'mt_chromStart': [100], 'mt_strand': ['+'],
+            'gt_id': ['geneA'], 'gt_chrom': ['chr1'], 'gt_chromStart': [500], 'gt_strand': ['+'],
+            'mt_est': [0.5], 'mt_p': [0.01]
+        }
+        self.create_dummy_parquet(data, self.input_file)
+
+        test_args = ['export_cytoscape.py', '-i', self.input_file, '-o', self.out_prefix]
+        with patch('sys.argv', test_args):
+            with self.assertRaises(SystemExit) as cm:
+                export_cytoscape.main()
+            self.assertEqual(cm.exception.code, 1)
+
+    def test_default_region_undefined(self):
+        data = {
+            'mt_id': ['cpg1'], 'mt_chrom': ['chr1'], 'mt_chromStart': [100], 'mt_strand': ['+'],
+            'gt_id': ['geneA'], 'gt_chrom': ['chr1'], 'gt_chromStart': [500], 'gt_strand': ['+'],
+            'mt_est': [0.5], 'mt_p': [0.01], 'mt_ig': [1.5]
+            # No region column
+        }
+        self.create_dummy_parquet(data, self.input_file)
+
+        test_args = ['export_cytoscape.py', '-i', self.input_file, '-o', self.out_prefix]
+        with patch('sys.argv', test_args):
+            export_cytoscape.main()
+
+        edges_df = pd.read_csv(self.out_edges)
+        self.assertIn('Interaction', edges_df.columns)
+        self.assertEqual(edges_df.iloc[0]['Interaction'], 'Undefined')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/export_cytoscape.py
+++ b/tools/export_cytoscape.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import sys
+import pandas as pd
+import logging
+
+logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+def main():
+    parser = argparse.ArgumentParser(description="Export eQTM Parquet file to Cytoscape Node and Edge tables.")
+    parser.add_argument("-i", "--input", required=True, help="Path to the input Parquet file (e.g., results.precise_p.annot.fdr.parquet).")
+    parser.add_argument("-o", "--out-prefix", default="cytoscape", help="Output prefix for generated CSV files (default: 'cytoscape').")
+    parser.add_argument("--top-k", type=int, default=10000, help="Number of top hits to include (default: 10000).")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input):
+        logging.error(f"Input file not found: {args.input}")
+        sys.exit(1)
+
+    logging.info(f"Loading data from {args.input}...")
+    try:
+        df = pd.read_parquet(args.input)
+    except Exception as e:
+        logging.error(f"Failed to read Parquet file: {e}")
+        sys.exit(1)
+
+    # 1. Check required node columns
+    required_node_cols = ['mt_id', 'mt_chrom', 'mt_chromStart', 'mt_strand',
+                          'gt_id', 'gt_chrom', 'gt_chromStart', 'gt_strand']
+    missing_node_cols = [col for col in required_node_cols if col not in df.columns]
+    if missing_node_cols:
+        logging.error(f"Missing required node columns: {missing_node_cols}. Expected: {required_node_cols}")
+        sys.exit(1)
+
+    # 2. Check required edge columns (statistical)
+    required_edge_cols = ['mt_est', 'mt_p']
+    missing_edge_cols = [col for col in required_edge_cols if col not in df.columns]
+    if missing_edge_cols:
+        logging.error(f"Missing required edge columns: {missing_edge_cols}. Expected at least: {required_edge_cols}")
+        sys.exit(1)
+
+    # 3. Handle region column
+    if 'region' not in df.columns:
+        logging.info("Column 'region' not found. Defaulting Interaction to 'Undefined'.")
+        df['region'] = 'Undefined'
+
+    # 4. Filter and sort by Saliency / mt_t
+    if 'mt_ig' in df.columns:
+        logging.info("Sorting by mt_ig (Saliency) in descending order.")
+        df_top = df.sort_values(by='mt_ig', ascending=False).head(args.top_k)
+        used_abs_t = False
+    elif 'mt_t' in df.columns:
+        logging.info("Column 'mt_ig' not found. Falling back to sorting by absolute mt_t.")
+        df['abs_t'] = df['mt_t'].abs()
+        df_top = df.sort_values(by='abs_t', ascending=False).head(args.top_k)
+        used_abs_t = True
+    else:
+        logging.error("Neither 'mt_ig' nor 'mt_t' column found in the Parquet file. Cannot perform top-K ranking.")
+        sys.exit(1)
+
+    # 5. Build Edge Table
+    logging.info("Building Edge table...")
+    base_edge_cols = ['mt_id', 'gt_id', 'region', 'mt_est', 'mt_p']
+    if 'mt_t' in df_top.columns:
+        base_edge_cols.append('mt_t')
+    if used_abs_t:
+        base_edge_cols.append('abs_t')
+    if 'fdr_est' in df_top.columns:
+        base_edge_cols.append('fdr_est')
+
+    ig_cols = [c for c in df_top.columns if c.endswith('_ig')]
+
+    edge_cols = base_edge_cols + ig_cols
+    edges = df_top[edge_cols].copy()
+    edges.rename(columns={'mt_id': 'Source', 'gt_id': 'Target', 'region': 'Interaction'}, inplace=True)
+
+    out_edges = f"{args.out_prefix}_edges.csv"
+    edges.to_csv(out_edges, index=False)
+
+    # 6. Build Node Table
+    logging.info("Building Node table...")
+    # Extract CpGs
+    cpgs = df_top[['mt_id', 'mt_chrom', 'mt_chromStart', 'mt_strand']].copy()
+    cpgs.columns = ['Node_ID', 'Chrom', 'Start', 'Strand']
+    cpgs['Node_Type'] = 'CpG'
+
+    # Extract Genes
+    genes = df_top[['gt_id', 'gt_chrom', 'gt_chromStart', 'gt_strand']].copy()
+    genes.columns = ['Node_ID', 'Chrom', 'Start', 'Strand']
+    genes['Node_Type'] = 'Gene'
+
+    # Stack and Deduplicate
+    nodes = pd.concat([cpgs, genes]).drop_duplicates(subset=['Node_ID'])
+
+    out_nodes = f"{args.out_prefix}_nodes.csv"
+    nodes.to_csv(out_nodes, index=False)
+
+    logging.info(f"Exported {len(nodes)} nodes to {out_nodes} and {len(edges)} edges to {out_edges} for Cytoscape.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces a standalone utility script (`tools/export_cytoscape.py`) to parse final eQTM Parquet files and generate Cytoscape-formatted Edge and Node tables. It addresses performance limitations in Cytoscape by implementing top-K filtering based on the `mt_ig` saliency score, with a fallback to absolute `mt_t`. The tool extracts unique sets of CpG and Gene nodes and structures edge attributes dynamically to seamlessly import into Cytoscape for bipartite network visualization.

Tested via `tests/test_export_cytoscape.py`.

---
*PR created automatically by Jules for task [1379277000660546022](https://jules.google.com/task/1379277000660546022) started by @kordk*