### PR TITLE
Update genome reference for plotCircos to hg19

### DIFF
--- a/pipelinePost.sh
+++ b/pipelinePost.sh
@@ -37,7 +37,7 @@ mkdir -p "$PLOTS_DIR" "$NETWORK_DIR"
 log "[1/5] Checking for cytoBand.txt..."
 if [ ! -f "cytoBand.txt" ]; then
     log "cytoBand.txt not found. Downloading from UCSC..."
-    curl -O http://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/cytoBand.txt.gz
+    curl -O http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/cytoBand.txt.gz
     gunzip -f cytoBand.txt.gz
     log "cytoBand.txt downloaded and extracted."
 else

--- a/tools/plotCircos.py
+++ b/tools/plotCircos.py
@@ -20,7 +20,7 @@ def parse_args():
         required=True,
         help="Path to the cytoband (karyotype) file for drawing the genome perimeter.\n"
              "You can download this from UCSC Genome Browser, for example:\n"
-             "  curl -O http://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/cytoBand.txt.gz\n"
+             "  curl -O http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/cytoBand.txt.gz\n"
              "  gunzip cytoBand.txt.gz\n"
              "Then provide the extracted cytoBand.txt file here."
     )


### PR DESCRIPTION
Update cytoband download to hg19 in `pipelinePost.sh` and help text in `tools/plotCircos.py` to match the default build for GTP and MESA datasets.

---
*PR created automatically by Jules for task [14099417251105968698](https://jules.google.com/task/14099417251105968698) started by @kordk*