### PR TITLE
Fix TypeError in visualizeBipartiteNetwork script when Region column contains missing values

### DIFF
--- a/tools/visualizeBipartiteNetwork.py
+++ b/tools/visualizeBipartiteNetwork.py
@@ -27,6 +27,18 @@ def load_data(args):
     logging.info(f"Loading nodes from {args.nodes}...")
     nodes = pd.read_csv(args.nodes)
 
+    if 'Region' not in nodes.columns:
+        logging.error("Column 'Region' not found in nodes. Cannot proceed.")
+        sys.exit(1)
+
+    nodes['Region'] = nodes['Region'].fillna('Undefined')
+
+    # Log summary of counts for each region
+    region_counts = nodes['Region'].value_counts()
+    logging.info("Region counts:")
+    for region, count in region_counts.items():
+        logging.info(f"  {region}: {count}")
+
     # Determine weight column
     if 'mt_ig' in edges.columns:
         weight_col = 'mt_ig'


### PR DESCRIPTION
Fix TypeError when Region values are empty in visualizeBipartiteNetwork

- Update `tools/visualizeBipartiteNetwork.py` to fill empty (NaN) `Region` values with 'Undefined', preventing `TypeError` during sort operations.
- Add an explicit check to exit with an error if the `Region` column is entirely missing from the nodes file.
- Add a logging step to output a summary of counts for each region type.

---
*PR created automatically by Jules for task [1055282738654993650](https://jules.google.com/task/1055282738654993650) started by @kordk*