### PR TITLE
fix: prevent KeyError on Parquet to Pandas conversion

### DIFF
--- a/tools/assignRegionToEcpg_parquet.py
+++ b/tools/assignRegionToEcpg_parquet.py
@@ -132,6 +132,8 @@ def reportPvalues(my_ecpgDataFile, pval_col, chunk_size):
 
     for batch in parquet_file.iter_batches(batch_size=chunk_size, columns=[pval_col]):
         df = batch.to_pandas()
+        if df.index.names != [None]:
+            df = df.reset_index()
 
         # Count missing
         missing_mask = df[pval_col].isna()
@@ -192,6 +194,8 @@ def assignRegion(my_ecpgDataFile, gH, mH, pval_col, outFileName, chunk_size):
 
     for batch in parquet_file.iter_batches(batch_size=chunk_size):
         df = batch.to_pandas()
+        if df.index.names != [None]:
+            df = df.reset_index()
         my_eqtmA = []
 
         for index, row in df.iterrows():
@@ -477,6 +481,8 @@ def verify_alignment(geneH, methylH, ecpgDataFile):
 
         batch = next(parquet_file.iter_batches(batch_size=1000, columns=['gt_id', 'mt_id', pval_col]))
         df = batch.to_pandas()
+        if df.index.names != [None]:
+            df = df.reset_index()
     except Exception as e:
         logger.error(f"[verify_alignment] Error reading parquet file for verification: {e}")
         sys.exit(1)

--- a/tools/benchmark_kennedy.py
+++ b/tools/benchmark_kennedy.py
@@ -26,6 +26,8 @@ def main():
     logging.info(f"Loading tecpg data from {args.tecpg}...")
     try:
         df_tecpg = pq.read_table(args.tecpg).to_pandas()
+        if df_tecpg.index.names != [None]:
+            df_tecpg = df_tecpg.reset_index()
         logging.info(f"tecpg data loaded. Shape: {df_tecpg.shape}")
         logging.info(f"tecpg columns: {list(df_tecpg.columns)}")
         logging.info(f"tecpg distinct genes (gt_id): {df_tecpg.get('gt_id', pd.Series()).nunique()}")

--- a/tools/mergeOutputs.py
+++ b/tools/mergeOutputs.py
@@ -203,6 +203,8 @@ def main():
                                     empty_files_count += 1
                                 else:
                                     df = table.to_pandas()
+                                    if df.index.names != [None]:
+                                        df = df.reset_index()
                                     csv_data = df.to_csv(index=False, header=not first_file_written).encode('utf-8')
                                     f_out.write(csv_data)
                                     first_file_written = True

--- a/tools/summarizeOutput_parquet.py
+++ b/tools/summarizeOutput_parquet.py
@@ -323,6 +323,8 @@ Outputs and Metrics Calculated:
     try:
         for i, batch in enumerate(parquet_file.iter_batches(batch_size=args.chunk_size)):
             df_chunk = batch.to_pandas()
+            if df_chunk.index.names != [None]:
+                df_chunk = df_chunk.reset_index()
             res = pool.apply_async(process_chunk, (df_chunk, sample_prob, args.df))
             results.append(res)
 
@@ -596,6 +598,8 @@ Outputs and Metrics Calculated:
         try:
             for i, batch in enumerate(parquet_file.iter_batches(batch_size=args.chunk_size)):
                 df_chunk = batch.to_pandas()
+                if df_chunk.index.names != [None]:
+                    df_chunk = df_chunk.reset_index()
 
                 # Use same logic to get p-values
                 if not using_fallback:
@@ -937,6 +941,8 @@ Outputs and Metrics Calculated:
         try:
             for i, batch in enumerate(parquet_file.iter_batches(batch_size=args.chunk_size)):
                 df_chunk = batch.to_pandas()
+                if df_chunk.index.names != [None]:
+                    df_chunk = df_chunk.reset_index()
 
                 # Retrieve or calculate p-values for this chunk
                 if not using_fallback:

--- a/tools/summaryParquetToCsv.py
+++ b/tools/summaryParquetToCsv.py
@@ -39,6 +39,8 @@ def main():
 
         for i, batch in enumerate(parquet_file.iter_batches(batch_size=chunk_size)):
             df = batch.to_pandas()
+            if df.index.names != [None]:
+                df = df.reset_index()
 
             # Write header only for the first chunk
             mode = 'w' if i == 0 else 'a'

--- a/tools/visualizeFindings.py
+++ b/tools/visualizeFindings.py
@@ -50,6 +50,8 @@ class Plotter:
 
         for batch in parquet_file.iter_batches(columns=cols_to_load):
             df_batch = batch.to_pandas()
+            if df_batch.index.names != [None]:
+                df_batch = df_batch.reset_index()
 
             # Extract p-values
             p_vals = df_batch[self.p_col]


### PR DESCRIPTION
When `tecpg` chunks are converted to Parquet and then read using PyArrow (`batch.to_pandas()`), the index is sometimes preserved instead of flattened into columns. This leads to `KeyError: 'gt_id'` in scripts like `assignRegionToEcpg_parquet.py` when they attempt to access `df['gt_id']`.

This PR applies a pattern conditionally invoking `reset_index()` immediately after `.to_pandas()` calls across all relevant scripts:
- `assignRegionToEcpg_parquet.py`
- `benchmark_kennedy.py`
- `mergeOutputs.py`
- `summarizeOutput_parquet.py`
- `summaryParquetToCsv.py`
- `visualizeFindings.py`

---
*PR created automatically by Jules for task [13573801360112927007](https://jules.google.com/task/13573801360112927007) started by @kordk*