### PR TITLE
feat: implement `qr_permute` walking skeleton

### DIFF
--- a/fix_syntax.py
+++ b/fix_syntax.py
@@ -1,8 +1,0 @@
-with open('tecpg/cli.py', 'r') as f:
-    lines = f.readlines()
-
-with open('tecpg/cli.py', 'w') as f:
-    for line in lines:
-        if "'qr_permute' runs permutation-null testing.\"" in line and not line.strip().startswith('"'):
-            line = line.replace("'qr_permute'", "\"        'qr_permute'")
-        f.write(line)

--- a/fix_syntax.py
+++ b/fix_syntax.py
@@ -1,0 +1,8 @@
+with open('tecpg/cli.py', 'r') as f:
+    lines = f.readlines()
+
+with open('tecpg/cli.py', 'w') as f:
+    for line in lines:
+        if "'qr_permute' runs permutation-null testing.\"" in line and not line.strip().startswith('"'):
+            line = line.replace("'qr_permute'", "\"        'qr_permute'")
+        f.write(line)

--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -804,13 +804,15 @@ def corr(
 )
 @click.option(
     '--mlr-method',
-    type=click.Choice(['legacy_normal_eq', 'qr', 'qr_bootstrap']),
+    type=click.Choice(['legacy_normal_eq', 'qr', 'qr_bootstrap', 'qr_permute']),
     default='legacy_normal_eq',
     show_default=True,
     help=(
         "The MLR computation method to use. 'legacy_normal_eq' uses the original"
         " optimized inversion; 'qr' uses QR decomposition (torch.linalg.qr) + torch.linalg.solve_triangular;"
-        " 'qr_bootstrap' runs empirical bootstrap on specific pairs."
+        " 'qr_bootstrap' runs empirical bootstrap on specific pairs;"
+
+        "        'qr_permute' runs permutation-null testing."
     ),
 )
 @click.option(
@@ -864,6 +866,13 @@ def corr(
     show_default=True,
     type=int,
     help='Number of tests to retain in the reservoir buffer (only for qr method)',
+)
+@click.option(
+    '--permutations',
+    show_default=True,
+    default=100,
+    type=int,
+    help='Number of permutations for qr_permute.',
 )
 @click.option(
     '--subsample-mt-count',
@@ -971,6 +980,7 @@ def mlr(
     thermal_threshold: int,
     thermal_wait: int,
     reservoir_count: Optional[int],
+    permutations: int,
     subsample_mt_count: Optional[int],
     subsample_g_count: Optional[int],
     seed: int,
@@ -1256,6 +1266,43 @@ def mlr(
             ig_baseline=ig_baseline,
             ig_covariates_filter=ig_covariates_filter,
             seed=seed,
+            logger=logger
+        )
+        return
+
+    if mlr_method == 'qr_permute':
+        from .permute import tecpg_mlr_qr_permute
+
+        # The merged permute output is named `permutation_results.<ext>` by
+        # default. We only honor an explicit --output-file; the default 'out.csv'
+        # is treated as "unset".
+        output_file_path = data['output']
+        if output_file_path == 'out.csv':
+            ext = 'parquet' if output_format == 'parquet' else 'csv'
+            output_file_path = os.path.join(
+                output_path, f'permutation_results.{ext}'
+            )
+        elif output_path and not output_file_path.startswith('/'):
+            output_file_path = os.path.join(output_path, output_file_path)
+
+        tecpg_mlr_qr_permute(
+            M=M,
+            G=G,
+            C=C,
+            M_annot=M_annot if region != 'all' else None,
+            G_annot=G_annot if region != 'all' else None,
+            region=region,
+            window_base=window_base,
+            downstream=downstream,
+            upstream=upstream,
+            permutations=permutations,
+            subsample_mt_count=subsample_mt_count,
+            subsample_g_count=subsample_g_count,
+            seed=seed,
+            output_file=output_file_path,
+            output_format=output_format,
+            thermal_threshold=thermal_threshold,
+            thermal_wait=thermal_wait,
             logger=logger
         )
         return

--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -1,0 +1,124 @@
+import os
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import torch
+from typing import Literal
+from .config import get_device, DTYPE
+from .logger import Logger
+
+
+def _select_null_population(M, G, C, M_annot, G_annot, region,
+                            window_base, downstream, upstream,
+                            subsample_mt_count, subsample_g_count, seed, logger):
+    # CHUNK 4: seeded uniform pair subsample for the NULL population.
+    # STUB: identity — return the full M, G (null population = all).
+    return M, G
+
+
+def _compute_trans_mask(reported_pairs, M_annot, G_annot, region,
+                        window_base, downstream, upstream, logger):
+    # CHUNK 3: real cis/trans masking via the shared mask helper.
+    # STUB: all-True over reported_pairs.
+    return np.ones(len(reported_pairs), dtype=bool)
+
+
+def _compute_observed_statistic(M, G, C, reported_pairs, logger):
+    # CHUNK 2: pivotal t = B/S per reported pair (reuse qr solve primitives).
+    # STUB: zeros, one per reported pair.
+    return np.zeros(len(reported_pairs), dtype=np.float64)
+
+
+def _residualize_and_permute(G, C, perm_vector, logger):
+    # CHUNK 5: design-fixed Freedman–Lane (residualize G on [1,C], permute
+    # reduced-model residuals, refit against cached [1,M,C] pseudo-inverse).
+    # STUB: identity — return G unchanged.
+    return G
+
+
+def _accumulate_null(permuted_stats, accumulator, logger):
+    # CHUNK 6: streaming t-histogram + tail-exceedance buffer.
+    # STUB: no-op — return accumulator unchanged.
+    return accumulator
+
+
+def _score_observed(observed_stats, null_accumulator, logger):
+    # CHUNK 7: empirical two-sided p = frac(null |t| >= observed |t|), floored 1/(N+1).
+    # STUB: 0.5 for every reported pair.
+    return np.full(len(observed_stats), 0.5, dtype=np.float64)
+
+
+def _fit_tail(empirical_p, null_accumulator, logger):
+    # CHUNK 8: generalized-Pareto tail (float64) extending p below the empirical floor.
+    # STUB: passthrough — return empirical_p unchanged.
+    return empirical_p
+
+
+def tecpg_mlr_qr_permute(
+    M, G, C,
+    M_annot=None, G_annot=None,
+    region: Literal['all', 'cis', 'distal', 'trans'] = 'all',
+    window_base=None, downstream=None, upstream=None,
+    permutations=100,
+    subsample_mt_count=None, subsample_g_count=None,
+    seed=42,
+    output_file=None, output_format='auto',
+    thermal_threshold=80, thermal_wait=30,
+    logger=None,
+):
+    if logger is None:
+        logger = Logger()
+
+    logger.info("Starting qr_permute with permutations={0}, seed={1}, output_file={2}", permutations, seed, output_file)
+
+    null_M, null_G = _select_null_population(M, G, C, M_annot, G_annot, region,
+                                             window_base, downstream, upstream,
+                                             subsample_mt_count, subsample_g_count, seed, logger)
+
+    # Cross product of M.index x G.index
+    # Explicitly casting indices to str to align with schema consistency
+    m_idx = M.index.astype(str)
+    g_idx = G.index.astype(str)
+
+    reported_pairs = pd.MultiIndex.from_product([m_idx, g_idx], names=['mt_id', 'gt_id']).to_frame(index=False)
+
+    trans_mask = _compute_trans_mask(reported_pairs, M_annot, G_annot, region,
+                                     window_base, downstream, upstream, logger)
+
+    reported_pairs = reported_pairs[trans_mask].reset_index(drop=True)
+
+    observed_t = _compute_observed_statistic(M, G, C, reported_pairs, logger)
+
+    accumulator = None
+    rng = np.random.default_rng(seed)
+    n_samples = len(C)
+
+    for _ in range(permutations):
+        perm_vector = rng.permutation(n_samples)
+        G_perm = _residualize_and_permute(null_G, C, perm_vector, logger)
+        perm_stats = _compute_observed_statistic(M, G_perm, C, reported_pairs, logger)
+        accumulator = _accumulate_null(perm_stats, accumulator, logger)
+
+    empirical_p = _score_observed(observed_t, accumulator, logger)
+    perm_mt_p = _fit_tail(empirical_p, accumulator, logger)
+
+    # Add final permutation p-values to dataframe
+    reported_pairs['perm_mt_p'] = perm_mt_p
+
+    # Honor output format
+    if output_format == 'auto':
+        ext = 'csv'
+        if output_file and output_file.endswith('.parquet'):
+            ext = 'parquet'
+    else:
+        ext = output_format
+
+    if ext == 'parquet' or (output_file and output_file.endswith('.parquet')):
+        # Use pyarrow to write parquet
+        table = pa.Table.from_pandas(reported_pairs)
+        pq.write_table(table, output_file)
+    else:
+        reported_pairs.to_csv(output_file, index=False)
+
+    logger.info("Finished qr_permute, wrote {0} pairs to {1}", len(reported_pairs), output_file)

--- a/tests/test_permute_skeleton.py
+++ b/tests/test_permute_skeleton.py
@@ -1,0 +1,45 @@
+import os
+import pandas as pd
+import pytest
+from tecpg.permute import tecpg_mlr_qr_permute
+from tecpg.test_data import generate_data
+
+
+def test_permute_skeleton_end_to_end(tmp_path):
+    # Set up small fixture using tecpg.test_data.generate_data
+    # matching standard harness style
+    M, G, C = generate_data(
+        sample_size=30,
+        m_rows=10,
+        g_rows=10,
+        annotation=False,
+    )
+
+    output_file = str(tmp_path / "permutation_results.csv")
+
+    # Call the newly created permutation function directly
+    tecpg_mlr_qr_permute(
+        M=M,
+        G=G,
+        C=C,
+        output_file=output_file,
+        permutations=10,
+        seed=42,
+    )
+
+    # Assert output exists
+    assert os.path.exists(output_file)
+
+    # Read output
+    df = pd.read_csv(output_file)
+
+    # Assert correct columns (schema)
+    expected_cols = ['mt_id', 'gt_id', 'perm_mt_p']
+    assert list(df.columns) == expected_cols
+
+    # Assert row count = |M| x |G|
+    expected_rows = len(M) * len(G)
+    assert len(df) == expected_rows
+
+    # Assert all perm_mt_p == 0.5
+    assert (df['perm_mt_p'] == 0.5).all()


### PR DESCRIPTION
This PR implements the walking skeleton of a new permutation-null MLR method, `qr_permute`. 
It introduces the new entry point, explicit output contracts, and wires the isolated pipeline stages end-to-end as trivial stubs for future incremental implementation.

- Adds `qr_permute` into the `--mlr-method` list in `cli.py` along with a new `--permutations` argument.
- Creates `tecpg/permute.py` mirroring `bootstrap.py` style with no internal side effects to shared application code. 
- Defines fully stubbed dummy components resolving to an isolated cross-product evaluation `DataFrame` returning 0.5 per row as specified.
- Avoids mutating or generating pre-existing regression artifacts/test-suite outputs, maintaining absolute byte-identity with legacy methods.

---
*PR created automatically by Jules for task [13625084620146485814](https://jules.google.com/task/13625084620146485814) started by @kordk*