### PR TITLE
Fix: Skip sample_reservoir.csv in mergeOutputs.py

### DIFF
--- a/tools/mergeOutputs.py
+++ b/tools/mergeOutputs.py
@@ -155,8 +155,8 @@ def main():
     search_path = os.path.join(input_dir, pattern)
     raw_files = glob.glob(search_path)
 
-    # Filter to only .csv and .parquet extensions
-    files = [f for f in raw_files if f.endswith('.csv') or f.endswith('.parquet')]
+    # Filter to only .csv and .parquet extensions, and ignore sample_reservoir.csv
+    files = [f for f in raw_files if (f.endswith('.csv') or f.endswith('.parquet')) and not f.endswith('sample_reservoir.csv')]
 
     if not files:
         print(f"Error: No files found matching '{pattern}' (and ending in .csv or .parquet) in '{input_dir}'.", file=sys.stderr)


### PR DESCRIPTION
Fixes an issue in the pipeline where the `mergeOutputs.py` script attempts to merge the `sample_reservoir.csv` file, resulting in schema mismatch errors and downstream failures.

---
*PR created automatically by Jules for task [12391296213405167943](https://jules.google.com/task/12391296213405167943) started by @kordk*