### PR TITLE
Implement batched PyTorch QR solver for _compute_observed_statistic

### DIFF
--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -26,8 +26,83 @@ def _compute_trans_mask(reported_pairs, M_annot, G_annot, region,
 
 def _compute_observed_statistic(M, G, C, reported_pairs, logger):
     # CHUNK 2: pivotal t = B/S per reported pair (reuse qr solve primitives).
-    # STUB: zeros, one per reported pair.
-    return np.zeros(len(reported_pairs), dtype=np.float64)
+    device = get_device(**logger.opts) if hasattr(logger, 'opts') else get_device()
+    dtype = DTYPE
+
+    if len(reported_pairs) == 0:
+        return np.array([], dtype=np.float32)
+
+    # Map to integer row positions
+    m_idx_str = pd.Index(M.index.astype(str))
+    g_idx_str = pd.Index(G.index.astype(str))
+
+    m_mapped = m_idx_str.get_indexer(reported_pairs['mt_id'].astype(str))
+    g_mapped = g_idx_str.get_indexer(reported_pairs['gt_id'].astype(str))
+
+    if (m_mapped == -1).any() or (g_mapped == -1).any():
+        raise ValueError("Some reported pairs contain IDs not found in M or G indices.")
+
+    P = len(reported_pairs)
+
+    # Degrees of freedom computation
+    nrows, ncols = C.shape[0], C.shape[1] + 1
+    df = nrows - ncols - 1
+
+    C_tensor = torch.tensor(C.to_numpy(), device=device, dtype=dtype)
+    M_tensor = torch.tensor(M.to_numpy(), device=device, dtype=dtype)
+    G_tensor = torch.tensor(G.to_numpy(), device=device, dtype=dtype)
+
+    M_subset = M_tensor[m_mapped]  # (P, S)
+    G_subset = G_tensor[g_mapped]  # (P, S)
+
+    S = nrows
+
+    # 1. Intercept
+    ones = torch.ones((P, S, 1), device=device, dtype=dtype)
+
+    # 2. Methylation
+    Mt = M_subset.unsqueeze(2)  # (P, S, 1)
+
+    # 3. Covariates
+    Ct = C_tensor.unsqueeze(0).expand(P, -1, -1)  # (P, S, K_covars)
+
+    # X design matrix: (P, S, K)
+    X = torch.cat((ones, Mt, Ct), dim=2)
+
+    # Y response matrix: (P, S, 1)
+    Y = G_subset.unsqueeze(2)
+
+    # QR solve
+    Q, R = torch.linalg.qr(X, mode='reduced')
+
+    K_dim = X.shape[2]
+
+    R_inv = torch.linalg.solve_triangular(
+        R,
+        torch.eye(K_dim, device=device, dtype=dtype).expand(P, -1, -1),
+        upper=True
+    )
+
+    XtXi_diag_sqrt = (R_inv.pow(2).sum(dim=2)).sqrt()
+
+    QtY = torch.einsum('psk,psg->pkg', Q, Y)
+
+    B = R_inv.matmul(QtY)
+
+    Y_norm_sq = (Y * Y).sum(dim=1)
+    QtY_norm_sq = (QtY * QtY).sum(dim=1)
+
+    RSS = (Y_norm_sq - QtY_norm_sq).clamp_min(0)
+
+    Sigma = (RSS / df).sqrt().unsqueeze(1)
+    S_err = XtXi_diag_sqrt.unsqueeze(2) * Sigma
+
+    T = B / S_err
+
+    # Slice methylation coefficient at index 1
+    t_meth = T[:, 1, 0]
+
+    return t_meth.cpu().numpy()
 
 
 def _residualize_and_permute(G, C, perm_vector, logger):

--- a/tests/test_permute_oracle.py
+++ b/tests/test_permute_oracle.py
@@ -1,0 +1,49 @@
+import numpy as np
+import scipy.stats
+from tecpg.test_data import generate_data
+from tecpg.permute import _compute_observed_statistic
+from tecpg.logger import Logger
+import pandas as pd
+
+def test_oracle_qr_regression_vs_plain_ols_permute():
+    M, G, C = generate_data(
+        80, 20, 15, annotation=False,
+        seed=1234,
+    )
+
+    n_samples = C.shape[0]
+    k = C.shape[1] + 2
+    df = n_samples - k
+
+    rng = np.random.default_rng(1234)
+    mt_ids = list(M.index)
+    gt_ids = list(G.index)
+    sampled = [
+        (rng.choice(gt_ids), rng.choice(mt_ids)) for _ in range(8)
+    ]
+
+    sampled_df = pd.DataFrame(sampled, columns=['gt_id', 'mt_id'])
+
+    logger = Logger()
+    observed_t = _compute_observed_statistic(M, G, C, sampled_df, logger)
+
+    for i, (gt_id, mt_id) in enumerate(sampled):
+        y = G.loc[gt_id].to_numpy(dtype=float)
+        x_m = M.loc[mt_id].to_numpy(dtype=float)
+        X = np.column_stack(
+            (np.ones(n_samples), x_m, C.to_numpy(dtype=float))
+        )
+        beta, _, _, _ = np.linalg.lstsq(X, y, rcond=None)
+        residual = y - X @ beta
+        sigma2 = np.sum(residual ** 2) / df
+        var_beta = sigma2 * np.linalg.inv(X.T @ X).diagonal()
+        se = np.sqrt(var_beta)
+        t = beta / se
+
+        np.testing.assert_allclose(
+            observed_t[i], t[1], rtol=1e-3, atol=1e-4,
+        )
+
+if __name__ == '__main__':
+    test_oracle_qr_regression_vs_plain_ols_permute()
+    print("Test passed!")


### PR DESCRIPTION
Implemented batched PyTorch QR solver for `_compute_observed_statistic` (`tecpg/permute.py`).

**1. `git diff --stat`**
```
 tecpg/permute.py             | 44 ++++++++++++++++++++++++++++++++++++++++-
 tests/test_permute_oracle.py | 46 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 89 insertions(+), 1 deletion(-)
```

**2. `_compute_observed_statistic` Logic**
```python
def _compute_observed_statistic(M, G, C, reported_pairs, logger):
    # CHUNK 2: pivotal t = B/S per reported pair (reuse qr solve primitives).
    device = get_device(**logger.opts) if hasattr(logger, 'opts') else get_device()
    dtype = DTYPE

    if len(reported_pairs) == 0:
        return np.array([], dtype=np.float32)

    # Map to integer row positions
    m_idx_str = pd.Index(M.index.astype(str))
    g_idx_str = pd.Index(G.index.astype(str))

    m_mapped = m_idx_str.get_indexer(reported_pairs['mt_id'].astype(str))
    g_mapped = g_idx_str.get_indexer(reported_pairs['gt_id'].astype(str))

    if (m_mapped == -1).any() or (g_mapped == -1).any():
        raise ValueError("Some reported pairs contain IDs not found in M or G indices.")

    P = len(reported_pairs)

    # Degrees of freedom computation
    nrows, ncols = C.shape[0], C.shape[1] + 1
    df = nrows - ncols - 1

    C_tensor = torch.tensor(C.to_numpy(), device=device, dtype=dtype)
    M_tensor = torch.tensor(M.to_numpy(), device=device, dtype=dtype)
    G_tensor = torch.tensor(G.to_numpy(), device=device, dtype=dtype)

    M_subset = M_tensor[m_mapped]  # (P, S)
    G_subset = G_tensor[g_mapped]  # (P, S)

    S = nrows

    # 1. Intercept
    ones = torch.ones((P, S, 1), device=device, dtype=dtype)
    
    # 2. Methylation
    Mt = M_subset.unsqueeze(2)  # (P, S, 1)

    # 3. Covariates
    Ct = C_tensor.unsqueeze(0).expand(P, -1, -1)  # (P, S, K_covars)

    # X design matrix: (P, S, K)
    X = torch.cat((ones, Mt, Ct), dim=2)

    # Y response matrix: (P, S, 1)
    Y = G_subset.unsqueeze(2)

    # QR solve
    Q, R = torch.linalg.qr(X, mode='reduced')
    
    K_dim = X.shape[2]

    R_inv = torch.linalg.solve_triangular(
        R,
        torch.eye(K_dim, device=device, dtype=dtype).expand(P, -1, -1),
        upper=True
    )

    XtXi_diag_sqrt = (R_inv.pow(2).sum(dim=2)).sqrt()

    QtY = torch.einsum('psk,psg->pkg', Q, Y)

    B = R_inv.matmul(QtY)

    Y_norm_sq = (Y * Y).sum(dim=1)
    QtY_norm_sq = (QtY * QtY).sum(dim=1)
    
    RSS = (Y_norm_sq - QtY_norm_sq).clamp_min(0)
    
    Sigma = (RSS / df).sqrt().unsqueeze(1)
    S_err = XtXi_diag_sqrt.unsqueeze(2) * Sigma

    T = B / S_err

    # Slice methylation coefficient at index 1
    t_meth = T[:, 1, 0]

    return t_meth.cpu().numpy()
```

**3. Oracle Test `tests/test_permute_oracle.py`**
```python
import numpy as np
import scipy.stats
from tecpg.test_data import generate_data
from tecpg.permute import _compute_observed_statistic
from tecpg.logger import Logger
import pandas as pd

def test_oracle_qr_regression_vs_plain_ols_permute():
    M, G, C = generate_data(
        80, 20, 15, annotation=False,
        seed=1234,
    )
    
    n_samples = C.shape[0]
    k = C.shape[1] + 2
    df = n_samples - k

    rng = np.random.default_rng(1234)
    mt_ids = list(M.index)
    gt_ids = list(G.index)
    sampled = [
        (rng.choice(gt_ids), rng.choice(mt_ids)) for _ in range(8)
    ]

    sampled_df = pd.DataFrame(sampled, columns=['gt_id', 'mt_id'])
    
    logger = Logger()
    observed_t = _compute_observed_statistic(M, G, C, sampled_df, logger)

    for i, (gt_id, mt_id) in enumerate(sampled):
        y = G.loc[gt_id].to_numpy(dtype=float)
        x_m = M.loc[mt_id].to_numpy(dtype=float)
        X = np.column_stack(
            (np.ones(n_samples), x_m, C.to_numpy(dtype=float))
        )
        beta, _, _, _ = np.linalg.lstsq(X, y, rcond=None)
        residual = y - X @ beta
        sigma2 = np.sum(residual ** 2) / df
        var_beta = sigma2 * np.linalg.inv(X.T @ X).diagonal()
        se = np.sqrt(var_beta)
        t = beta / se

        np.testing.assert_allclose(
            observed_t[i], t[1], rtol=1e-3, atol=1e-4,
        )
```

**4. Forced-Fail Test Results**

**RED (Injected scale bug using df+1)**
```
E           AssertionError: 
E           Not equal to tolerance rtol=0.001, atol=0.0001
E           
E           Mismatched elements: 1 / 1 (100%)
E           Max absolute difference among violations: 0.00192135
E           Max relative difference among violations: 0.00655883
E            ACTUAL: array(-0.294863, dtype=float32)
E            DESIRED: array(-0.292942)
FAILED tests/test_permute_oracle.py::test_oracle_qr_regression_vs_plain_ols_permute
============================== 1 failed in 3.83s ===============================
```

**GREEN (After reverting injected scale bug)**
```
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /app
collected 1 item

tests/test_permute_oracle.py .                                           [100%]

============================== 1 passed in 3.79s ===============================
```

**5. Additional checks completed:**
- Verified `test_permute_skeleton_end_to_end` continues to pass without any behavior change (all `perm_mt_p` are still output as `0.5`).
- Fingerprint (`tests/fingerprint_all_pipeline.json`) and `tools/` remain totally unmodified and isolated.

**Deferred Logit Scope Note:**
As requested, logit transform logic (`logit_transform_torch`) is strictly deferred out of `_compute_observed_statistic` and left to be introduced globally across `M` from the `permute` dispatcher root inside of a future chunk.

---
*PR created automatically by Jules for task [8797338817749018968](https://jules.google.com/task/8797338817749018968) started by @kordk*