### PR TITLE
Phase 3 scaffold: standalone read-only eval_permute diagnostic

### DIFF
--- a/tests/test_eval_permute.py
+++ b/tests/test_eval_permute.py
@@ -40,8 +40,12 @@ def test_analytic_p_oracle():
         assert np.isclose(p_ana, expected_p, atol=1e-8), f"Failed for t={t_val}, df={df}: got {p_ana}, expected {expected_p}"
 
 # ==============================================================================
-# ORACLE 2: GPD-RECOVERY():
+# ORACLE 2: GPD-RECOVERY
+# ==============================================================================
+def test_gpd_recovery_oracle():
     """
+    Draw genpareto samples with known (xi, sigma), fit via the script's fitter,
+    assert recovery within a stated tolerance. Includes a xi approx 0 case.
     Draw genpareto samples with known (xi, sigma), fit via the script's fitter,
     assert recovery within a stated tolerance. Includes a xi approx 0 case.
     """
@@ -61,7 +65,6 @@ def test_analytic_p_oracle():
 
         fit_xi, fit_sigma = ep.fit_gpd(data, u)
 
-        # Method of moments is roughly robust but we need a loose tolerance for it
         assert np.isclose(fit_xi, xi, atol=0.02), f"Failed xi recovery: expected {xi}, got {fit_xi}"
         assert np.isclose(fit_sigma, sigma, atol=0.02), f"Failed sigma recovery: expected {sigma}, got {fit_sigma}"
 
@@ -189,6 +192,13 @@ def test_label_strata_value_error():
     with pytest.raises(ValueError, match="missing from annotations"):
         ep.label_strata(output, m_annot, g_annot)
 
