### PR TITLE
Fix TOTAL_TESTS reporting and preserve sample reservoir for unchunked MLR

### DIFF
--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -1251,7 +1251,7 @@ def mlr(
         kwargs.pop('ig_covariates_filter', None)
         output = regression_full(**kwargs, **logger)
     if not chunking:
-        save_dataframes([output], output_path, [data['output']], **logger)
+        save_dataframes([output], output_path, [data['output']], clear_dir=False, **logger)
 
 
 @run.command()

--- a/tecpg/import_data.py
+++ b/tecpg/import_data.py
@@ -21,16 +21,20 @@ def save_dataframes(
     save_func: Callable = pandas.DataFrame.to_csv,
     *args,
     logger: Logger = Logger(),
+    clear_dir: bool = True,
     **kwargs,
 ) -> None:
     """
     Saves any number of dataframes to an output_dir, with file_names for
     each file. Default file names count up from one for as many files
-    that are given. The save_func function is called with the panads
+    that are given. The save_func function is called with the pandas
     dataframe and the output path, which defaults to saving as a csv.
     Extra args and kwargs passed to save_func.
     """
-    initialize_dir(output_dir, **logger)
+    if clear_dir:
+        initialize_dir(output_dir, **logger)
+    else:
+        os.makedirs(output_dir, exist_ok=True)
 
     logger.start_timer('info', 'Saving {0} dataframes...', len(dataframes))
     for df, file_name in zip(dataframes, file_names):

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -1264,20 +1264,19 @@ def _tecpg_mlr_qr_inner(
             prefetch_executor.shutdown(wait=True)
 
         # Print end-of-run summary
-        if len(run_metrics['prep_ms']) > 0:
-            import numpy as np
-            summary_str = ["--- END OF RUN SUMMARY ---"]
-            summary_str.append(f"Genes evaluated: {len(G)}")
-            summary_str.append(f"Methylation loci evaluated: {len(M)}")
-            summary_str.append(f"Total tests evaluated: {total_tests_evaluated} (TOTAL_TESTS={total_tests_evaluated})")
-            summary_str.append(f"Tests passed p-value filter and saved: {total_tests_passed_filter}")
-            summary_str.append(f"Chunks saved: {total_chunks_saved}")
-            summary_str.append(f"Total bytes written: {total_bytes_written} ({total_bytes_written/1024/1024:.2f} MB)")
-            for metric, vals in run_metrics.items():
-                if len(vals) > 0:
-                    summary_str.append(f"{metric}: sum={sum(vals):.1f}ms, mean={np.mean(vals):.1f}ms, p95={np.percentile(vals, 95):.1f}ms")
-            for line in summary_str:
-                logger.info(line)
+        import numpy as np
+        summary_str = ["--- END OF RUN SUMMARY ---"]
+        summary_str.append(f"Genes evaluated: {len(G)}")
+        summary_str.append(f"Methylation loci evaluated: {len(M)}")
+        summary_str.append(f"Total tests evaluated: {total_tests_evaluated} (TOTAL_TESTS={total_tests_evaluated})")
+        summary_str.append(f"Tests passed p-value filter and saved: {total_tests_passed_filter}")
+        summary_str.append(f"Chunks saved: {total_chunks_saved}")
+        summary_str.append(f"Total bytes written: {total_bytes_written} ({total_bytes_written/1024/1024:.2f} MB)")
+        for metric, vals in run_metrics.items():
+            if len(vals) > 0:
+                summary_str.append(f"{metric}: sum={sum(vals):.1f}ms, mean={np.mean(vals):.1f}ms, p95={np.percentile(vals, 95):.1f}ms")
+        for line in summary_str:
+            logger.info(line)
 
         if do_reservoir and reservoir_processed > 0:
             logger.info('Saving reservoir sample ({0} rows)', min(reservoir_processed, reservoir_count))


### PR DESCRIPTION
Fixes bugs affecting small (unchunked) dataset runs:
1. Unindents the END OF RUN SUMMARY in `tecpg/processing.py` to unconditionally print the `TOTAL_TESTS` metric for log parsing by wrapper scripts.
2. Introduces a `clear_dir` parameter to `save_dataframes` in `tecpg/import_data.py`. Sets `clear_dir=False` in `tecpg/cli.py` to prevent `initialize_dir` from maliciously deleting `sample_reservoir.csv` when saving the final non-chunked output.

---
*PR created automatically by Jules for task [8560863059562634286](https://jules.google.com/task/8560863059562634286) started by @kordk*