### PR TITLE
feat: Add between-sample quantile normalization for Gene Expression (G)

### DIFF
--- a/tecpg/gtp.py
+++ b/tecpg/gtp.py
@@ -192,6 +192,21 @@ def process_gtp(
     G = G.clip(lower=0)
     G = np.log2(G + 1)
 
+    logger.info(f'Applying between-sample quantile normalization to Gene Expression (G) [shape {G.shape}]')
+    if G.isna().any().any() or np.isinf(G).any().any():
+        raise ValueError("G contains NaN or inf before QN.")
+
+    sorted_vals = np.sort(G.values, axis=0)
+    row_means = np.mean(sorted_vals, axis=1)
+
+    G_norm = pandas.DataFrame(index=G.index, columns=G.columns, dtype=float)
+    for col in G.columns:
+        col_vals = G[col].values
+        col_sorted = np.sort(col_vals)
+        mapping = pandas.Series(row_means).groupby(col_sorted).mean()
+        G_norm[col] = G[col].map(mapping)
+    G = G_norm
+
     logger.info('Sorting columns')
     M = M.reindex(sorted(M.columns, key=int), axis=1)
     G = G.reindex(sorted(G.columns, key=int), axis=1)

--- a/tecpg/mesa.py
+++ b/tecpg/mesa.py
@@ -194,6 +194,21 @@ def process_mesa(
     G = G.clip(lower=0)
     G = np.log2(G + 1)
 
+    logger.info(f'Applying between-sample quantile normalization to Gene Expression (G) [shape {G.shape}]')
+    if G.isna().any().any() or np.isinf(G).any().any():
+        raise ValueError("G contains NaN or inf before QN.")
+
+    sorted_vals = np.sort(G.values, axis=0)
+    row_means = np.mean(sorted_vals, axis=1)
+
+    G_norm = pandas.DataFrame(index=G.index, columns=G.columns, dtype=float)
+    for col in G.columns:
+        col_vals = G[col].values
+        col_sorted = np.sort(col_vals)
+        mapping = pandas.Series(row_means).groupby(col_sorted).mean()
+        G_norm[col] = G[col].map(mapping)
+    G = G_norm
+
     logger.info('Sorting columns')
     M = M.reindex(sorted(M.columns, key=int), axis=1)
     G = G.reindex(sorted(G.columns, key=int), axis=1)

--- a/tecpg/test_data.py
+++ b/tecpg/test_data.py
@@ -130,6 +130,24 @@ def generate_data(
         person_codes, g_row_codes, randrange(-1, 100, rng=rng)
     )
 
+    import numpy as np
+    G = G.clip(lower=0)
+    G = np.log2(G + 1)
+
+    if G.isna().any().any() or np.isinf(G).any().any():
+        raise ValueError("G contains NaN or inf before QN.")
+
+    sorted_vals = np.sort(G.values, axis=0)
+    row_means = np.mean(sorted_vals, axis=1)
+
+    G_norm = pandas.DataFrame(index=G.index, columns=G.columns, dtype=float)
+    for col in G.columns:
+        col_vals = G[col].values
+        col_sorted = np.sort(col_vals)
+        mapping = pandas.Series(row_means).groupby(col_sorted).mean()
+        G_norm[col] = G[col].map(mapping)
+    G = G_norm
+
     covariate_template = {
         'age': randrange(18, 64, rng=rng),
         'sex': randrange(0, 1, True, rng=rng),


### PR DESCRIPTION
Between-sample quantile normalization of expression (G)

Objective

Add between-sample quantile normalization (QN) to the gene-expression matrix G, applied
immediately after the existing floor + log2(x+1), in each of the three dataset loaders.
This removes the global array-intensity axis (currently ~76% of PC1 / ~90% of the top-5 residual
PCs) from the regression-facing G.csv — the matrix used as the response in the eQTM fit
G ~ intercept + M + C, not merely the PCA diagnostic input.

---
*PR created automatically by Jules for task [9003444392531458253](https://jules.google.com/task/9003444392531458253) started by @kordk*