### PR TITLE
Implement real null-population subsampling and orchestrator rewire

### DIFF
--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -14,8 +14,36 @@ def _select_null_population(M, G, C, M_annot, G_annot, region,
                             window_base, downstream, upstream,
                             subsample_mt_count, subsample_g_count, seed, logger):
     # CHUNK 4: seeded uniform pair subsample for the NULL population.
-    # STUB: identity — return the full M, G (null population = all).
-    return M, G
+    if subsample_mt_count is None and subsample_g_count is None:
+        return M, G
+
+    rng = np.random.default_rng(seed)
+
+    if subsample_mt_count is None:
+        null_M = M
+    elif subsample_mt_count <= 0:
+        raise ValueError("qr_permute subsample mt_count must be positive; got {0}".format(subsample_mt_count))
+    elif subsample_mt_count > len(M):
+        logger.warning('Requested mt_count {0} > available {1} for null population; using full.', subsample_mt_count, len(M))
+        null_M = M
+    else:
+        idx = rng.choice(len(M), size=subsample_mt_count, replace=False)
+        idx.sort()
+        null_M = M.iloc[idx]
+
+    if subsample_g_count is None:
+        null_G = G
+    elif subsample_g_count <= 0:
+        raise ValueError("qr_permute subsample g_count must be positive; got {0}".format(subsample_g_count))
+    elif subsample_g_count > len(G):
+        logger.warning('Requested g_count {0} > available {1} for null population; using full.', subsample_g_count, len(G))
+        null_G = G
+    else:
+        idx = rng.choice(len(G), size=subsample_g_count, replace=False)
+        idx.sort()
+        null_G = G.iloc[idx]
+
+    return null_M, null_G
 
 
 def _compute_trans_mask(reported_pairs, M_annot, G_annot, region,
@@ -193,10 +221,15 @@ def tecpg_mlr_qr_permute(
     rng = np.random.default_rng(seed)
     n_samples = len(C)
 
+    null_pairs = pd.MultiIndex.from_product(
+        [null_M.index.astype(str), null_G.index.astype(str)],
+        names=['mt_id', 'gt_id'],
+    ).to_frame(index=False)
+
     for _ in range(permutations):
         perm_vector = rng.permutation(n_samples)
         G_perm = _residualize_and_permute(null_G, C, perm_vector, logger)
-        perm_stats = _compute_observed_statistic(M, G_perm, C, reported_pairs, logger)
+        perm_stats = _compute_observed_statistic(null_M, G_perm, C, null_pairs, logger)
         accumulator = _accumulate_null(perm_stats, accumulator, logger)
 
     empirical_p = _score_observed(observed_t, accumulator, logger)

--- a/tests/test_permute_subsample.py
+++ b/tests/test_permute_subsample.py
@@ -1,0 +1,106 @@
+import os
+import pytest
+import numpy as np
+import pandas as pd
+from tecpg.permute import _select_null_population, tecpg_mlr_qr_permute
+from tecpg.test_data import generate_data
+from tecpg.logger import Logger
+
+class MockLogger:
+    def __init__(self):
+        self.warnings = []
+
+    def warning(self, template, *args):
+        self.warnings.append((template, args))
+
+    def info(self, template, *args):
+        pass
+
+def test_select_null_population_subsamples():
+    M, G, C = generate_data(sample_size=30, m_rows=20, g_rows=20, annotation=False)
+    logger = MockLogger()
+    seed = 42
+
+    # Normal valid subsample
+    null_M, null_G = _select_null_population(M, G, C, None, None, 'all', None, None, None,
+                                             subsample_mt_count=5, subsample_g_count=10, seed=seed, logger=logger)
+
+    assert len(null_M) == 5
+    assert len(null_G) == 10
+
+    # Assert proper subset
+    assert null_M.index.isin(M.index).all()
+    assert null_G.index.isin(G.index).all()
+
+    # Assert no duplicates
+    assert len(null_M.index.unique()) == len(null_M)
+    assert len(null_G.index.unique()) == len(null_G)
+
+def test_select_null_population_determinism():
+    M, G, C = generate_data(sample_size=30, m_rows=20, g_rows=20, annotation=False)
+    logger = MockLogger()
+    seed = 42
+
+    null_M_1, null_G_1 = _select_null_population(M, G, C, None, None, 'all', None, None, None,
+                                             subsample_mt_count=5, subsample_g_count=10, seed=seed, logger=logger)
+
+    null_M_2, null_G_2 = _select_null_population(M, G, C, None, None, 'all', None, None, None,
+                                             subsample_mt_count=5, subsample_g_count=10, seed=seed, logger=logger)
+
+    pd.testing.assert_frame_equal(null_M_1, null_M_2)
+    pd.testing.assert_frame_equal(null_G_1, null_G_2)
+
+def test_select_null_population_warn_and_full():
+    M, G, C = generate_data(sample_size=30, m_rows=20, g_rows=20, annotation=False)
+    logger = MockLogger()
+    seed = 42
+
+    null_M, null_G = _select_null_population(M, G, C, None, None, 'all', None, None, None,
+                                             subsample_mt_count=50, subsample_g_count=50, seed=seed, logger=logger)
+
+    assert len(null_M) == 20
+    assert len(null_G) == 20
+    assert len(logger.warnings) == 2
+    assert logger.warnings[0][0] == 'Requested mt_count {0} > available {1} for null population; using full.'
+    assert logger.warnings[1][0] == 'Requested g_count {0} > available {1} for null population; using full.'
+    assert logger.warnings[0][1] == (50, 20)
+    assert logger.warnings[1][1] == (50, 20)
+
+def test_select_null_population_zero_count_raises():
+    M, G, C = generate_data(sample_size=30, m_rows=20, g_rows=20, annotation=False)
+    logger = MockLogger()
+    seed = 42
+
+    with pytest.raises(ValueError, match="qr_permute subsample mt_count must be positive; got 0"):
+        _select_null_population(M, G, C, None, None, 'all', None, None, None,
+                                subsample_mt_count=0, subsample_g_count=10, seed=seed, logger=logger)
+
+    with pytest.raises(ValueError, match="qr_permute subsample g_count must be positive; got -5"):
+        _select_null_population(M, G, C, None, None, 'all', None, None, None,
+                                subsample_mt_count=10, subsample_g_count=-5, seed=seed, logger=logger)
+
+def test_permute_with_subsample(tmp_path):
+    M, G, C = generate_data(sample_size=30, m_rows=10, g_rows=10, annotation=False)
+    output_file = str(tmp_path / "permutation_results.csv")
+
+    tecpg_mlr_qr_permute(
+        M=M,
+        G=G,
+        C=C,
+        output_file=output_file,
+        permutations=10,
+        seed=42,
+        subsample_mt_count=5,
+        subsample_g_count=5
+    )
+
+    assert os.path.exists(output_file)
+    df = pd.read_csv(output_file)
+
+    expected_cols = ['mt_id', 'gt_id', 'perm_mt_p']
+    assert list(df.columns) == expected_cols
+
+    expected_rows = len(M) * len(G)
+    assert len(df) == expected_rows
+
+    assert (df['perm_mt_p'] == 0.5).all()


### PR DESCRIPTION
Implement chunk-4 of permutation logic which introduces real subsampling behavior onto the null sets independently. We enforce safe subset validation to fail closed if non-positive sizes are requested. Added specific unit tests testing dimensions, proper subsets, unicity and seed-driven determinism. Loop logic in the orchestrator is rewritten to process calculations purely on the `null_M`, `null_G` and `null_pairs` keeping the reported pairs purely isolated on unmodified dimensions. This provides a strong framework for following Freedman–Lane residualization.

---
*PR created automatically by Jules for task [11570823573209580445](https://jules.google.com/task/11570823573209580445) started by @kordk*