### PR TITLE
feat(permute): calculate observed empirical p-values

### DIFF
--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -238,8 +238,30 @@ def _accumulate_null(permuted_stats, accumulator, logger):
 
 def _score_observed(observed_stats, null_accumulator, logger):
     # CHUNK 7: empirical two-sided p = frac(null |t| >= observed |t|), floored 1/(N+1).
-    # STUB: 0.5 for every reported pair.
-    return np.full(len(observed_stats), 0.5, dtype=np.float64)
+    acc = null_accumulator
+    if acc is None or acc['total_count'] <= 0:
+        raise ValueError("Empty null accumulator; cannot score observed statistics.")
+
+    N = acc['total_count']
+    bin_edges = acc['bin_edges']
+    hist = acc['hist_counts']
+    overflow = acc['overflow_count']
+    n_bins = hist.size
+
+    abs_obs = np.abs(np.asarray(observed_stats, dtype=np.float64))   # two-sided: fold to |t|
+
+    # rev[i] = count of null |t| in bin i and all higher bins
+    rev = np.cumsum(hist[::-1])[::-1]
+
+    # bin index containing each observed value (conservative: count that whole bin + above)
+    b = np.searchsorted(bin_edges, abs_obs, side='right') - 1        # in [-1 .. n_bins]
+    in_range = b < n_bins                                            # False => |t| beyond T_MAX
+    b_clipped = np.clip(b, 0, n_bins - 1)
+    count = np.where(in_range, rev[b_clipped], 0) + overflow
+
+    p = count / N
+    p = np.maximum(p, 1.0 / (N + 1))                                 # empirical floor
+    return p
 
 
 def _fit_tail(empirical_p, null_accumulator, logger):
@@ -262,6 +284,12 @@ def tecpg_mlr_qr_permute(
 ):
     if logger is None:
         logger = Logger()
+
+    if M_annot is None or G_annot is None:
+        raise ValueError(
+            "qr_permute requires methylation and expression annotations to build the "
+            "chromosome-stratified (trans) null; none were provided."
+        )
 
     logger.info("Starting qr_permute with permutations={0}, seed={1}, output_file={2}", permutations, seed, output_file)
 
@@ -292,12 +320,9 @@ def tecpg_mlr_qr_permute(
         names=['mt_id', 'gt_id'],
     ).to_frame(index=False)
 
-    if M_annot is None or G_annot is None:
-        logger.warning("No annotations provided; null distribution will not be stratified (using all pairs).")
-    else:
-        trans_mask_null = _compute_trans_mask(null_pairs, M_annot, G_annot, 'trans',
-                                              window_base, downstream, upstream, logger)
-        null_pairs = null_pairs[trans_mask_null].reset_index(drop=True)
+    trans_mask_null = _compute_trans_mask(null_pairs, M_annot, G_annot, 'trans',
+                                          window_base, downstream, upstream, logger)
+    null_pairs = null_pairs[trans_mask_null].reset_index(drop=True)
 
     for _ in range(permutations):
         perm_vector = rng.permutation(n_samples)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+from tecpg.test_data import generate_data
+
+@pytest.fixture
+def annotated_fixture():
+    def _make(sample_size, m_rows, g_rows, seed=42):
+        M, G, C, M_annot, G_annot = generate_data(sample_size, m_rows, g_rows,
+                                                   annotation=True, seed=seed)
+        M_annot = M_annot.set_index("name")[["chrom", "chromStart"]]
+        M_annot[["chrom", "chromStart"]] = M_annot[["chrom", "chromStart"]].astype(int)
+        G_annot = G_annot.set_index("name")[["chrom", "chromStart", "strand"]]
+        G_annot["strand"] = G_annot["strand"].replace({"+": 1, "-": -1})
+        G_annot[["chrom", "chromStart", "strand"]] = G_annot[["chrom", "chromStart", "strand"]].astype(int)
+        return M, G, C, M_annot, G_annot
+    return _make

--- a/tests/test_permute_accumulate.py
+++ b/tests/test_permute_accumulate.py
@@ -91,31 +91,23 @@ def test_accumulate_topk_correctness():
     np.testing.assert_allclose(actual_topk, expected_topk)
     assert len(actual_topk) <= TOPK_CAPACITY
 
-def test_accumulate_determinism(tmp_path):
-    M, G, C = generate_data(sample_size=30, m_rows=10, g_rows=10, annotation=False)
+def test_accumulate_determinism(tmp_path, annotated_fixture):
+    M, G, C, M_annot, G_annot = annotated_fixture(sample_size=30, m_rows=10, g_rows=10)
 
     # Run 1
     out1 = str(tmp_path / "out1.csv")
-    tecpg_mlr_qr_permute(M, G, C, permutations=10, seed=123, output_file=out1)
+    tecpg_mlr_qr_permute(M, G, C, M_annot=M_annot, G_annot=G_annot, permutations=10, seed=123, output_file=out1)
 
     # Run 2
     out2 = str(tmp_path / "out2.csv")
