### PR TITLE
feat(plotCircos): add detailed reasons for excluded pairs

### DIFF
--- a/tools/plotCircos.py
+++ b/tools/plotCircos.py
@@ -166,7 +166,20 @@ def load_and_validate_data(filepath, valid_chroms):
         for _, row in missing_df.iterrows():
             mt_name = row['mt_id'] if has_mt_id else "UNKNOWN_CPG"
             gt_name = row['gt_id'] if has_gt_id else "UNKNOWN_GENE"
-            print(f"Excluding pair: CpG={mt_name}, Gene={gt_name}")
+
+            reasons = []
+            if pd.isna(row['mt_chromStart']) or row['mt_chrom'] == 'chrnan' or row['mt_chrom'] == 'chrNone':
+                reasons.append("Missing/Invalid Methylation Coordinates")
+            elif row['mt_chrom'] not in valid_chroms:
+                reasons.append(f"Methylation Chromosome '{row['mt_chrom']}' not in Cytoband")
+
+            if pd.isna(row['gt_chromStart']) or row['gt_chrom'] == 'chrnan' or row['gt_chrom'] == 'chrNone':
+                reasons.append("Missing/Invalid Gene Coordinates")
+            elif row['gt_chrom'] not in valid_chroms:
+                reasons.append(f"Gene Chromosome '{row['gt_chrom']}' not in Cytoband")
+
+            reason_str = ", ".join(reasons)
+            print(f"Excluding pair: CpG={mt_name}, Gene={gt_name} (Reason: {reason_str})")
 
         unique_cpgs = missing_df['mt_id'].nunique() if has_mt_id else 0
         unique_genes = missing_df['gt_id'].nunique() if has_gt_id else 0


### PR DESCRIPTION
Added logic in `tools/plotCircos.py` to evaluate and print exactly why a CpG-Gene pair is excluded from plotting. The logs now detail whether the exclusion was due to missing/invalid methylation coordinates, missing/invalid gene coordinates, or if the respective chromosome was not found in the cytoband annotation file. This greatly improves debugging and transparency of the pipeline's plotting step.

---
*PR created automatically by Jules for task [15220113080056076836](https://jules.google.com/task/15220113080056076836) started by @kordk*