+
+def test_label_strata_nan_chrom():
+    m_annot = pd.DataFrame({'name': ['m1'], 'chrom': [None]}).set_index('name')
+    g_annot = pd.DataFrame({'name': ['g1'], 'chrom': [1]}).set_index('name')
+    output = pd.DataFrame({'mt_id': ['m1'], 'gt_id': ['g1']})
+    with pytest.raises(ValueError, match="NaN chromosome in annotation"):
+        ep.label_strata(output, m_annot, g_annot)
 def test_stratify_decision_smoke(tmp_path):
     """
     Construct one synthetic case where cis == trans (expect "single_global_null_adequate")
@@ -347,32 +357,37 @@ def test_sidecar_absent_smoke(tmp_path):
     assert np.isclose(rep['arms']['calibration']['qq_data']['neg_log10_p_ana'][0], expected_neg_log)
 
 
-def test_stratum_mixed_dtype_regression(tmp_path):
+
+@pytest.mark.parametrize("m_chrom_col, g_chrom_col", [
+    ([1, 2, 'X'], [1, 2, 3]),  # object-vs-int (existing)
+    ([1.0, 2.0, None], [1, 2, 3]),  # float-vs-int (None on unused forces float64)
+    (['chr1', 'chr2', 'chr3'], [1, 2, 3])  # 'chr1'-vs-1
+])
+def test_stratum_mixed_dtype_regression(tmp_path, m_chrom_col, g_chrom_col):
     import json
     import subprocess
     import sys
     import os
     import pandas as pd
 
-    # Mixed dtype fixture: m_annot has 'X' row (object dtype), g_annot is autosome-only (int64)
     m_annot = pd.DataFrame({
-        'name': ['m1', 'm2', 'mX'],
-        'chrom': [1, 2, 'X'],
+        'name': ['m1', 'm2', 'm3'],
+        'chrom': m_chrom_col,
         'chromStart': [100, 200, 300]
     })
 
     g_annot = pd.DataFrame({
         'name': ['g1', 'g2', 'g3'],
-        'chrom': [1, 2, 3],
+        'chrom': g_chrom_col,
         'chromStart': [150, 250, 350]
     })
 
-    # m1-g1 is cis (1-1), m2-g2 is cis (2-2), mX-g3 is trans ('X'-3)
+    # m1-g1 is cis (1-1), m2-g2 is cis (2-2)
     output = pd.DataFrame({
-        'mt_id': ['m1', 'm2', 'mX'],
-        'gt_id': ['g1', 'g2', 'g3'],
-        'mt_t': [1.0, 1.0, 1.0],
-        'perm_mt_p': [0.5, 0.5, 0.5]
+        'mt_id': ['m1', 'm2'],
+        'gt_id': ['g1', 'g2'],
+        'mt_t': [1.0, 1.0],
+        'perm_mt_p': [0.5, 0.5]
     })
 
     m_annot_path = tmp_path / "m_annot.csv"
@@ -403,4 +418,4 @@ def test_stratum_mixed_dtype_regression(tmp_path):
         report = json.load(f)
 
     assert report['metadata']['n_cis'] == 2, f"Expected 2 cis, got {report['metadata'].get('n_cis')}"
-    assert report['metadata']['n_trans'] == 1, f"Expected 1 trans, got {report['metadata'].get('n_trans')}"
+    assert report['metadata']['n_trans'] == 0, f"Expected 0 trans, got {report['metadata'].get('n_trans')}"

--- a/tests/test_eval_permute.py
+++ b/tests/test_eval_permute.py
@@ -1,0 +1,304 @@
+import json
+import os
+import subprocess
+import tempfile
+import warnings
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import scipy.stats
+
+# Import the actual module for whitebox testing of isolated functions
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import tools.eval_permute as ep
+
+# ==============================================================================
+# ORACLE 1: ANALYTIC-P
+# ==============================================================================
+def test_analytic_p_oracle():
+    """
+    Assert that the script's analytic p-value computation using Student-t sf
+    exactly matches known exact tail values to atol=1e-10.
+    """
+    test_cases = [
+        # (t, df, expected_p)
+        (0.0, 10, 1.0),
+        (1.96, 10000, 0.05002352023),  # roughly 0.05
+        (2.0, 10, 0.07338803477),
+        (5.0, 5, 0.00410471598)
+    ]
+
+    for t_val, df, expected_p in test_cases:
+        p_ana = 2.0 * scipy.stats.t.sf(np.abs(t_val), df)
+        assert np.isclose(p_ana, expected_p, atol=1e-8), f"Failed for t={t_val}, df={df}: got {p_ana}, expected {expected_p}"
+
+# ==============================================================================
+# ORACLE 2: GPD-RECOVERY
+# ==============================================================================
+def test_gpd_recovery_oracle():
+    """
+    Draw genpareto samples with known (xi, sigma), fit via the script's fitter,
+    assert recovery within a stated tolerance. Includes a xi approx 0 case.
+    """
+    rng = np.random.default_rng(42)
+    u = 0.0
+
+    cases = [
+        # (xi, sigma) Note: scipy param c = xi, scale = sigma
+        (0.2, 1.5),
+        (0.01, 1.0),  # approx exponential
+        (-0.2, 0.5)
+    ]
+
+    for xi, sigma in cases:
+        # Generate GPD samples
+        data = scipy.stats.genpareto.rvs(c=xi, scale=sigma, size=100_000, random_state=rng)
+
+        fit_xi, fit_sigma = ep.fit_gpd(data, u)
+
+        # Method of moments is roughly robust but we need a loose tolerance for it
+        assert np.isclose(fit_xi, xi, atol=0.05), f"Failed xi recovery: expected {xi}, got {fit_xi}"
+        assert np.isclose(fit_sigma, sigma, atol=0.05), f"Failed sigma recovery: expected {sigma}, got {fit_sigma}"
+
+# ==============================================================================
+# ORACLE 3: UNIFORMITY
+# ==============================================================================
+def test_uniformity_oracle():
+    """
+    Feed U(0,1) draws through lambda / KS null-sanity code; assert lambda approx 1
+    and KS small on genuine null. Assert lambda > 1 flags on inflated input.
+    """
+    rng = np.random.default_rng(42)
+    n = 100_000
+
+    # Genuine null: p ~ U(0,1), so t ~ StudentT
+    df = 50
+    t_null = scipy.stats.t.rvs(df, size=n, random_state=rng)
+
+    lam_null = ep.calculate_genomic_inflation(t_null)
+    assert np.isclose(lam_null, 1.0, atol=0.05), f"Null lambda inflated: {lam_null}"
+
+    p_null = 2.0 * scipy.stats.t.sf(np.abs(t_null), df)
+    ks_stat, ks_p = scipy.stats.kstest(p_null, 'uniform')
+    assert ks_p > 0.01, f"Null p-values not uniform, ks_p={ks_p}"
+
+    # Inflated input: scale t
+    t_inflated = t_null * 1.5
+    lam_inflated = ep.calculate_genomic_inflation(t_inflated)
+    assert lam_inflated > 1.5, f"Inflated lambda not > 1.5: {lam_inflated}"
+
+# ==============================================================================
+# ORACLE 4: STRATUM-LABELING
+# ==============================================================================
+def test_stratum_labeling_oracle(tmp_path):
+    """
+    Tiny synthetic annotation where cis/trans is hand-known.
+    Assert is_cis is exactly correct, and reported id missing raises ValueError.
+    """
+    m_annot = pd.DataFrame({
+        'name': ['m1', 'm2', 'm3'],
+        'chrom': [1, 1, 2],
+        'chromStart': [100, 200, 300]
+    })
+
+    g_annot = pd.DataFrame({
+        'name': ['g1', 'g2', 'g3'],
+        'chrom': [1, 2, 2],
+        'chromStart': [150, 250, 350]
+    })
+
+    output = pd.DataFrame({
+        'mt_id': ['m1', 'm2', 'm3', 'm1'],
+        'gt_id': ['g1', 'g2', 'g3', 'g3'],
+        'mt_t': [1.0, 1.0, 1.0, 1.0],
+        'perm_mt_p': [0.5, 0.5, 0.5, 0.5]
+    })
+    # expected:
+    # m1-g1: chrom 1-1 (cis)
+    # m2-g2: chrom 1-2 (trans)
+    # m3-g3: chrom 2-2 (cis)
+    # m1-g3: chrom 1-2 (trans)
+
+    m_annot_path = tmp_path / "m_annot.csv"
+    g_annot_path = tmp_path / "g_annot.csv"
+    output_path = tmp_path / "output.csv"
+
+    m_annot.to_csv(m_annot_path, index=False)
+    g_annot.to_csv(g_annot_path, index=False)
+    output.to_csv(output_path, index=False)
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    script_path = os.path.join(os.path.dirname(__file__), "../tools/eval_permute.py")
+
+    res = subprocess.run([
+        "python", script_path,
+        "--perm-output", str(output_path),
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--df", "10",
+        "--out-dir", str(out_dir)
+    ], capture_output=True, text=True)
+
+    assert res.returncode == 0, f"Script failed: {res.stderr}"
+
+    with open(out_dir / "eval_permute_report.json") as f:
+        report = json.load(f)
+
+    # Total 4, cis 2, trans 2
+    assert report['arms']['calibration']['all']['n_perm_below_analytic'] is not None
+
+    # Test fail closed on missing ID
+    output_bad = pd.DataFrame({
+        'mt_id': ['m1', 'm99'],
+        'gt_id': ['g1', 'g1'],
+        'mt_t': [1.0, 1.0],
+        'perm_mt_p': [0.5, 0.5]
+    })
+    output_bad_path = tmp_path / "output_bad.csv"
+    output_bad.to_csv(output_bad_path, index=False)
+
+    res_bad = subprocess.run([
+        "python", script_path,
+        "--perm-output", str(output_bad_path),
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--df", "10",
+        "--out-dir", str(out_dir)
+    ], capture_output=True, text=True)
+
+    assert res_bad.returncode == 1
+    assert "missing from annotations" in res_bad.stderr
+
+# ==============================================================================
+# ORACLE 5: STRATIFY-DECISION SMOKE
+# ==============================================================================
+def test_stratify_decision_smoke(tmp_path):
+    """
+    Construct one synthetic case where cis == trans (expect "single_global_null_adequate")
+    and one where cis is deliberately shifted (expect "stratification_warranted" or confound).
+    """
+    df_val = 50
+    rng = np.random.default_rng(42)
+    n = 10000
+
+    m_annot = pd.DataFrame({'name': [f'm{i}' for i in range(n)], 'chrom': [1]*n})
+    g_annot = pd.DataFrame({'name': [f'g{i}' for i in range(n)], 'chrom': [1]*(n//2) + [2]*(n//2)})
+
+    m_annot_path = tmp_path / "m_annot.csv"
+    g_annot_path = tmp_path / "g_annot.csv"
+    m_annot.to_csv(m_annot_path, index=False)
+    g_annot.to_csv(g_annot_path, index=False)
+
+    # Case 1: Identical Distributions (cis == trans)
+    t_vals = scipy.stats.t.rvs(df_val, size=n, random_state=rng)
+    p_ana = 2.0 * scipy.stats.t.sf(np.abs(t_vals), df_val)
+    p_perm = p_ana * 1.0  # Exact match
+
+    output1 = pd.DataFrame({
+        'mt_id': [f'm{i}' for i in range(n)],
+        'gt_id': [f'g{i}' for i in range(n)],
+        'mt_t': t_vals,
+        'perm_mt_p': p_perm
+    })
+
+    out1_path = tmp_path / "out1.parquet"
+    table1 = pa.Table.from_pandas(output1)
+    pq.write_table(table1, out1_path)
+
+    script_path = os.path.join(os.path.dirname(__file__), "../tools/eval_permute.py")
+    out_dir1 = tmp_path / "dir1"
+
+    subprocess.run([
+        "python", script_path,
+        "--perm-output", str(out1_path),
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--df", str(df_val),
+        "--out-dir", str(out_dir1)
+    ], check=True)
+
+    with open(out_dir1 / "eval_permute_report.json") as f:
+        rep1 = json.load(f)
+    assert rep1['arms']['stratify_decision']['recommendation'] == "single_global_null_adequate"
+
+    # Case 2: Divergence
+    # We alter perm_mt_p for cis so it's significantly lower than analytic
+    # Half of the data is cis (chrom 1 == chrom 1). Indices 0 to n//2-1
+    p_perm2 = p_ana.copy()
+    p_perm2[:n//2] = p_perm2[:n//2] * 0.05  # Massive downward shift, ratio < 0
+
+    output2 = pd.DataFrame({
+        'mt_id': [f'm{i}' for i in range(n)],
+        'gt_id': [f'g{i}' for i in range(n)],
+        'mt_t': t_vals,
+        'perm_mt_p': p_perm2
+    })
+    out2_path = tmp_path / "out2.parquet"
+    table2 = pa.Table.from_pandas(output2)
+    pq.write_table(table2, out2_path)
+
+    out_dir2 = tmp_path / "dir2"
+    subprocess.run([
+        "python", script_path,
+        "--perm-output", str(out2_path),
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--df", str(df_val),
+        "--out-dir", str(out_dir2)
+    ], check=True)
+
+    with open(out_dir2 / "eval_permute_report.json") as f:
+        rep2 = json.load(f)
+    assert rep2['arms']['stratify_decision']['recommendation'] == "stratification_warranted"
+
+# ==============================================================================
+# ORACLE 6: SIDECAR-ABSENT SMOKE
+# ==============================================================================
+def test_sidecar_absent_smoke(tmp_path):
+    """
+    Run end-to-end with no --perm-null-sidecar.
+    Assert JSON report is produced and gated sections read "skipped_no_sidecar".
+    """
+    df_val = 50
+    m_annot = pd.DataFrame({'name': ['m1'], 'chrom': [1]})
+    g_annot = pd.DataFrame({'name': ['g1'], 'chrom': [1]})
+    output = pd.DataFrame({
+        'mt_id': ['m1'],
+        'gt_id': ['g1'],
+        'mt_t': [1.0],
+        'perm_mt_p': [0.5]
+    })
+
+    m_annot_path = tmp_path / "m_annot.csv"
+    g_annot_path = tmp_path / "g_annot.csv"
+    out_path = tmp_path / "out.parquet"
+
+    m_annot.to_csv(m_annot_path, index=False)
+    g_annot.to_csv(g_annot_path, index=False)
+    table = pa.Table.from_pandas(output)
+    pq.write_table(table, out_path)
+
+    script_path = os.path.join(os.path.dirname(__file__), "../tools/eval_permute.py")
+    out_dir = tmp_path / "dir"
+
+    subprocess.run([
+        "python", script_path,
+        "--perm-output", str(out_path),
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--df", str(df_val),
+        "--out-dir", str(out_dir)
+    ], check=True)
+
+    with open(out_dir / "eval_permute_report.json") as f:
+        rep = json.load(f)
+
+    assert rep['arms']['sidecar']['status'] == "skipped_no_sidecar"

--- a/tests/test_eval_permute.py
+++ b/tests/test_eval_permute.py
@@ -21,6 +21,7 @@ import tools.eval_permute as ep
 # ==============================================================================
 # ORACLE 1: ANALYTIC-P
 # ==============================================================================
+
 def test_analytic_p_oracle():
     """
     Assert that the script's analytic p-value computation using Student-t sf
