### PR TITLE
Fix: Change debug short flag from -d to -D in tecpg CLI

### DIFF
--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -519,7 +519,7 @@ from .tool import (
     '-v', '--verbosity', show_default=True, default=1, type=int, count=True
 )
 @click.option(
-    '-d', '--debug', is_flag=True, show_default=True, default=False, type=bool
+    '-D', '--debug', is_flag=True, show_default=True, default=False, type=bool
 )
 @click.option(
     '-l',


### PR DESCRIPTION
Change the `--debug` short flag in `tecpg/cli.py` from `-d` to `-D` to align with the rest of the utility scripts and free up `-d` in `tecpg run mlr` for `--downstream`. This resolves the conceptual confusion with the `-d/--dataset` flag in downstream `.sh` pipeline scripts.

---
*PR created automatically by Jules for task [11027286964491999445](https://jules.google.com/task/11027286964491999445) started by @kordk*