-    tecpg_mlr_qr_permute(M, G, C, permutations=10, seed=123, output_file=out2)
+    tecpg_mlr_qr_permute(M, G, C, M_annot=M_annot, G_annot=G_annot, permutations=10, seed=123, output_file=out2)
 
     df1 = pd.read_csv(out1)
     df2 = pd.read_csv(out2)
     pd.testing.assert_frame_equal(df1, df2)
 
-def test_accumulate_null_pair_stratification(tmp_path, monkeypatch):
-    M, G, C, M_annot, G_annot = generate_data(sample_size=30, m_rows=15, g_rows=15, annotation=True, seed=42)
-    M_annot = M_annot.set_index("name")[["chrom", "chromStart"]]
-    M_annot["chromStart"] = M_annot["chromStart"].astype(int)
-    M_annot["chrom"] = M_annot["chrom"].astype(int)
-    G_annot = G_annot.set_index("name")[["chrom", "chromStart", "strand"]]
-    G_annot["chromStart"] = G_annot["chromStart"].astype(int)
-    G_annot["chrom"] = G_annot["chrom"].astype(int)
-    G_annot["strand"] = G_annot["strand"].replace({"+": 1, "-": -1}).astype(int)
-
+def test_accumulate_null_pair_stratification(tmp_path, monkeypatch, annotated_fixture):
+    M, G, C, M_annot, G_annot = annotated_fixture(sample_size=30, m_rows=15, g_rows=15, seed=42)
 
     # We will patch _accumulate_null to capture the final accumulator
     captured_acc = []
@@ -150,15 +142,8 @@ def test_accumulate_null_pair_stratification(tmp_path, monkeypatch):
     expected_total_count = 10 * expected_trans_pairs
     assert final_acc['total_count'] == expected_total_count
 
-def test_accumulate_calibration_sanity(tmp_path, monkeypatch):
-    M, G, C, M_annot, G_annot = generate_data(sample_size=120, m_rows=25, g_rows=25, annotation=True, seed=42)
-    M_annot = M_annot.set_index("name")[["chrom", "chromStart"]]
-    M_annot["chromStart"] = M_annot["chromStart"].astype(int)
-    M_annot["chrom"] = M_annot["chrom"].astype(int)
-    G_annot = G_annot.set_index("name")[["chrom", "chromStart", "strand"]]
-    G_annot["chromStart"] = G_annot["chromStart"].astype(int)
-    G_annot["chrom"] = G_annot["chrom"].astype(int)
-    G_annot["strand"] = G_annot["strand"].replace({"+": 1, "-": -1}).astype(int)
+def test_accumulate_calibration_sanity(tmp_path, monkeypatch, annotated_fixture):
+    M, G, C, M_annot, G_annot = annotated_fixture(sample_size=120, m_rows=25, g_rows=25, seed=42)
 
 
     captured_acc = []

--- a/tests/test_permute_score.py
+++ b/tests/test_permute_score.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+from tecpg.permute import _accumulate_null, _score_observed, tecpg_mlr_qr_permute
+from tecpg.logger import Logger
+from tecpg.test_data import generate_data
+
+def test_score_oracle_edge_aligned():
+    logger = Logger()
+    rng = np.random.default_rng(42)
+    null_stats = rng.normal(scale=2.5, size=50000)
+
+    acc = _accumulate_null(null_stats, None, logger)
+
+    obs_on_edges = acc['bin_edges'][[50, 150, 300, 500, 800]]
+
+    abs_null = np.abs(null_stats)
+    N = acc['total_count']
+
+    ref = np.array([max((abs_null >= e).sum() / N, 1.0 / (N + 1)) for e in obs_on_edges])
+
+    np.testing.assert_allclose(_score_observed(obs_on_edges, acc, logger), ref, atol=1e-12)
+
+def test_score_monotonicity():
+    logger = Logger()
+    rng = np.random.default_rng(42)
+    null_stats = rng.normal(scale=2.5, size=50000)
+    acc = _accumulate_null(null_stats, None, logger)
+
+    obs = np.linspace(0, 6, 50)
+    p = _score_observed(obs, acc, logger)
+
+    assert np.all(np.diff(p) <= 1e-12)
+
+def test_score_floor_and_endpoints():
+    logger = Logger()
+    rng = np.random.default_rng(42)
+    # Use a small scale so there are 0 overflow elements to strictly test the floor
+    null_stats = rng.normal(scale=0.5, size=500)
+    acc = _accumulate_null(null_stats, None, logger)
+
+    N = acc['total_count']
+    assert acc['overflow_count'] == 0
+
+    assert _score_observed([100.0], acc, logger)[0] == 1.0 / (N + 1)
+
+    # 0.0 will match all values, so p should be 1.0
+    assert _score_observed([0.0], acc, logger)[0] == 1.0
+
+def test_score_two_sided():
+    logger = Logger()
+    rng = np.random.default_rng(42)
+    null_stats = rng.normal(scale=2.5, size=50000)
+    acc = _accumulate_null(null_stats, None, logger)
+
+    for x in [0.5, 1.0, 2.0, 5.0]:
+        assert _score_observed([x], acc, logger)[0] == _score_observed([-x], acc, logger)[0]
+
+def test_score_empty_null_fail_closed():
+    logger = Logger()
+
+    with pytest.raises(ValueError, match="Empty null accumulator; cannot score observed statistics."):
+        _score_observed([1.0], None, logger)
+
+    empty_acc = {
+        'bin_edges': np.linspace(0, 10, 100),
+        'hist_counts': np.zeros(99, dtype=np.int64),
+        'overflow_count': 0,
+        'total_count': 0,
+    }
+
+    with pytest.raises(ValueError, match="Empty null accumulator; cannot score observed statistics."):
+        _score_observed([1.0], empty_acc, logger)
+
+def test_score_requires_annotations():
+    M, G, C = generate_data(sample_size=30, m_rows=10, g_rows=10, annotation=False)
+
+    with pytest.raises(ValueError, match="qr_permute requires methylation and expression annotations"):
+        tecpg_mlr_qr_permute(M, G, C)

