### PR TITLE
Add permutation output finalization and thresholding (Chunk 9)

### DIFF
--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -316,6 +316,18 @@ def _fit_tail(empirical_p, observed_stats, null_accumulator, logger):
     return perm_mt_p
 
 
+def _finalize_output(reported_pairs, observed_stats, perm_mt_p, seed, n_perm,
+                     output_p_threshold, logger):
+    df = reported_pairs.copy()
+    df['mt_t'] = np.asarray(observed_stats, dtype=np.float64)
+    df['perm_mt_p'] = np.asarray(perm_mt_p, dtype=np.float64)
+    df['seed'] = seed
+    df['n_perm'] = n_perm
+    if output_p_threshold is not None:
+        df = df[df['perm_mt_p'] <= output_p_threshold].reset_index(drop=True)
+    return df
+
+
 def tecpg_mlr_qr_permute(
     M, G, C,
     M_annot=None, G_annot=None,
@@ -324,7 +336,7 @@ def tecpg_mlr_qr_permute(
     permutations=100,
     subsample_mt_count=None, subsample_g_count=None,
     seed=42,
-    output_file=None, output_format='auto',
+    output_file=None, output_format='auto', output_p_threshold=None,
     thermal_threshold=80, thermal_wait=30,
     logger=None,
 ):
@@ -336,6 +348,11 @@ def tecpg_mlr_qr_permute(
             "qr_permute requires methylation and expression annotations to build the "
             "chromosome-stratified (trans) null; none were provided."
         )
+
+    if seed is None:
+        seed = int(np.random.SeedSequence().generate_state(1)[0])
+        logger.info("No seed provided; generated seed={0} (recorded with outputs).", seed)
+    seed = int(seed)
 
     logger.info("Starting qr_permute with permutations={0}, seed={1}, output_file={2}", permutations, seed, output_file)
 
@@ -379,8 +396,9 @@ def tecpg_mlr_qr_permute(
     empirical_p = _score_observed(observed_t, accumulator, logger)
     perm_mt_p = _fit_tail(empirical_p, observed_t, accumulator, logger)
 
-    # Add final permutation p-values to dataframe
-    reported_pairs['perm_mt_p'] = perm_mt_p
+    n_reported = len(reported_pairs)
+
+    final_df = _finalize_output(reported_pairs, observed_t, perm_mt_p, seed, permutations, output_p_threshold, logger)
 
     # Honor output format
     if output_format == 'auto':
@@ -392,9 +410,17 @@ def tecpg_mlr_qr_permute(
 
     if ext == 'parquet' or (output_file and output_file.endswith('.parquet')):
         # Use pyarrow to write parquet
-        table = pa.Table.from_pandas(reported_pairs)
-        pq.write_table(table, output_file)
+        table = pa.Table.from_pandas(final_df)
+        existing = table.schema.metadata or {}
+        new_meta = {
+            **existing,
+            b'tecpg_perm_seed': str(seed).encode(),
+            b'tecpg_perm_n_perm': str(permutations).encode(),
+            b'tecpg_perm_n_reported': str(n_reported).encode(),
+        }
+        table = table.replace_schema_metadata(new_meta)
+        pq.write_table(table, output_file, compression='snappy')
     else:
-        reported_pairs.to_csv(output_file, index=False)
+        final_df.to_csv(output_file, index=False)
 
-    logger.info("Finished qr_permute, wrote {0} pairs to {1}", len(reported_pairs), output_file)
+    logger.info("Finished qr_permute, wrote {0} of {1} reported pairs to {2}", len(final_df), n_reported, output_file)

--- a/tests/test_permute_finalize.py
+++ b/tests/test_permute_finalize.py
@@ -1,0 +1,141 @@
+import pytest
+import pandas as pd
+import numpy as np
+import pyarrow.parquet as pq
+import os
+from tecpg.permute import _finalize_output, tecpg_mlr_qr_permute
+from tecpg.logger import Logger
+
+def test_finalize_output_columns_and_values():
+    # Test 1: Columns + order exactly match expectations.
+    # mt_t / perm_mt_p equal the inputs; seed / n_perm constant on every row.
+    reported_pairs = pd.DataFrame({'mt_id': ['m1', 'm2', 'm3'], 'gt_id': ['g1', 'g2', 'g3']})
+    observed_stats = np.array([2.5, -1.0, 0.5])
+    perm_mt_p = np.array([0.01, 0.5, 0.9])
+    seed = 42
+    n_perm = 100
+
+    df = _finalize_output(
+        reported_pairs=reported_pairs,
+        observed_stats=observed_stats,
+        perm_mt_p=perm_mt_p,
+        seed=seed,
+        n_perm=n_perm,
+        output_p_threshold=None,
+        logger=Logger()
+    )
+
+    expected_cols = ['mt_id', 'gt_id', 'mt_t', 'perm_mt_p', 'seed', 'n_perm']
+    assert list(df.columns) == expected_cols
+
+    np.testing.assert_allclose(df['mt_t'].values, observed_stats)
+    np.testing.assert_allclose(df['perm_mt_p'].values, perm_mt_p)
+    assert (df['seed'] == seed).all()
+    assert (df['n_perm'] == n_perm).all()
+
+
+def test_finalize_output_threshold():
+    # Test 2: Threshold filter works properly.
+    reported_pairs = pd.DataFrame({'mt_id': ['m1', 'm2', 'm3'], 'gt_id': ['g1', 'g2', 'g3']})
+    observed_stats = np.array([2.5, -1.0, 0.5])
+    perm_mt_p = np.array([0.01, 0.5, 0.9])
+
+    # With threshold 0.1, only m1 remains
+    df_thresh = _finalize_output(
+        reported_pairs=reported_pairs,
+        observed_stats=observed_stats,
+        perm_mt_p=perm_mt_p,
+        seed=42,
+        n_perm=100,
+        output_p_threshold=0.1,
+        logger=Logger()
+    )
+    assert len(df_thresh) == 1
+    assert df_thresh['mt_id'].iloc[0] == 'm1'
+    assert df_thresh['perm_mt_p'].iloc[0] <= 0.1
+
+    # With None, all 3 remain
+    df_none = _finalize_output(
+        reported_pairs=reported_pairs,
+        observed_stats=observed_stats,
+        perm_mt_p=perm_mt_p,
+        seed=42,
+        n_perm=100,
+        output_p_threshold=None,
+        logger=Logger()
+    )
+    assert len(df_none) == 3
+
+
+def test_finalize_output_mt_t_alignment():
+    # Test 3: mt_t correctly mirrors observed_stats exactly row-for-row.
+    reported_pairs = pd.DataFrame({'mt_id': ['m1', 'm2'], 'gt_id': ['g1', 'g2']})
+    observed_stats = np.array([10.5, -5.5])
+    perm_mt_p = np.array([0.2, 0.8])
+
+    df = _finalize_output(
+        reported_pairs=reported_pairs,
+        observed_stats=observed_stats,
+        perm_mt_p=perm_mt_p,
+        seed=42,
+        n_perm=100,
+        output_p_threshold=None,
+        logger=Logger()
+    )
+
+    assert df.loc[0, 'mt_t'] == 10.5
+    assert df.loc[1, 'mt_t'] == -5.5
+    assert df.loc[0, 'perm_mt_p'] == 0.2
+    assert df.loc[1, 'perm_mt_p'] == 0.8
+
+
+def test_permute_parquet_metadata_roundtrip(tmp_path, annotated_fixture):
+    # Test 4: Parquet schema metadata successfully saves and matches seed, permutations, and total rows.
+    M, G, C, M_annot, G_annot = annotated_fixture(sample_size=30, m_rows=10, g_rows=10)
+    output_file = str(tmp_path / "perm_output.parquet")
+
+    seed = 77
+    permutations = 5
+
+    tecpg_mlr_qr_permute(
+        M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot,
+        output_file=output_file, permutations=permutations, seed=seed
+    )
+
+    assert os.path.exists(output_file)
+
+    table = pq.read_table(output_file)
+    metadata = table.schema.metadata
+
+    assert b'tecpg_perm_seed' in metadata
+    assert b'tecpg_perm_n_perm' in metadata
+    assert b'tecpg_perm_n_reported' in metadata
+
+    assert int(metadata[b'tecpg_perm_seed']) == seed
+    assert int(metadata[b'tecpg_perm_n_perm']) == permutations
+    assert int(metadata[b'tecpg_perm_n_reported']) == len(M) * len(G)
+
+
+def test_permute_end_to_end_threshold_and_universe(tmp_path, annotated_fixture):
+    # Test 5: End-to-end threshold + universe size accurately persists under threshold conditions.
+    M, G, C, M_annot, G_annot = annotated_fixture(sample_size=30, m_rows=10, g_rows=10)
+    output_file = str(tmp_path / "perm_output_thresh.parquet")
+
+    # We use output_p_threshold = 0.5 to drop some rows, ensuring not all are returned.
+    tecpg_mlr_qr_permute(
+        M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot,
+        output_file=output_file, permutations=10, seed=42,
+        output_p_threshold=0.5
+    )
+
+    table = pq.read_table(output_file)
+    metadata = table.schema.metadata
+    df = table.to_pandas()
+
+    n_reported_universe = len(M) * len(G)
+
+    # The written row count is less than or equal to n_reported.
+    # Given the test data and standard null distributions, some should easily be > 0.5
+    assert len(df) <= n_reported_universe
+    assert (df['perm_mt_p'] <= 0.5).all()
+    assert int(metadata[b'tecpg_perm_n_reported']) == n_reported_universe

--- a/tests/test_permute_skeleton.py
+++ b/tests/test_permute_skeleton.py
@@ -34,7 +34,7 @@ def test_permute_skeleton_end_to_end(tmp_path, annotated_fixture):
     df = pd.read_csv(output_file)
 
     # Assert correct columns (schema)
-    expected_cols = ['mt_id', 'gt_id', 'perm_mt_p']
+    expected_cols = ['mt_id', 'gt_id', 'mt_t', 'perm_mt_p', 'seed', 'n_perm']
     assert list(df.columns) == expected_cols
 
     # Assert row count = |M| x |G|
@@ -45,3 +45,9 @@ def test_permute_skeleton_end_to_end(tmp_path, annotated_fixture):
     assert (df['perm_mt_p'] > 0).all()
     assert (df['perm_mt_p'] <= 1.0).all()
     assert df['perm_mt_p'].nunique() > 1
+
+    # Assert additional columns
+    import numpy as np
+    assert np.isfinite(df['mt_t']).all()
+    assert (df['seed'] == 42).all()
+    assert (df['n_perm'] == 10).all()


### PR DESCRIPTION
Added robust finalization and thresholding features for chunk 9 including output seed resolutions, snappy parquet compression, and comprehensive test suites.

---
*PR created automatically by Jules for task [17551513643635463577](https://jules.google.com/task/17551513643635463577) started by @kordk*