### PR TITLE
Add edge filtering to exportBipartiteNetwork and visualizeBipartiteNetwork

### DIFF
--- a/pipelinePost.sh
+++ b/pipelinePost.sh
@@ -20,6 +20,10 @@ PLOTS_DIR="${OUT_DIR}/plots"
 NETWORK_DIR="${OUT_DIR}/network"
 PARQUET_FILE="${OUT_DIR}/bootstrap_merged.parquet"
 
+# Network export filtering defaults
+NETWORK_TOP_K=500
+NETWORK_MAX_BOOT_P=0.05
+
 log "======================================"
 log "Starting Pipeline Post-Processing for DATASET: ${DATASET}"
 log "======================================"
@@ -54,7 +58,12 @@ python3 -u tools/visualizeFindings.py --all -m "$DATA_DIR/M.csv" -g "$DATA_DIR/G
 
 # Stage 4: Run exportBipartiteNetwork.py to generate cytoscape nodes/edges
 log "[4/5] Generating Cytoscape network files..."
-python3 -u tools/exportBipartiteNetwork.py -i "$PARQUET_FILE" -o cytoscape --out-dir "$NETWORK_DIR"
+python3 -u tools/exportBipartiteNetwork.py \
+    -i "$PARQUET_FILE" \
+    -o cytoscape \
+    --out-dir "$NETWORK_DIR" \
+    --top-k "$NETWORK_TOP_K" \
+    --max-boot-p "$NETWORK_MAX_BOOT_P"
 
 # Stage 5: Run visualizeBipartiteNetwork.py
 log "[5/5] Running visualizeBipartiteNetwork.py..."

--- a/tests/test_exportBipartiteNetwork.py
+++ b/tests/test_exportBipartiteNetwork.py
@@ -159,5 +159,101 @@ class TestExportCytoscape(unittest.TestCase):
         self.assertIn('Interaction', edges_df.columns)
         self.assertEqual(edges_df.iloc[0]['Interaction'], 'Undefined')
 