--- a/tests/test_permute_skeleton.py
+++ b/tests/test_permute_skeleton.py
@@ -5,14 +5,12 @@ from tecpg.permute import tecpg_mlr_qr_permute
 from tecpg.test_data import generate_data
 
 
-def test_permute_skeleton_end_to_end(tmp_path):
-    # Set up small fixture using tecpg.test_data.generate_data
-    # matching standard harness style
-    M, G, C = generate_data(
+def test_permute_skeleton_end_to_end(tmp_path, annotated_fixture):
+    # Set up small fixture using annotated_fixture
+    M, G, C, M_annot, G_annot = annotated_fixture(
         sample_size=30,
         m_rows=10,
         g_rows=10,
-        annotation=False,
     )
 
     output_file = str(tmp_path / "permutation_results.csv")
@@ -22,6 +20,8 @@ def test_permute_skeleton_end_to_end(tmp_path):
         M=M,
         G=G,
         C=C,
+        M_annot=M_annot,
+        G_annot=G_annot,
         output_file=output_file,
         permutations=10,
         seed=42,
@@ -41,5 +41,7 @@ def test_permute_skeleton_end_to_end(tmp_path):
     expected_rows = len(M) * len(G)
     assert len(df) == expected_rows
 
-    # Assert all perm_mt_p == 0.5
-    assert (df['perm_mt_p'] == 0.5).all()
+    # Assert real scoring assertions
+    assert (df['perm_mt_p'] > 0).all()
+    assert (df['perm_mt_p'] <= 1.0).all()
+    assert df['perm_mt_p'].nunique() > 1


### PR DESCRIPTION
This pull request addresses the chunk 7 tasks of the `tecpg` empirical p-values implementation. The stub `_score_observed` has been completely replaced with an implementation that calculates the two-sided empirical p-values from the streamed `null_accumulator` histogram. The p-values are floored minimally at `1 / (N + 1)`. 

A fail-closed guard was additionally added to prevent calculating trans-stratified observed tests when annotation is absent. Tests were adjusted and centralized using `tests/conftest.py`.

### Captured reports

**Injection A — wrong tail direction**
```
________________________ test_score_oracle_edge_aligned ________________________
...
E       AssertionError: 
E       Not equal to tolerance rtol=1e-07, atol=1e-12
E       
E       Mismatched elements: 5 / 5 (100%)
```

**Injection B — drop the floor**
```
________________________ test_score_floor_and_endpoints ________________________
...
>       assert _score_observed([100.0], acc, logger)[0] == 1.0 / (N + 1)
E       assert np.float64(0.0) == (1.0 / (500 + 1))
```

**Injection C — remove the annotation raise**
```
_______________________ test_score_requires_annotations ________________________
...
>           tecpg_mlr_qr_permute(M, G, C)

tests/test_permute_score.py:78: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tecpg/permute.py:324: in tecpg_mlr_qr_permute
    trans_mask_null = _compute_trans_mask(null_pairs, M_annot, G_annot, 'trans',
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
...
```

**Green suite output:**
```
============================= test session starts ==============================
...
collected 13 items

tests/test_permute_score.py ......                                       [ 46%]
tests/test_permute_skeleton.py .                                         [ 53%]
tests/test_permute_accumulate.py ......                                  [100%]

============================== 13 passed in 4.48s ==============================
```

---
*PR created automatically by Jules for task [10324756793151755046](https://jules.google.com/task/10324756793151755046) started by @kordk*