@@ -35,13 +36,11 @@ def test_analytic_p_oracle():
     ]
 
     for t_val, df, expected_p in test_cases:
-        p_ana = 2.0 * scipy.stats.t.sf(np.abs(t_val), df)
+        p_ana = ep.compute_analytic_p(t_val, df)
         assert np.isclose(p_ana, expected_p, atol=1e-8), f"Failed for t={t_val}, df={df}: got {p_ana}, expected {expected_p}"
 
 # ==============================================================================
-# ORACLE 2: GPD-RECOVERY
-# ==============================================================================
-def test_gpd_recovery_oracle():
+# ORACLE 2: GPD-RECOVERY():
     """
     Draw genpareto samples with known (xi, sigma), fit via the script's fitter,
     assert recovery within a stated tolerance. Includes a xi approx 0 case.
@@ -63,8 +62,8 @@ def test_gpd_recovery_oracle():
         fit_xi, fit_sigma = ep.fit_gpd(data, u)
 
         # Method of moments is roughly robust but we need a loose tolerance for it
-        assert np.isclose(fit_xi, xi, atol=0.05), f"Failed xi recovery: expected {xi}, got {fit_xi}"
-        assert np.isclose(fit_sigma, sigma, atol=0.05), f"Failed sigma recovery: expected {sigma}, got {fit_sigma}"
+        assert np.isclose(fit_xi, xi, atol=0.02), f"Failed xi recovery: expected {xi}, got {fit_xi}"
+        assert np.isclose(fit_sigma, sigma, atol=0.02), f"Failed sigma recovery: expected {sigma}, got {fit_sigma}"
 
 # ==============================================================================
 # ORACLE 3: UNIFORMITY
@@ -149,11 +148,13 @@ def test_stratum_labeling_oracle(tmp_path):
 
     assert res.returncode == 0, f"Script failed: {res.stderr}"
 
+
     with open(out_dir / "eval_permute_report.json") as f:
         report = json.load(f)
 
-    # Total 4, cis 2, trans 2
-    assert report['arms']['calibration']['all']['n_perm_below_analytic'] is not None
+    assert report['metadata']['n_cis'] == 2
+    assert report['metadata']['n_trans'] == 2
+
 
     # Test fail closed on missing ID
     output_bad = pd.DataFrame({
@@ -180,6 +181,14 @@ def test_stratum_labeling_oracle(tmp_path):
 # ==============================================================================
 # ORACLE 5: STRATIFY-DECISION SMOKE
 # ==============================================================================
+
+def test_label_strata_value_error():
+    m_annot = pd.DataFrame({'name': ['m1'], 'chrom': [1]}).set_index('name')
+    g_annot = pd.DataFrame({'name': ['g1'], 'chrom': [1]}).set_index('name')
+    output = pd.DataFrame({'mt_id': ['m1'], 'gt_id': ['g2']})  # g2 is missing
+    with pytest.raises(ValueError, match="missing from annotations"):
+        ep.label_strata(output, m_annot, g_annot)
+
 def test_stratify_decision_smoke(tmp_path):
     """
     Construct one synthetic case where cis == trans (expect "single_global_null_adequate")
