### PR TITLE
Refactor missing annotation logging in assignRegionToEcpg_parquet.py

### DIFF
--- a/tools/assignRegionToEcpg_parquet.py
+++ b/tools/assignRegionToEcpg_parquet.py
@@ -173,6 +173,9 @@ def assignRegion(my_ecpgDataFile, gH, mH, pval_col, outFileName, chunk_size):
     npskip = 0
     assigned_total = 0
 
+    missing_gene_ids = {}
+    missing_meth_ids = {}
+
     parquet_file = pq.ParquetFile(my_ecpgDataFile)
     writer = None
 
@@ -217,15 +220,19 @@ def assignRegion(my_ecpgDataFile, gH, mH, pval_col, outFileName, chunk_size):
 
             if not has_mt_annot:
                 if mt_id not in mH:
-                    logger.info(f"[assignRegion] Annotation missing - methylation: {nlp} {mt_id}")
+                    if mt_id not in missing_meth_ids:
+                        missing_meth_ids[mt_id] = "missing_id"
                 else:
-                    logger.info(f"[assignRegion] Annotation missing - methylation [chrom]: {nlp} {mt_id}")
+                    if mt_id not in missing_meth_ids:
+                        missing_meth_ids[mt_id] = "missing_chrom"
                 nemt += 1
             if not has_gt_annot:
                 if gt_id not in gH:
-                    logger.info(f"[assignRegion] Annotation missing - gene expression: {nlp} {gt_id}")
+                    if gt_id not in missing_gene_ids:
+                        missing_gene_ids[gt_id] = "missing_id"
                 else:
-                    logger.info(f"[assignRegion] Annotation missing - gene expression [chrom]: {nlp} {gt_id}")
+                    if gt_id not in missing_gene_ids:
+                        missing_gene_ids[gt_id] = "missing_chrom"
                 negx += 1
 
             if not has_mt_annot or not has_gt_annot:
@@ -431,6 +438,23 @@ def assignRegion(my_ecpgDataFile, gH, mH, pval_col, outFileName, chunk_size):
         # If no results matched, we still want to create an empty parquet file
         writer = pq.ParquetWriter(outFileName, schema)
         writer.close()
+
+    # Write missing annotation IDs to sidecar file
+    out_dir = os.path.dirname(outFileName)
+    if not out_dir:
+        out_dir = "."
+    sidecar_path = os.path.join(out_dir, "annotation_missing_ids.txt")
+
+    with open(sidecar_path, "w") as f:
+        f.write("type\tid\treason\n")
+        for g_id in sorted(missing_gene_ids.keys()):
+            f.write(f"gene\t{g_id}\t{missing_gene_ids[g_id]}\n")
+        for m_id in sorted(missing_meth_ids.keys()):
+            f.write(f"meth\t{m_id}\t{missing_meth_ids[m_id]}\n")
+
+    N_gene = len(missing_gene_ids)
+    N_meth = len(missing_meth_ids)
+    logger.info(f"[assignRegion] Annotation missing: {N_gene} unique genes, {N_meth} unique CpGs (full list -> {os.path.abspath(sidecar_path)})")
 
     logger.info(f"[assignRegion] eCpgs Processed: {nlp} Assigned: {assigned_total} Excluded (any): {ne}")
     logger.info(f"[assignRegion] eCpgs Excluded: p-value filter: {npvalx} p-value missing: {npskip} gx annotation: {negx} mt annotation: {nemt}")


### PR DESCRIPTION
Refactored how `assignRegionToEcpg_parquet.py` handles logging for missing annotations.

Previously, the script emitted a log line for every single eQTM pair whose CpG or gene lacked coordinates. Since an unmapped probe can appear in many pairs, this resulted in tens of thousands of repetitive log lines.

**Changes:**
1. Initialized `missing_gene_ids` and `missing_meth_ids` dictionaries to collect missing IDs and their specific reasons (`missing_id` vs `missing_chrom`).
2. Replaced per-pair logging calls with updates to these dictionaries.
3. Added logic after processing to write these unique missing IDs to a sidecar file (`annotation_missing_ids.txt`) formatted as `type\tid\treason`, sorted first by type (gene, then meth) and then alphabetically by ID.
4. Emitted a single summary log line indicating the number of unique missing genes and CpGs, including the absolute path to the sidecar file.

The sidecar file is saved in the same directory as the output parquet file, or the current working directory if a directory path cannot be derived from the output file name.

---
*PR created automatically by Jules for task [2894656716941448130](https://jules.google.com/task/2894656716941448130) started by @kordk*