+    def test_min_effect_filter(self):
+        data = {
+            'mt_id': ['cpg1', 'cpg2', 'cpg3'],
+            'mt_chrom': ['chr1', 'chr1', 'chr1'],
+            'mt_chromStart': [100, 200, 300],
+            'mt_strand': ['+', '+', '+'],
+            'gt_id': ['geneA', 'geneB', 'geneC'],
+            'gt_chrom': ['chr1', 'chr1', 'chr1'],
+            'gt_chromStart': [500, 600, 700],
+            'gt_strand': ['+', '+', '+'],
+            'mt_est': [0.5, -0.3, 0.1],  # cpg3 should be filtered out by min_effect=0.2
+            'mt_p': [0.01, 0.05, 0.01],
+            'mt_ig': [1.5, 2.5, 3.5]
+        }
+        self.create_dummy_parquet(data, self.input_file)
+
+        test_args = ['exportBipartiteNetwork.py', '-i', self.input_file, '-o', self.out_prefix, '--min-effect', '0.2']
+        with patch('sys.argv', test_args):
+            exportBipartiteNetwork.main()
+
+        edges_df = pd.read_csv(self.out_edges)
+        nodes_df = pd.read_csv(self.out_nodes)
+
+        self.assertEqual(len(edges_df), 2)
+        # Should contain cpg1 and cpg2, but not cpg3
+        sources = edges_df['Source'].tolist()
+        self.assertIn('cpg1', sources)
+        self.assertIn('cpg2', sources)
+        self.assertNotIn('cpg3', sources)
+
+        # Verify isolated node is excluded
+        node_ids = nodes_df['Node_ID'].tolist()
+        self.assertNotIn('cpg3', node_ids)
+        self.assertNotIn('geneC', node_ids)
+
+    def test_max_boot_p_filter(self):
+        data = {
+            'mt_id': ['cpg1', 'cpg2', 'cpg3'],
+            'mt_chrom': ['chr1', 'chr1', 'chr1'],
+            'mt_chromStart': [100, 200, 300],
+            'mt_strand': ['+', '+', '+'],
+            'gt_id': ['geneA', 'geneB', 'geneC'],
+            'gt_chrom': ['chr1', 'chr1', 'chr1'],
+            'gt_chromStart': [500, 600, 700],
+            'gt_strand': ['+', '+', '+'],
+            'mt_est': [0.5, -0.3, 0.1],
+            'mt_p': [0.01, 0.05, 0.01],
+            'p_boot': [0.01, 0.1, 0.05], # cpg2 should be filtered out by max_boot_p=0.05
+            'mt_ig': [1.5, 2.5, 3.5]
+        }
+        self.create_dummy_parquet(data, self.input_file)
+
+        test_args = ['exportBipartiteNetwork.py', '-i', self.input_file, '-o', self.out_prefix, '--max-boot-p', '0.05']
+        with patch('sys.argv', test_args):
+            exportBipartiteNetwork.main()
+
+        edges_df = pd.read_csv(self.out_edges)
+        nodes_df = pd.read_csv(self.out_nodes)
+
+        self.assertEqual(len(edges_df), 2)
+        sources = edges_df['Source'].tolist()
+        self.assertIn('cpg1', sources)
+        self.assertIn('cpg3', sources)
+        self.assertNotIn('cpg2', sources)
+
+        # Verify isolated node is excluded
+        node_ids = nodes_df['Node_ID'].tolist()
+        self.assertNotIn('cpg2', node_ids)
+        self.assertNotIn('geneB', node_ids)
+
+    def test_max_boot_p_filter_missing_column(self):
+        data = {
+            'mt_id': ['cpg1', 'cpg2', 'cpg3'],
+            'mt_chrom': ['chr1', 'chr1', 'chr1'],
+            'mt_chromStart': [100, 200, 300],
+            'mt_strand': ['+', '+', '+'],
+            'gt_id': ['geneA', 'geneB', 'geneC'],
+            'gt_chrom': ['chr1', 'chr1', 'chr1'],
+            'gt_chromStart': [500, 600, 700],
+            'gt_strand': ['+', '+', '+'],
+            'mt_est': [0.5, -0.3, 0.1],
+            'mt_p': [0.01, 0.05, 0.01],
+            'mt_ig': [1.5, 2.5, 3.5]
+            # No p_boot column
+        }
+        self.create_dummy_parquet(data, self.input_file)
+
+        test_args = ['exportBipartiteNetwork.py', '-i', self.input_file, '-o', self.out_prefix, '--max-boot-p', '0.05']
+        with patch('sys.argv', test_args):
+            exportBipartiteNetwork.main()
+
+        edges_df = pd.read_csv(self.out_edges)
+
+        # All 3 edges should remain because missing p_boot causes the filter to be skipped
+        self.assertEqual(len(edges_df), 3)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tools/exportBipartiteNetwork.py
+++ b/tools/exportBipartiteNetwork.py
@@ -13,6 +13,8 @@ def main():
     parser.add_argument("-o", "--out-prefix", default="cytoscape", help="Output prefix for generated CSV files (default: 'cytoscape').")
     parser.add_argument("--out-dir", default=".", help="Directory to save output files (default: current directory).")
     parser.add_argument("--top-k", type=int, default=10000, help="Number of top hits to include (default: 10000).")
+    parser.add_argument("--min-effect", type=float, default=None, help="Retain only edges where abs(mt_est) >= min-effect.")
+    parser.add_argument("--max-boot-p", type=float, default=None, help="Retain only edges where p_boot <= max-boot-p.")
     args = parser.parse_args()
 
     if not os.path.exists(args.input):
@@ -46,19 +48,38 @@ def main():
         logging.info("Column 'region' not found. Defaulting Interaction to 'Undefined'.")
         df['region'] = 'Undefined'
 