@@ -259,6 +268,36 @@ def test_stratify_decision_smoke(tmp_path):
         rep2 = json.load(f)
     assert rep2['arms']['stratify_decision']['recommendation'] == "stratification_warranted"
 
+
+    # Case 3: Confound Branch
+    p_perm3 = p_ana.copy()
+    p_perm3[:n//2] = p_perm3[:n//2] * 0.05
+    t_vals3 = t_vals.copy()
+    t_vals3[:n//2] = t_vals3[:n//2] * 2.0  # Inflate cis t-values substantially
+
+    output3 = pd.DataFrame({
+        'mt_id': [f'm{i}' for i in range(n)],
+        'gt_id': [f'g{i}' for i in range(n)],
+        'mt_t': t_vals3,
+        'perm_mt_p': p_perm3
+    })
+    out3_path = tmp_path / "out3.parquet"
+    pq.write_table(pa.Table.from_pandas(output3), out3_path)
+
+    out_dir3 = tmp_path / "dir3"
+    subprocess.run([
+        sys.executable, script_path,
+        "--perm-output", str(out3_path),
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--df", str(df_val),
+        "--out-dir", str(out_dir3)
+    ], check=True)
+
+    with open(out_dir3 / "eval_permute_report.json") as f:
+        rep3 = json.load(f)
+    assert rep3['arms']['stratify_decision']['recommendation'] == "inconclusive_cis_signal_confound"
+
 # ==============================================================================
 # ORACLE 6: SIDECAR-ABSENT SMOKE
 # ==============================================================================
@@ -302,3 +341,66 @@ def test_sidecar_absent_smoke(tmp_path):
         rep = json.load(f)
 
     assert rep['arms']['sidecar']['status'] == "skipped_no_sidecar"
+    # End-to-end assert for analytic_p
+    p_ana_expected = float(ep.compute_analytic_p(1.0, df_val))
+    expected_neg_log = -float(np.log10(p_ana_expected))
+    assert np.isclose(rep['arms']['calibration']['qq_data']['neg_log10_p_ana'][0], expected_neg_log)
+
+
+def test_stratum_mixed_dtype_regression(tmp_path):
+    import json
+    import subprocess
+    import sys
+    import os
+    import pandas as pd
+
+    # Mixed dtype fixture: m_annot has 'X' row (object dtype), g_annot is autosome-only (int64)
+    m_annot = pd.DataFrame({
+        'name': ['m1', 'm2', 'mX'],
+        'chrom': [1, 2, 'X'],
+        'chromStart': [100, 200, 300]
+    })
+
+    g_annot = pd.DataFrame({
+        'name': ['g1', 'g2', 'g3'],
+        'chrom': [1, 2, 3],
+        'chromStart': [150, 250, 350]
+    })
+
+    # m1-g1 is cis (1-1), m2-g2 is cis (2-2), mX-g3 is trans ('X'-3)
+    output = pd.DataFrame({
+        'mt_id': ['m1', 'm2', 'mX'],
+        'gt_id': ['g1', 'g2', 'g3'],
+        'mt_t': [1.0, 1.0, 1.0],
+        'perm_mt_p': [0.5, 0.5, 0.5]
+    })
+
+    m_annot_path = tmp_path / "m_annot.csv"
+    g_annot_path = tmp_path / "g_annot.csv"
+    output_path = tmp_path / "output.csv"
+
+    m_annot.to_csv(m_annot_path, index=False)
+    g_annot.to_csv(g_annot_path, index=False)
+    output.to_csv(output_path, index=False)
+
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    script_path = os.path.join(os.path.dirname(__file__), "../tools/eval_permute.py")
+
+    res = subprocess.run([
+        sys.executable, script_path,
+        "--perm-output", str(output_path),
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--df", "10",
+        "--out-dir", str(out_dir)
+    ], capture_output=True, text=True)
+
+    assert res.returncode == 0, f"Script failed: {res.stderr}"
+
+    with open(out_dir / "eval_permute_report.json") as f:
+        report = json.load(f)
+
+    assert report['metadata']['n_cis'] == 2, f"Expected 2 cis, got {report['metadata'].get('n_cis')}"
+    assert report['metadata']['n_trans'] == 1, f"Expected 1 trans, got {report['metadata'].get('n_trans')}"

--- a/tools/eval_permute.py
+++ b/tools/eval_permute.py
@@ -94,10 +94,14 @@ def compute_calibration_stats(t_vals, p_perm, p_ana, is_bulk, is_tail):
 
     return stats
 
-def _canon_chrom(arr):
-    s = pd.Series(arr).astype(str).str.strip()
-    s = s.str.replace(r'^chr', '', regex=True, case=False)
-    return s.to_numpy()
+def _canon_chrom(arr, which):
+    s = pd.Series(arr)
+    if s.isna().any():
+        raise ValueError(f"{which}: NaN chromosome in annotation")
+    s = s.astype(str).str.strip()
+    s = s.str.replace(r'\.0$', '', regex=True)              # 1.0 -> 1
+    s = s.str.replace(r'^chr', '', regex=True, case=False)  # chr1 -> 1
+    return s.str.upper().to_numpy()                         # x -> X
 
 def label_strata(output, m_annot, g_annot):
     m_mapped = m_annot.index.astype(str).get_indexer(output['mt_id'].astype(str))
@@ -106,8 +110,9 @@ def label_strata(output, m_annot, g_annot):
     if (m_mapped == -1).any() or (g_mapped == -1).any():
         raise ValueError("Reported mt_id/gt_id missing from annotations.")
 
-    m_chrom = _canon_chrom(m_annot.iloc[m_mapped]['chrom'].to_numpy())
-    g_chrom = _canon_chrom(g_annot.iloc[g_mapped]['chrom'].to_numpy())
+    m_chrom = _canon_chrom(m_annot.iloc[m_mapped]['chrom'].to_numpy(), 'm_annot')
+    g_chrom = _canon_chrom(g_annot.iloc[g_mapped]['chrom'].to_numpy(), 'g_annot')
+
 
     is_cis = (m_chrom == g_chrom)
     is_trans = ~is_cis

--- a/tools/eval_permute.py
+++ b/tools/eval_permute.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import logging
+import os
+import sys
+import warnings
+
+import numpy as np
+import pandas as pd
+import pyarrow.parquet as pq
+import scipy.stats
+
+# ==============================================================================
+# CONSTANTS & THRESHOLDS
+# ==============================================================================
+# Provisional — calibrate from eval output on GTP/MESA before blessing.
+BULK_LO = 0.05
+BULK_HI = 1.0  # mostly-null band for divergence
+TAIL_P_ANA = 1e-4  # tail band for arm (a)
+TOLERANCE_MEDIAN_LOG10_RATIO_DIFF = 0.5  # |Δ| below this => strata agree
+LAMBDA_EXCESS_CONFOUND_FLAG = 0.2  # (λ_cis − λ_trans) above this => cis signal-contaminated
+
+# Frozen Sidecar Contract: The sidecar .npz is expected to have these exactly.
+# Arrays: bin_edges, hist_counts, overflow_count, total_count, topk_values
+# Scalars: gpd_xi, gpd_sigma, gpd_u, gpd_N_u, gpd_N
+
+# ==============================================================================
+# GPD RECOVERY (Standalone Fitter for Sidecar Arm)
+# ==============================================================================
+def fit_gpd(data, u):
+    """
+    Fits Generalized Pareto Distribution to data > u using method of moments or MLE.
+    This is a standalone stub/fitter used by the sidecar-gated arm.
+    """
+    exceedances = data[data > u] - u
+    if len(exceedances) < 5:
+        return np.nan, np.nan
+
+    # Simple Method of Moments (MoM) as a robust fallback/fitter
+    mean_ex = np.mean(exceedances)
+    var_ex = np.var(exceedances, ddof=1)
+
+    # MoM estimators for GPD
+    xi = 0.5 * (1 - (mean_ex**2) / var_ex)
+    sigma = 0.5 * mean_ex * (1 + (mean_ex**2) / var_ex)
+
+    return xi, sigma
+
+# ==============================================================================
+# DIAGNOSTICS & ARMS
+# ==============================================================================
+def compute_calibration_stats(t_vals, p_perm, df_val, p_ana, is_bulk, is_tail):
+    """Arm A.a: Calibration"""
+    stats = {}
+
+    # Bulk agreement
+    if np.any(is_bulk):
+        p_perm_bulk = p_perm[is_bulk]
+        p_ana_bulk = p_ana[is_bulk]
+
+        # Spearman correlation on -log10
+        # Prevent log(0)
+        p_perm_bulk_safe = np.clip(p_perm_bulk, a_min=1e-300, a_max=1.0)
+        p_ana_bulk_safe = np.clip(p_ana_bulk, a_min=1e-300, a_max=1.0)
+
+        corr, _ = scipy.stats.spearmanr(-np.log10(p_perm_bulk_safe), -np.log10(p_ana_bulk_safe))
+        stats['bulk_spearman_corr'] = float(corr)
+
+        log_ratio = np.log10(p_perm_bulk_safe / p_ana_bulk_safe)
+        stats['bulk_median_abs_log_ratio'] = float(np.median(np.abs(log_ratio)))
+        stats['bulk_90th_abs_log_ratio'] = float(np.percentile(np.abs(log_ratio), 90))
+    else:
+        stats['bulk_spearman_corr'] = None
+        stats['bulk_median_abs_log_ratio'] = None
+        stats['bulk_90th_abs_log_ratio'] = None
+
+    # Tail behavior
+    n_perm_below_analytic = int(np.sum(p_perm < p_ana))
+    stats['n_perm_below_analytic'] = n_perm_below_analytic
+
+    if np.any(is_tail):
+        p_perm_tail = p_perm[is_tail]
+        p_ana_tail = p_ana[is_tail]
+
+        p_perm_tail_safe = np.clip(p_perm_tail, a_min=1e-300, a_max=1.0)
+        p_ana_tail_safe = np.clip(p_ana_tail, a_min=1e-300, a_max=1.0)
+
+        log_ratio_tail = np.log10(p_perm_tail_safe / p_ana_tail_safe)
+
+        stats['tail_median_log_ratio'] = float(np.median(log_ratio_tail))
+        stats['tail_10th_log_ratio'] = float(np.percentile(log_ratio_tail, 10))
+        stats['tail_90th_log_ratio'] = float(np.percentile(log_ratio_tail, 90))
+    else:
+        stats['tail_median_log_ratio'] = None
+        stats['tail_10th_log_ratio'] = None
+        stats['tail_90th_log_ratio'] = None
+
+    return stats
+
+def calculate_genomic_inflation(t_vals):
+    """Arm A.c: Genomic Inflation Lambda"""
+    median_t_sq = np.median(t_vals**2)
+    expected_median_chi2 = scipy.stats.chi2.ppf(0.5, 1)
+    return float(median_t_sq / expected_median_chi2)
+
+def main():
+    parser = argparse.ArgumentParser(description="Phase 3 standalone read-only permutation-evaluation diagnostic")
+    parser.add_argument("--perm-output", required=True, help="Path to qr_permute output, .parquet or .csv")
+    parser.add_argument("--m-annot", required=True, help="Path to methylation annotation (mt_id -> chrom,...)")
+    parser.add_argument("--g-annot", required=True, help="Path to expression annotation (gt_id -> chrom,...)")
+    parser.add_argument("--df", required=True, type=int, help="Run-level df = n_samples - n_covars - 2. MUST equal the df that produced mt_t.")
+    parser.add_argument("--perm-null-sidecar", help="Path to null-accumulator sidecar .npz. When absent, sidecar-gated arms are skipped.")
+    parser.add_argument("--out-dir", required=True, help="Directory for the JSON report.")
+    parser.add_argument("--bulk-lo", type=float, default=BULK_LO, help="Lower bound of p_ana for bulk band.")
+    parser.add_argument("--bulk-hi", type=float, default=BULK_HI, help="Upper bound of p_ana for bulk band.")
+
+    args = parser.parse_args()
+
+    # -------------------------------------------------------------------------
+    # Setup & Validation
+    # -------------------------------------------------------------------------
+    if args.df <= 0 or not np.isfinite(args.df):
+        print(f"Error: Non-finite or invalid df ({args.df}).", file=sys.stderr)
+        sys.exit(1)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    report_path = os.path.join(args.out_dir, "eval_permute_report.json")
+
+    # Load data
+    try:
+        if args.perm_output.endswith(".parquet"):
+            output = pq.read_table(args.perm_output).to_pandas()
+            if output.index.names != [None]:
+                output = output.reset_index()
+        else:
+            output = pd.read_csv(args.perm_output)
+
+        m_annot = pd.read_csv(args.m_annot)
+        g_annot = pd.read_csv(args.g_annot)
+
+        # Replicate annotated_fixture logic
+        if 'name' in m_annot.columns:
+            m_annot = m_annot.set_index('name')
+        if 'name' in g_annot.columns:
+            g_annot = g_annot.set_index('name')
+
+    except Exception as e:
+        print(f"Error loading inputs: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if len(output) == 0:
+        print("Error: Empty permutation output.", file=sys.stderr)
+        sys.exit(1)
+
+    required_cols = {'mt_id', 'gt_id', 'mt_t', 'perm_mt_p'}
+    if not required_cols.issubset(output.columns):
+        print(f"Error: Missing columns in permutation output. Requires {required_cols}", file=sys.stderr)
+        sys.exit(1)
+
+    # Map Chromosomes
+    m_mapped = m_annot.index.astype(str).get_indexer(output['mt_id'].astype(str))
+    g_mapped = g_annot.index.astype(str).get_indexer(output['gt_id'].astype(str))
+
+    if (m_mapped == -1).any() or (g_mapped == -1).any():
+        print("Error: Reported mt_id/gt_id missing from annotations.", file=sys.stderr)
+        sys.exit(1)
+
+    m_chrom = m_annot.iloc[m_mapped]['chrom'].to_numpy()
+    g_chrom = g_annot.iloc[g_mapped]['chrom'].to_numpy()
+
+    # -------------------------------------------------------------------------
+    # Core Data Extraction
+    # -------------------------------------------------------------------------
+    t = output['mt_t'].to_numpy(dtype=np.float64)
+    p_perm = output['perm_mt_p'].to_numpy(dtype=np.float64)
+    df_val = args.df
+
+    # Precise analytic ref
+    p_ana = 2.0 * scipy.stats.t.sf(np.abs(t), df_val)
+
+    # Strata
+    is_cis = (m_chrom == g_chrom)
+    is_trans = ~is_cis
+
+    # Bands
+    is_bulk = (p_ana >= args.bulk_lo) & (p_ana <= args.bulk_hi)
+    is_tail = p_ana < TAIL_P_ANA
+
+    report = {
+        "metadata": {
+            "n_pairs": len(t),
+            "df": df_val,
+            "bulk_lo": args.bulk_lo,
+            "bulk_hi": args.bulk_hi,
+            "tail_p_ana": TAIL_P_ANA
+        },
+        "arms": {}
+    }
+
+    # -------------------------------------------------------------------------
+    # Arm A.a: Calibration
+    # -------------------------------------------------------------------------
+    calib = {}
+
+    # all
+    calib['all'] = compute_calibration_stats(t, p_perm, df_val, p_ana, is_bulk, is_tail)
+    # cis
+    calib['cis'] = compute_calibration_stats(t[is_cis], p_perm[is_cis], df_val, p_ana[is_cis], is_bulk[is_cis], is_tail[is_cis])
+    # trans
+    calib['trans'] = compute_calibration_stats(t[is_trans], p_perm[is_trans], df_val, p_ana[is_trans], is_bulk[is_trans], is_tail[is_trans])
+
+    # Downsampled QQ Data (All)
+    n_qq = min(len(t), 5000)
+    rng = np.random.default_rng(42)
+    qq_idx = rng.choice(len(t), size=n_qq, replace=False)
+
+    p_ana_safe_qq = np.clip(p_ana[qq_idx], a_min=1e-300, a_max=1.0)
+    p_perm_safe_qq = np.clip(p_perm[qq_idx], a_min=1e-300, a_max=1.0)
+
+    calib['qq_data'] = {
+        "neg_log10_p_ana": (-np.log10(p_ana_safe_qq)).tolist(),
+        "neg_log10_p_perm": (-np.log10(p_perm_safe_qq)).tolist()
+    }
+
+    report["arms"]["calibration"] = calib
+
+    # -------------------------------------------------------------------------
+    # Arm A.c: Null-Sanity
+    # -------------------------------------------------------------------------
+    null_sanity = {}
+
+    lambda_trans = calculate_genomic_inflation(t[is_trans]) if np.any(is_trans) else None
+    lambda_cis = calculate_genomic_inflation(t[is_cis]) if np.any(is_cis) else None
+
+    null_sanity['lambda_trans'] = lambda_trans
+    null_sanity['lambda_cis'] = lambda_cis
+    null_sanity['lambda_cis_label'] = "expected > 1 under real cis signal; NOT a miscalibration flag"
+
+    trans_bulk_mask = is_trans & is_bulk
+    if np.any(trans_bulk_mask):
+        ks_stat, ks_p = scipy.stats.kstest(p_ana[trans_bulk_mask], 'uniform')
+        null_sanity['ks_trans_bulk_vs_uniform'] = {"stat": float(ks_stat), "p": float(ks_p)}
+    else:
+        null_sanity['ks_trans_bulk_vs_uniform'] = None
+
+    report["arms"]["null_sanity"] = null_sanity
+
+    # -------------------------------------------------------------------------
+    # Arm A.d: Stratify-or-not
+    # -------------------------------------------------------------------------
+    stratify = {}
+
+    cis_bulk_mask = is_cis & is_bulk
+
+    if np.any(trans_bulk_mask) and np.any(cis_bulk_mask):
+        p_perm_trans_safe = np.clip(p_perm[trans_bulk_mask], a_min=1e-300, a_max=1.0)
+        p_ana_trans_safe = np.clip(p_ana[trans_bulk_mask], a_min=1e-300, a_max=1.0)
+
+        p_perm_cis_safe = np.clip(p_perm[cis_bulk_mask], a_min=1e-300, a_max=1.0)
+        p_ana_cis_safe = np.clip(p_ana[cis_bulk_mask], a_min=1e-300, a_max=1.0)
+
+        log_ratio_trans = np.log10(p_perm_trans_safe / p_ana_trans_safe)
+        log_ratio_cis = np.log10(p_perm_cis_safe / p_ana_cis_safe)
+
+        median_trans = float(np.median(log_ratio_trans))
+        median_cis = float(np.median(log_ratio_cis))
+
+        delta = median_cis - median_trans
+
+        mw_stat, mw_p = scipy.stats.mannwhitneyu(log_ratio_cis, log_ratio_trans, alternative='two-sided')
+        ks_stat2, ks_p2 = scipy.stats.kstest(log_ratio_cis, log_ratio_trans)
+
+        stratify['median_log10_ratio_trans'] = median_trans
+        stratify['median_log10_ratio_cis'] = median_cis
+        stratify['delta_median_log10_ratio'] = delta
+
+        stratify['test_name'] = "mann_whitney_u"
+        stratify['test_stat'] = float(mw_stat)
+        stratify['test_p'] = float(mw_p)
+        stratify['ks_stat'] = float(ks_stat2)
+        stratify['ks_p'] = float(ks_p2)
+
+        lambda_excess = (lambda_cis - lambda_trans) if (lambda_cis is not None and lambda_trans is not None) else 0.0
+        stratify['lambda_excess'] = float(lambda_excess)
+
+        if abs(delta) < TOLERANCE_MEDIAN_LOG10_RATIO_DIFF:
+            rec = "single_global_null_adequate"
+        elif lambda_excess > LAMBDA_EXCESS_CONFOUND_FLAG:
+            rec = "inconclusive_cis_signal_confound"
+        else:
+            rec = "stratification_warranted"
+
+        stratify['recommendation'] = rec
+    else:
+        stratify['status'] = "skipped_insufficient_data"
+
+    report["arms"]["stratify_decision"] = stratify
+
+    # -------------------------------------------------------------------------
+    # Arm B: Sidecar-gated
+    # -------------------------------------------------------------------------
+    sidecar_arm = {}
+
+    if args.perm_null_sidecar:
+        if os.path.exists(args.perm_null_sidecar):
+            # Future sidecar integration
+            sidecar_arm['status'] = "loaded"
+            # TODO: Literal null-flatness / rigorous null-shape stratify
+        else:
+            warnings.warn(f"Sidecar file specified but not found: {args.perm_null_sidecar}")
+            sidecar_arm['status'] = "skipped_no_sidecar"
+    else:
+        print("Warning: --perm-null-sidecar not provided. Skipping sidecar-gated arms.")
+        sidecar_arm['status'] = "skipped_no_sidecar"
+
+    report["arms"]["sidecar"] = sidecar_arm
+
+    # Write JSON report
+    with open(report_path, "w") as f:
+        json.dump(report, f, indent=2)
+
+    print(f"Report written to {report_path}")
+
+if __name__ == "__main__":
+    main()

--- a/tools/eval_permute.py
+++ b/tools/eval_permute.py
@@ -33,24 +33,20 @@ def fit_gpd(data, u):
     Fits Generalized Pareto Distribution to data > u using method of moments or MLE.
     This is a standalone stub/fitter used by the sidecar-gated arm.
     """
-    exceedances = data[data > u] - u
-    if len(exceedances) < 5:
+    exc = data[data > u] - u
+    if exc.size < 50:
         return np.nan, np.nan
 
-    # Simple Method of Moments (MoM) as a robust fallback/fitter
-    mean_ex = np.mean(exceedances)
-    var_ex = np.var(exceedances, ddof=1)
-
-    # MoM estimators for GPD
-    xi = 0.5 * (1 - (mean_ex**2) / var_ex)
-    sigma = 0.5 * mean_ex * (1 + (mean_ex**2) / var_ex)
-
-    return xi, sigma
+    xi, _, sigma = scipy.stats.genpareto.fit(exc, floc=0)
+    return float(xi), float(sigma)
 
 # ==============================================================================
 # DIAGNOSTICS & ARMS
 # ==============================================================================
-def compute_calibration_stats(t_vals, p_perm, df_val, p_ana, is_bulk, is_tail):
+def compute_analytic_p(t, df):
+    return 2.0 * scipy.stats.t.sf(np.abs(np.asarray(t, dtype=np.float64)), df)
+
+def compute_calibration_stats(t_vals, p_perm, p_ana, is_bulk, is_tail):
     """Arm A.a: Calibration"""
     stats = {}
 
@@ -97,6 +93,26 @@ def compute_calibration_stats(t_vals, p_perm, df_val, p_ana, is_bulk, is_tail):
         stats['tail_90th_log_ratio'] = None
 
     return stats
+
+def _canon_chrom(arr):
+    s = pd.Series(arr).astype(str).str.strip()
+    s = s.str.replace(r'^chr', '', regex=True, case=False)
+    return s.to_numpy()
+
+def label_strata(output, m_annot, g_annot):
+    m_mapped = m_annot.index.astype(str).get_indexer(output['mt_id'].astype(str))
+    g_mapped = g_annot.index.astype(str).get_indexer(output['gt_id'].astype(str))
+
+    if (m_mapped == -1).any() or (g_mapped == -1).any():
+        raise ValueError("Reported mt_id/gt_id missing from annotations.")
+
+    m_chrom = _canon_chrom(m_annot.iloc[m_mapped]['chrom'].to_numpy())
+    g_chrom = _canon_chrom(g_annot.iloc[g_mapped]['chrom'].to_numpy())
+
+    is_cis = (m_chrom == g_chrom)
+    is_trans = ~is_cis
+
+    return is_cis, is_trans, int(is_cis.sum()), int(is_trans.sum())
 
 def calculate_genomic_inflation(t_vals):
     """Arm A.c: Genomic Inflation Lambda"""
@@ -158,16 +174,12 @@ def main():
         print(f"Error: Missing columns in permutation output. Requires {required_cols}", file=sys.stderr)
         sys.exit(1)
 
-    # Map Chromosomes
-    m_mapped = m_annot.index.astype(str).get_indexer(output['mt_id'].astype(str))
-    g_mapped = g_annot.index.astype(str).get_indexer(output['gt_id'].astype(str))
 
-    if (m_mapped == -1).any() or (g_mapped == -1).any():
-        print("Error: Reported mt_id/gt_id missing from annotations.", file=sys.stderr)
+    try:
+        is_cis, is_trans, n_cis, n_trans = label_strata(output, m_annot, g_annot)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
-
-    m_chrom = m_annot.iloc[m_mapped]['chrom'].to_numpy()
-    g_chrom = g_annot.iloc[g_mapped]['chrom'].to_numpy()
 
     # -------------------------------------------------------------------------
     # Core Data Extraction
@@ -177,11 +189,8 @@ def main():
     df_val = args.df
 
     # Precise analytic ref
-    p_ana = 2.0 * scipy.stats.t.sf(np.abs(t), df_val)
+    p_ana = compute_analytic_p(t, df_val)
 
-    # Strata
-    is_cis = (m_chrom == g_chrom)
-    is_trans = ~is_cis
 
     # Bands
     is_bulk = (p_ana >= args.bulk_lo) & (p_ana <= args.bulk_hi)
@@ -190,6 +199,8 @@ def main():
     report = {
         "metadata": {
             "n_pairs": len(t),
+            "n_cis": n_cis,
+            "n_trans": n_trans,
             "df": df_val,
             "bulk_lo": args.bulk_lo,
             "bulk_hi": args.bulk_hi,
@@ -204,11 +215,11 @@ def main():
     calib = {}
 
     # all
-    calib['all'] = compute_calibration_stats(t, p_perm, df_val, p_ana, is_bulk, is_tail)
+    calib['all'] = compute_calibration_stats(t, p_perm, p_ana, is_bulk, is_tail)
     # cis
-    calib['cis'] = compute_calibration_stats(t[is_cis], p_perm[is_cis], df_val, p_ana[is_cis], is_bulk[is_cis], is_tail[is_cis])
+    calib['cis'] = compute_calibration_stats(t[is_cis], p_perm[is_cis], p_ana[is_cis], is_bulk[is_cis], is_tail[is_cis])
     # trans
-    calib['trans'] = compute_calibration_stats(t[is_trans], p_perm[is_trans], df_val, p_ana[is_trans], is_bulk[is_trans], is_tail[is_trans])
+    calib['trans'] = compute_calibration_stats(t[is_trans], p_perm[is_trans], p_ana[is_trans], is_bulk[is_trans], is_tail[is_trans])
 
     # Downsampled QQ Data (All)
     n_qq = min(len(t), 5000)


### PR DESCRIPTION
Implements the Phase 3 scaffold `tools/eval_permute.py` and its accompanying test suite. The new script is a standalone diagnostic utility that consumes output generated by `qr_permute` without needing `torch`. It parses annotations, constructs a `cis`/`trans` stratum mask via pandas, and produces a JSON report that evaluates the data's deviation from an analytic reference, along with a recommendation for stratification.

---
*PR created automatically by Jules for task [773489949961422833](https://jules.google.com/task/773489949961422833) started by @kordk*