### PR TITLE
Make parquet the default output format for all mlr methods

### DIFF
--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -952,8 +952,7 @@ def corr(
         "snappy compression and is typically 5-10x smaller and 5-10x faster to "
         "write than CSV; recommended on slow filesystems (e.g. dm-crypt/RAID6). "
         "'csv' preserves the previous behavior for downstream tooling. "
-        "'auto' (default) selects 'parquet' on server-class hosts and 'csv' on "
-        "minimum-class hosts (controlled by --host-profile)."
+        "'auto' (default) resolves to 'parquet' on all host profiles."
     ),
 )
 @click.option(
@@ -1037,11 +1036,7 @@ def mlr(
     output_format = output_format.lower()
     if output_format == 'auto':
         host_profile = logger.carry_data.get('host_profile', 'minimum')
-        # Server-class hosts default to parquet (faster + far smaller on
-        # RAID6/dm-crypt). Minimum-class hosts keep the historical CSV
-        # default so downstream tooling and small-fixture tests are
-        # unchanged. Explicit --output-format always wins.
-        output_format = 'parquet' if host_profile == 'server' else 'csv'
+        output_format = 'parquet'
         logger.info(
             'Auto-resolved output_format={0} (host_profile={1})',
             output_format, host_profile,

--- a/tests/test_minimal_config.sh
+++ b/tests/test_minimal_config.sh
@@ -112,9 +112,9 @@ assert_files_present() {
     echo "[test_minimal_config] OK: $count '$pattern' file(s) written, >=1 non-empty"
 }
 
-# 2. Auto output-format. On minimum profile this must resolve to CSV.
+# 2. Auto output-format. It must resolve to parquet.
 run_mlr auto_format
-assert_files_present auto_format '*.csv'
+assert_files_present auto_format '*.parquet'
 
 # 3. Explicit --output-format csv (historical default behavior).
 run_mlr explicit_csv --output-format csv


### PR DESCRIPTION
Updates the auto-resolution of the output format to always return parquet instead of branching on the host_profile. This effectively changes the default output format to parquet for all mlr methods on all hosts.

---
*PR created automatically by Jules for task [8570313162921817185](https://jules.google.com/task/8570313162921817185) started by @kordk*