-    # 4. Filter and sort by Saliency / mt_t
+    # 4. Apply Filters (Order: --min-effect, --max-boot-p, --top-k)
+    # The --top-k filter selects the top K from whatever survives the threshold filters.
+    # It ranks by mt_ig (Integrated Gradients score) descending, with fallback ranking by abs(mt_t).
+
+    total_edges = len(df)
+    logging.info(f"Total edges before filtering: {total_edges}")
+
+    if args.min_effect is not None:
+        df = df[df['mt_est'].abs() >= args.min_effect]
+        logging.info(f"Edges surviving --min-effect >= {args.min_effect}: {len(df)}")
+
+    if args.max_boot_p is not None:
+        if 'p_boot' in df.columns:
+            df = df[df['p_boot'] <= args.max_boot_p]
+            logging.info(f"Edges surviving --max-boot-p <= {args.max_boot_p}: {len(df)}")
+        else:
+            logging.warning("Column 'p_boot' not found in Parquet file. Skipping --max-boot-p filter.")
+
     if 'mt_ig' in df.columns:
-        logging.info("Sorting by mt_ig (Saliency) in descending order.")
+        logging.info(f"Sorting by mt_ig (Saliency) in descending order and taking top {args.top_k}.")
         df_top = df.sort_values(by='mt_ig', ascending=False).head(args.top_k)
         used_abs_t = False
     elif 'mt_t' in df.columns:
-        logging.info("Column 'mt_ig' not found. Falling back to sorting by absolute mt_t.")
+        logging.info(f"Column 'mt_ig' not found. Falling back to sorting by absolute mt_t and taking top {args.top_k}.")
         df['abs_t'] = df['mt_t'].abs()
         df_top = df.sort_values(by='abs_t', ascending=False).head(args.top_k)
         used_abs_t = True
     else:
         logging.error("Neither 'mt_ig' nor 'mt_t' column found in the Parquet file. Cannot perform top-K ranking.")
         sys.exit(1)
+
+    logging.info(f"Edges surviving --top-k filter: {len(df_top)}")
 
     # 5. Build Edge Table
     logging.info("Building Edge table...")
@@ -101,6 +122,7 @@ def main():
     out_nodes = os.path.join(args.out_dir, f"{args.out_prefix}_nodes.csv")
     nodes.to_csv(out_nodes, index=False)
 
+    logging.info(f"Final edge count written to output: {len(edges)}")
     logging.info(f"Exported {len(nodes)} nodes to {out_nodes} and {len(edges)} edges to {out_edges} for Cytoscape.")
 
 if __name__ == "__main__":

--- a/tools/visualizeBipartiteNetwork.py
+++ b/tools/visualizeBipartiteNetwork.py
@@ -27,6 +27,11 @@ def load_data(args):
     logging.info(f"Loading nodes from {args.nodes}...")
     nodes = pd.read_csv(args.nodes)
 
+    num_edges = len(edges)
+    num_cpg_nodes = len(nodes[nodes['Node_Type'] == 'CpG']) if 'Node_Type' in nodes.columns else 0
+    num_gene_nodes = len(nodes[nodes['Node_Type'] == 'Gene']) if 'Node_Type' in nodes.columns else 0
+    logging.info(f"Network input: {num_edges} edges, {num_cpg_nodes} CpG nodes, {num_gene_nodes} gene nodes")
+
     if 'Region' not in nodes.columns:
         logging.error("Column 'Region' not found in nodes. Cannot proceed.")
         sys.exit(1)


### PR DESCRIPTION
This PR adds configurable pre-visualization edge filtering to the bipartite network export and visualization tools to address the issue of rendering overly dense "hairball" networks.

Key improvements:
1.  **exportBipartiteNetwork.py**: Added `--min-effect` (threshold for absolute `mt_est`) and `--max-boot-p` (threshold for `p_boot`). The existing `--top-k` filter works sequentially after the threshold filters.
2.  **visualizeBipartiteNetwork.py**: Added an informational log trace showing the incoming edge count and node breakdown explicitly at startup.
3.  **pipelinePost.sh**: Provided default values for `NETWORK_TOP_K` (500) and `NETWORK_MAX_BOOT_P` (0.05) and passes them when invoking `exportBipartiteNetwork.py`.
4.  **Testing**: Expanded tests in `test_exportBipartiteNetwork.py` to cover threshold filtering and edge cases with missing `p_boot` columns.

This ensures the user can scale visual network complexity while preserving backward compatibility.

---
*PR created automatically by Jules for task [17531734606954787490](https://jules.google.com/task/17531734606954787490) started by @kordk*