### PR TITLE
feat: make qr_permute invocable from the CLI with real BED6 annotations at --all

### DIFF
--- a/docs/mlr_qr_permute.md
+++ b/docs/mlr_qr_permute.md
@@ -143,7 +143,7 @@ Each reported pair carries `mt_id`, `gt_id`, the observed statistic `mt_t`, the 
 
 `tecpg_perm_n_reported` records the **pre-threshold** universe size. This matters: scoring computes a p for every reported pair, but an optional `output_p_threshold` writes only pairs at or below a cutoff (genome scale cannot materialize `~2e10` rows). The default writes **all** reported pairs, preserving the full FDR universe on disk; when a threshold is used, `tecpg_perm_n_reported` is what keeps a downstream BH-FDR correction honest about the universe it was drawn from (Phase 4).
 
-> **Two current gaps.** (i) The metadata keys are written on the **parquet** path only — a CSV run keeps the `seed` and `n_perm` *columns* but loses `n_reported`, so a thresholded CSV artifact cannot reconstruct its FDR universe. Prefer parquet for permutation output. (ii) `output_p_threshold` is presently a function-level parameter and is **not exposed as a CLI flag**.
+> **One current gap.** (i) The metadata keys are written on the **parquet** path only — a CSV run keeps the `seed` and `n_perm` *columns* but loses `n_reported`, so a thresholded CSV artifact cannot reconstruct its FDR universe. Prefer parquet for permutation output.
 
 ---
 
@@ -213,6 +213,7 @@ Relevant options:
 - `--all` / `--cis` / `--distal` / `--trans` — coverage selection (the standard region flags); scoring stratum is derived per pair (§4).
 - `--subsample-mt-count` / `--subsample-g-count` — random loci selection for null estimation (§3.3).
 - `--seed` — permutation/subsample seed, recorded with the output.
+- `--output-p-threshold` — writes only pairs at or below this permutation p-value cutoff. Pre-threshold size is retained in metadata.
 
 **Annotations are required.** Because the null is chromosome-stratified (§3.4, §3.8), methylation and expression annotations must be supplied; running without them raises rather than silently producing an unstratified null.
 

--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -962,6 +962,15 @@ def corr(
     default=False,
     help='Call torch.cuda.empty_cache() after every gene chunk. Default is to only empty the cache under memory pressure (> 75% allocated). Useful on memory-constrained GPUs.',
 )
+@click.option(
+    '--output-p-threshold',
+    type=click.FloatRange(0, 1, min_open=True),
+    default=None,
+    show_default=True,
+    help='Filters which pairs are written (not which are scored). '
+    'The tecpg_perm_n_reported metadata will preserve the '
+    'pre-threshold universe. For qr_permute.',
+)
 @click.pass_context
 def mlr(
     ctx: click.Context,
@@ -982,6 +991,7 @@ def mlr(
     permutations: int,
     subsample_mt_count: Optional[int],
     subsample_g_count: Optional[int],
+    output_p_threshold: Optional[float],
     seed: int,
     permute_label_test: bool,
     compute_ig: bool,
@@ -1125,7 +1135,10 @@ def mlr(
                 meth_loci_per_chunk, host_profile,
             )
 
-    if region != 'all':
+    M_annot = None
+    G_annot = None
+
+    if region != 'all' or mlr_method == 'qr_permute':
         annot_path = os.path.join(data['root_path'], data['annot_dir'])
         M_annot = pandas.read_csv(
             os.path.join(annot_path, data['meth_annot']), sep=None, engine='python'
@@ -1284,8 +1297,8 @@ def mlr(
             M=M,
             G=G,
             C=C,
-            M_annot=M_annot if region != 'all' else None,
-            G_annot=G_annot if region != 'all' else None,
+            M_annot=M_annot,
+            G_annot=G_annot,
             region=region,
             window_base=window_base,
             downstream=downstream,
@@ -1296,6 +1309,7 @@ def mlr(
             seed=seed,
             output_file=output_file_path,
             output_format=output_format,
+            output_p_threshold=output_p_threshold,
             thermal_threshold=thermal_threshold,
             thermal_wait=thermal_wait,
             logger=logger

--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -1450,7 +1450,7 @@ def mlr_single(
 
     include = (not no_est, not no_err, not no_t, not no_p)
 
-    if region != 'all':
+    if region != 'all' or mlr_method == 'qr_permute':
         annot_path = os.path.join(data['root_path'], data['annot_dir'])
         M_annot = (
             pandas.read_csv(

--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -1450,7 +1450,7 @@ def mlr_single(
 
     include = (not no_est, not no_err, not no_t, not no_p)
 
-    if region != 'all' or mlr_method == 'qr_permute':
+    if region != 'all':
         annot_path = os.path.join(data['root_path'], data['annot_dir'])
         M_annot = (
             pandas.read_csv(

--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -18,6 +18,56 @@ N_BINS = 1000
 TOPK_CAPACITY = 10_000
 
 
+def _normalize_annotations(M_annot, G_annot, M, G, logger):
+    def map_chrom(s):
+        # Allow pass-through of integer columns
+        if pd.api.types.is_integer_dtype(s):
+            return s
+        s = s.astype('string').str.strip()
+        s = s
+        s = s.str.upper()
+        s = s.str.replace(r'^chr', '', regex=True, case=False)
+        num = pd.to_numeric(s, errors='coerce')
+        spec = s.map({'X': -1, 'Y': -2, 'MT': -3, 'M': -3})
+        return num.fillna(spec)
+
+    M_annot_n = M_annot.copy()
+    G_annot_n = G_annot.copy()
+
+    M_annot_n['chrom'] = map_chrom(M_annot_n['chrom'])
+    G_annot_n['chrom'] = map_chrom(G_annot_n['chrom'])
+
+    if hasattr(G_annot_n['strand'], "replace"):
+        G_annot_n['strand'] = pd.to_numeric(G_annot_n['strand'].replace({'+': 1, '-': -1}), errors='coerce')
+
+    M_annot_n = M_annot_n[['chrom', 'chromStart']]
+    G_annot_n = G_annot_n[['chrom', 'chromStart', 'strand']]
+
+    M_loci_before = len(M.index)
+    M_annot_n = M_annot_n.reindex(M.index).dropna()
+    logger.info(
+        'Drop site permute._normalize_annotations[M_annot]: dropped methylation loci with '
+        'missing/unmappable annotation: {0} -> {1} ({2} dropped)',
+        M_loci_before, len(M_annot_n), M_loci_before - len(M_annot_n)
+    )
+
+    G_loci_before = len(G.index)
+    G_annot_n = G_annot_n.reindex(G.index).dropna()
+    logger.info(
+        'Drop site permute._normalize_annotations[G_annot]: dropped gene expression loci with '
+        'missing/unmappable annotation: {0} -> {1} ({2} dropped)',
+        G_loci_before, len(G_annot_n), G_loci_before - len(G_annot_n)
+    )
+
+    if len(M_annot_n) == 0 or len(G_annot_n) == 0:
+        raise ValueError("Normalization dropped all loci on one or both axes.")
+
+    M_n = M.loc[M_annot_n.index]
+    G_n = G.loc[G_annot_n.index]
+
+    return M_annot_n, G_annot_n, M_n, G_n
+
+
 def _select_null_population(M, G, C, M_annot, G_annot, region,
                             window_base, downstream, upstream,
                             subsample_mt_count, subsample_g_count, seed, logger):
@@ -353,6 +403,8 @@ def tecpg_mlr_qr_permute(
         seed = int(np.random.SeedSequence().generate_state(1)[0])
         logger.info("No seed provided; generated seed={0} (recorded with outputs).", seed)
     seed = int(seed)
+
+    M_annot, G_annot, M, G = _normalize_annotations(M_annot, G_annot, M, G, logger)
 
     logger.info("Starting qr_permute with permutations={0}, seed={1}, output_file={2}", permutations, seed, output_file)
 

--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -24,9 +24,8 @@ def _normalize_annotations(M_annot, G_annot, M, G, logger):
         if pd.api.types.is_integer_dtype(s):
             return s
         s = s.astype('string').str.strip()
-        s = s
-        s = s.str.upper()
         s = s.str.replace(r'^chr', '', regex=True, case=False)
+        s = s.str.upper()
         num = pd.to_numeric(s, errors='coerce')
         spec = s.map({'X': -1, 'Y': -2, 'MT': -3, 'M': -3})
         return num.fillna(spec)
@@ -37,27 +36,28 @@ def _normalize_annotations(M_annot, G_annot, M, G, logger):
     M_annot_n['chrom'] = map_chrom(M_annot_n['chrom'])
     G_annot_n['chrom'] = map_chrom(G_annot_n['chrom'])
 
-    if hasattr(G_annot_n['strand'], "replace"):
-        G_annot_n['strand'] = pd.to_numeric(G_annot_n['strand'].replace({'+': 1, '-': -1}), errors='coerce')
+    G_annot_n['strand'] = pd.to_numeric(G_annot_n['strand'].replace({'+': 1, '-': -1}), errors='coerce')
 
     M_annot_n = M_annot_n[['chrom', 'chromStart']]
     G_annot_n = G_annot_n[['chrom', 'chromStart', 'strand']]
 
     M_loci_before = len(M.index)
     M_annot_n = M_annot_n.reindex(M.index).dropna()
-    logger.info(
-        'Drop site permute._normalize_annotations[M_annot]: dropped methylation loci with '
-        'missing/unmappable annotation: {0} -> {1} ({2} dropped)',
-        M_loci_before, len(M_annot_n), M_loci_before - len(M_annot_n)
-    )
+    if M_loci_before != len(M_annot_n):
+        logger.info(
+            'Drop site permute._normalize_annotations[M_annot]: dropped methylation loci with '
+            'missing/unmappable annotation: {0} -> {1} ({2} dropped)',
+            M_loci_before, len(M_annot_n), M_loci_before - len(M_annot_n)
+        )
 
     G_loci_before = len(G.index)
     G_annot_n = G_annot_n.reindex(G.index).dropna()
-    logger.info(
-        'Drop site permute._normalize_annotations[G_annot]: dropped gene expression loci with '
-        'missing/unmappable annotation: {0} -> {1} ({2} dropped)',
-        G_loci_before, len(G_annot_n), G_loci_before - len(G_annot_n)
-    )
+    if G_loci_before != len(G_annot_n):
+        logger.info(
+            'Drop site permute._normalize_annotations[G_annot]: dropped gene expression loci with '
+            'missing/unmappable annotation: {0} -> {1} ({2} dropped)',
+            G_loci_before, len(G_annot_n), G_loci_before - len(G_annot_n)
+        )
 
     if len(M_annot_n) == 0 or len(G_annot_n) == 0:
         raise ValueError("Normalization dropped all loci on one or both axes.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 from tecpg.test_data import generate_data
 
 @pytest.fixture
@@ -12,4 +13,40 @@ def annotated_fixture():
         G_annot["strand"] = G_annot["strand"].replace({"+": 1, "-": -1})
         G_annot[["chrom", "chromStart", "strand"]] = G_annot[["chrom", "chromStart", "strand"]].astype(int)
         return M, G, C, M_annot, G_annot
+    return _make
+
+
+@pytest.fixture
+def cli_shaped_annotated_fixture():
+    def _make(sample_size, m_rows, g_rows, seed=42):
+        M, G, C, M_annot, G_annot = generate_data(sample_size, m_rows, g_rows,
+                                                   annotation=True, seed=seed)
+
+        # Simulating the raw format handed by the CLI parser:
+        # strings with chr-prefix, extra columns, some missing/X/Y mappings
+        M_annot_raw = pd.DataFrame(index=M_annot['name'])
+        M_annot_raw['chrom'] = ['chr19'] * len(M_annot_raw)
+        if len(M_annot_raw) > 0:
+            M_annot_raw.loc[M_annot_raw.index[0], 'chrom'] = 'chrX'
+        if len(M_annot_raw) > 1:
+            M_annot_raw.loc[M_annot_raw.index[1], 'chrom'] = float('nan') # dropped
+
+        M_annot_raw['chromStart'] = range(len(M_annot_raw))
+        M_annot_raw['chromEnd'] = range(len(M_annot_raw))
+        M_annot_raw['score'] = 0
+        M_annot_raw['strand'] = '+'
+
+        G_annot_raw = pd.DataFrame(index=G_annot['name'])
+        G_annot_raw['chrom'] = ['chr19'] * len(G_annot_raw)
+        if len(G_annot_raw) > 0:
+            G_annot_raw.loc[G_annot_raw.index[0], 'chrom'] = 'chrY'
+        if len(G_annot_raw) > 1:
+            G_annot_raw.loc[G_annot_raw.index[1], 'chrom'] = 'GL000220.1' # unmappable, dropped
+
+        G_annot_raw['chromStart'] = range(len(G_annot_raw))
+        G_annot_raw['chromEnd'] = range(len(G_annot_raw))
+        G_annot_raw['score'] = 0
+        G_annot_raw['strand'] = ['-'] * len(G_annot_raw)
+
+        return M, G, C, M_annot_raw, G_annot_raw
     return _make

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,12 +24,14 @@ def cli_shaped_annotated_fixture():
 
         # Simulating the raw format handed by the CLI parser:
         # strings with chr-prefix, extra columns, some missing/X/Y mappings
+        # M chroms: ['chr1', 'chr2', 'chrX', nan, 'chr7'] ... repeating if > 5
+        # G chroms: ['chr1', 'chr7', 'chrY', 'GL000220.1', 'chr2'] ... repeating if > 5
+
+        M_chroms_cycle = ['chr1', 'chr2', 'chrX', float('nan'), 'chr7']
+        G_chroms_cycle = ['chr1', 'chr7', 'chrY', 'GL000220.1', 'chr2']
+
         M_annot_raw = pd.DataFrame(index=M_annot['name'])
-        M_annot_raw['chrom'] = ['chr19'] * len(M_annot_raw)
-        if len(M_annot_raw) > 0:
-            M_annot_raw.loc[M_annot_raw.index[0], 'chrom'] = 'chrX'
-        if len(M_annot_raw) > 1:
-            M_annot_raw.loc[M_annot_raw.index[1], 'chrom'] = float('nan') # dropped
+        M_annot_raw['chrom'] = [M_chroms_cycle[i % 5] for i in range(len(M_annot_raw))]
 
         M_annot_raw['chromStart'] = range(len(M_annot_raw))
         M_annot_raw['chromEnd'] = range(len(M_annot_raw))
@@ -37,11 +39,7 @@ def cli_shaped_annotated_fixture():
         M_annot_raw['strand'] = '+'
 
         G_annot_raw = pd.DataFrame(index=G_annot['name'])
-        G_annot_raw['chrom'] = ['chr19'] * len(G_annot_raw)
-        if len(G_annot_raw) > 0:
-            G_annot_raw.loc[G_annot_raw.index[0], 'chrom'] = 'chrY'
-        if len(G_annot_raw) > 1:
-            G_annot_raw.loc[G_annot_raw.index[1], 'chrom'] = 'GL000220.1' # unmappable, dropped
+        G_annot_raw['chrom'] = [G_chroms_cycle[i % 5] for i in range(len(G_annot_raw))]
 
         G_annot_raw['chromStart'] = range(len(G_annot_raw))
         G_annot_raw['chromEnd'] = range(len(G_annot_raw))

--- a/tests/test_permute_annotations.py
+++ b/tests/test_permute_annotations.py
@@ -120,30 +120,43 @@ def test_end_to_end_permute(cli_shaped_annotated_fixture, tmp_path):
     assert df['perm_mt_p'].max() <= 1
     assert df['perm_mt_p'].isna().sum() == 0
 
+def test_drop_and_trim_trans_mask_oracle(cli_shaped_annotated_fixture):
+    """Test decisive alignment assertion on stratum"""
+    from tecpg.permute import _compute_trans_mask
+    M, G, C, M_annot, G_annot = cli_shaped_annotated_fixture(10, 5, 5)
 
+    logger = Logger()
+    M_annot_n, G_annot_n, M_n, G_n = _normalize_annotations(M_annot, G_annot, M, G, logger)
 
+    m_idx = M_n.index.astype(str)
+    g_idx = G_n.index.astype(str)
 
+    reported_pairs = pd.MultiIndex.from_product([m_idx, g_idx], names=['mt_id', 'gt_id']).to_frame(index=False)
 
+    trans_mask = _compute_trans_mask(reported_pairs, M_annot_n, G_annot_n, 'trans', window_base=1000, downstream=1000, upstream=1000, logger=logger)
 
+    # Fixture M cycle: chr1 (i=0), chr2 (i=1), chrX (i=2), nan (i=3) [dropped], chr7 (i=4)
+    # Fixture G cycle: chr1 (i=0), chr7 (i=1), chrY (i=2), GL000220.1 (i=3) [dropped], chr2 (i=4)
+    # Both arrays dropped index 3.
+    # M remaining indices: cg001 (chr1), cg002 (chr2), cg003 (chrX), cg005 (chr7).
+    # G remaining indices: ILMN_001 (chr1), ILMN_002 (chr7), ILMN_003 (chrY), ILMN_005 (chr2).
+    # cg001_ILMN_001 -> cis (chr1 == chr1)
+    # cg002_ILMN_005 -> cis (chr2 == chr2)
+    # cg005_ILMN_002 -> cis (chr7 == chr7)
+    # All others are trans.
 
+    cis_pairs = set([
+        (m_idx[0], g_idx[0]),
+        (m_idx[1], g_idx[3]),
+        (m_idx[3], g_idx[1])
+    ])
 
+    expected_trans_mask = np.array([
+        (row['mt_id'], row['gt_id']) not in cis_pairs
+        for _, row in reported_pairs.iterrows()
+    ], dtype=bool)
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+    np.testing.assert_array_equal(trans_mask, expected_trans_mask)
 
 def test_cli_regression():
     """7. CLI REGRESSION - exact pass-through assertions matrix"""
@@ -214,3 +227,35 @@ def test_cli_regression():
             assert isinstance(mock_qr_permute.call_args.kwargs['M_annot'], pd.DataFrame)
             assert isinstance(mock_qr_permute.call_args.kwargs['G_annot'], pd.DataFrame)
             assert mock_qr_permute.call_args.kwargs['output_p_threshold'] == 0.05
+
+
+def test_end_to_end_permute_determinism(cli_shaped_annotated_fixture, tmp_path):
+    """8. DETERMINISM TEST"""
+    M, G, C, M_annot, G_annot = cli_shaped_annotated_fixture(10, 5, 5)
+    logger = Logger()
+
+    output_file1 = str(tmp_path / "output1.csv")
+    tecpg_mlr_qr_permute(
+        M=M, G=G, C=C,
+        M_annot=M_annot, G_annot=G_annot,
+        region='all',
+        permutations=10,
+        seed=42,
+        output_file=output_file1,
+        logger=logger
+    )
+    df1 = pd.read_csv(output_file1)
+
+    output_file2 = str(tmp_path / "output2.csv")
+    tecpg_mlr_qr_permute(
+        M=M, G=G, C=C,
+        M_annot=M_annot, G_annot=G_annot,
+        region='all',
+        permutations=10,
+        seed=42,
+        output_file=output_file2,
+        logger=logger
+    )
+    df2 = pd.read_csv(output_file2)
+
+    pd.testing.assert_series_equal(df1['perm_mt_p'], df2['perm_mt_p'])

--- a/tests/test_permute_annotations.py
+++ b/tests/test_permute_annotations.py
@@ -1,0 +1,155 @@
+import pytest
+import pandas as pd
+import numpy as np
+from tecpg.permute import _normalize_annotations, tecpg_mlr_qr_permute
+from tecpg.logger import Logger
+from tecpg.cli import mlr
+from click.testing import CliRunner
+import os
+
+def test_chrom_coding_oracle():
+    """1. ORACLE — chrom coding"""
+    logger = Logger()
+    M_annot = pd.DataFrame({
+        'chrom': ['chr19', '19', 19, 19.0, 'chrX', 'X', 'chrY', 'x', float('nan'), 'GL000220.1'],
+        'chromStart': range(10)
+    }, index=[f'm{i}' for i in range(10)])
+    G_annot = pd.DataFrame({
+        'chrom': ['chr19'] * 10,
+        'chromStart': range(10),
+        'strand': ['+'] * 10
+    }, index=[f'g{i}' for i in range(10)])
+    M = pd.DataFrame(np.random.rand(10, 5), index=M_annot.index)
+    G = pd.DataFrame(np.random.rand(10, 5), index=G_annot.index)
+
+    M_annot_n, G_annot_n, M_n, G_n = _normalize_annotations(M_annot, G_annot, M, G, logger)
+
+    assert M_annot_n.loc['m0', 'chrom'] == 19
+    assert M_annot_n.loc['m1', 'chrom'] == 19
+    assert M_annot_n.loc['m2', 'chrom'] == 19
+    assert M_annot_n.loc['m3', 'chrom'] == 19
+    assert M_annot_n.loc['m4', 'chrom'] == -1
+    assert M_annot_n.loc['m5', 'chrom'] == -1
+    assert M_annot_n.loc['m6', 'chrom'] == -2
+    assert M_annot_n.loc['m7', 'chrom'] == -1
+    assert 'm8' not in M_annot_n.index
+    assert 'm9' not in M_annot_n.index
+
+    # integer exactness
+    assert pd.api.types.is_integer_dtype(M_annot_n['chrom'].astype(int))
+
+def test_qr_code_parity():
+    """2. ORACLE — qr-code parity"""
+    logger = Logger()
+    M_annot = pd.DataFrame({'chrom': ['chrX', 'chrY'], 'chromStart': [0, 1]}, index=['m1', 'm2'])
+    G_annot = pd.DataFrame({'chrom': ['chrX', 'chrY'], 'chromStart': [0, 1], 'strand': ['+', '-']}, index=['g1', 'g2'])
+    M = pd.DataFrame(np.random.rand(2, 5), index=M_annot.index)
+    G = pd.DataFrame(np.random.rand(2, 5), index=G_annot.index)
+
+    M_annot_n, G_annot_n, M_n, G_n = _normalize_annotations(M_annot, G_annot, M, G, logger)
+
+    assert M_annot_n.loc['m1', 'chrom'] == -1
+    assert M_annot_n.loc['m2', 'chrom'] == -2
+    assert G_annot_n.loc['g1', 'chrom'] == -1
+    assert G_annot_n.loc['g2', 'chrom'] == -2
+
+def test_idempotence(annotated_fixture):
+    """3. IDEMPOTENCE"""
+    logger = Logger()
+    M, G, _, M_annot, G_annot = annotated_fixture(10, 5, 5)
+
+    M_annot_n, G_annot_n, M_n, G_n = _normalize_annotations(M_annot, G_annot, M, G, logger)
+
+    pd.testing.assert_frame_equal(M_annot_n, M_annot, check_names=False)
+    pd.testing.assert_frame_equal(G_annot_n, G_annot, check_names=False)
+    pd.testing.assert_frame_equal(M_n, M)
+    pd.testing.assert_frame_equal(G_n, G)
+
+def test_drop_and_trim(cli_shaped_annotated_fixture):
+    """4. DROP + TRIM"""
+    logger = Logger()
+    M, G, _, M_annot, G_annot = cli_shaped_annotated_fixture(10, 5, 5)
+
+    # 5 M rows, 1 dropped (NaN chrom). 5 G rows, 1 dropped (GL000220.1)
+    M_annot_n, G_annot_n, M_n, G_n = _normalize_annotations(M_annot, G_annot, M, G, logger)
+
+    assert len(M_annot_n) == 4
+    assert len(G_annot_n) == 4
+
+    assert M_annot_n.index.equals(M_n.index)
+    assert G_annot_n.index.equals(G_n.index)
+
+def test_fail_closed():
+    """5. FAIL-CLOSED"""
+    logger = Logger()
+    M_annot = pd.DataFrame({'chrom': [float('nan'), float('nan')], 'chromStart': [0, 1]}, index=['m1', 'm2'])
+    G_annot = pd.DataFrame({'chrom': ['chr19', 'chr19'], 'chromStart': [0, 1], 'strand': ['+', '-']}, index=['g1', 'g2'])
+    M = pd.DataFrame(np.random.rand(2, 5), index=M_annot.index)
+    G = pd.DataFrame(np.random.rand(2, 5), index=G_annot.index)
+
+    with pytest.raises(ValueError, match="Normalization dropped all loci on one or both axes."):
+        _normalize_annotations(M_annot, G_annot, M, G, logger)
+
+def test_end_to_end_permute(cli_shaped_annotated_fixture, tmp_path):
+    """6. END-TO-END"""
+    M, G, C, M_annot, G_annot = cli_shaped_annotated_fixture(10, 5, 5)
+
+    output_file = str(tmp_path / "output.csv")
+
+    logger = Logger()
+
+    # Running permute
+    tecpg_mlr_qr_permute(
+        M=M, G=G, C=C,
+        M_annot=M_annot, G_annot=G_annot,
+        region='all',
+        permutations=10,
+        seed=42,
+        output_file=output_file,
+        logger=logger
+    )
+
+    assert os.path.exists(output_file)
+    df = pd.read_csv(output_file)
+
+    # Expected rows: 4 * 4 = 16 (since 1 dropped from each axis)
+    assert len(df) == 16
+
+    assert set(df.columns) == {'mt_id', 'gt_id', 'mt_t', 'perm_mt_p', 'seed', 'n_perm'}
+    assert df['perm_mt_p'].min() > 0
+    assert df['perm_mt_p'].max() <= 1
+    assert df['perm_mt_p'].isna().sum() == 0
+
+
+def test_cli_regression():
+    """7. CLI REGRESSION - test qr method behavior unchanged at --all and --cis"""
+    runner = CliRunner()
+    # just basic smoke test ensuring we get correct help text or errors
+    result = runner.invoke(mlr, ['--mlr-method', 'qr', '--all', '--help'])
+    assert result.exit_code == 0
+
+def test_drop_and_trim_trans_mask_oracle(cli_shaped_annotated_fixture):
+    """Test decisive alignment assertion on stratum"""
+    from tecpg.permute import _compute_trans_mask
+    M, G, C, M_annot, G_annot = cli_shaped_annotated_fixture(10, 5, 5)
+
+    logger = Logger()
+    M_annot_n, G_annot_n, M_n, G_n = _normalize_annotations(M_annot, G_annot, M, G, logger)
+
+    m_idx = M_n.index.astype(str)
+    g_idx = G_n.index.astype(str)
+
+    reported_pairs = pd.MultiIndex.from_product([m_idx, g_idx], names=['mt_id', 'gt_id']).to_frame(index=False)
+
+    trans_mask = _compute_trans_mask(reported_pairs, M_annot_n, G_annot_n, 'trans', window_base=1000, downstream=1000, upstream=1000, logger=logger)
+
+    # We constructed the cli-shaped fixture such that one has chrom=chrX -> -1, another has chrY -> -2
+    # For a trans mask between chrom -1 and -2, it should be True
+    # The expected mask should match exactly what we anticipate from the hand-known strata
+    # To check the specific mask exactly:
+    m_chroms = M_annot_n.loc[reported_pairs['mt_id'], 'chrom'].values
+    g_chroms = G_annot_n.loc[reported_pairs['gt_id'], 'chrom'].values
+
+    expected_trans_mask = (m_chroms != g_chroms)
+
+    np.testing.assert_array_equal(trans_mask, expected_trans_mask)

--- a/tests/test_permute_annotations.py
+++ b/tests/test_permute_annotations.py
@@ -121,35 +121,96 @@ def test_end_to_end_permute(cli_shaped_annotated_fixture, tmp_path):
     assert df['perm_mt_p'].isna().sum() == 0
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 def test_cli_regression():
-    """7. CLI REGRESSION - test qr method behavior unchanged at --all and --cis"""
+    """7. CLI REGRESSION - exact pass-through assertions matrix"""
+    from click.testing import CliRunner
+    from unittest.mock import patch
+    import os
+    import json
+    from tecpg.cli import cli
+    from tecpg.logger import Logger
+
     runner = CliRunner()
-    # just basic smoke test ensuring we get correct help text or errors
-    result = runner.invoke(mlr, ['--mlr-method', 'qr', '--all', '--help'])
-    assert result.exit_code == 0
+    with runner.isolated_filesystem():
+        cwd = os.getcwd()
 
-def test_drop_and_trim_trans_mask_oracle(cli_shaped_annotated_fixture):
-    """Test decisive alignment assertion on stratum"""
-    from tecpg.permute import _compute_trans_mask
-    M, G, C, M_annot, G_annot = cli_shaped_annotated_fixture(10, 5, 5)
+        # Setup dummy filesystem for CLI
+        os.makedirs(os.path.join(cwd, 'data'), exist_ok=True)
+        os.makedirs(os.path.join(cwd, 'annot'), exist_ok=True)
+        os.makedirs(os.path.join(cwd, 'output'), exist_ok=True)
 
-    logger = Logger()
-    M_annot_n, G_annot_n, M_n, G_n = _normalize_annotations(M_annot, G_annot, M, G, logger)
+        # Tiny valid datasets
+        pd.DataFrame({'a': [1,2], 'b': [3,4]}, index=['m1', 'm2']).to_csv(os.path.join(cwd, 'data/M.csv'))
+        pd.DataFrame({'a': [1,2], 'b': [3,4]}, index=['g1', 'g2']).to_csv(os.path.join(cwd, 'data/G.csv'))
+        pd.DataFrame({'c': [1,2]}).to_csv(os.path.join(cwd, 'data/C.csv'), index=False)
 
-    m_idx = M_n.index.astype(str)
-    g_idx = G_n.index.astype(str)
+        # Minimal BED6 annotations
+        bed6_content = "chrom\tchromStart\tchromEnd\tname\tscore\tstrand\nchr1\t1\t2\tm1\t0\t+\nchr1\t1\t2\tm2\t0\t+\n"
+        with open(os.path.join(cwd, 'annot/M.bed6'), 'w') as f: f.write(bed6_content)
+        bed6_content_g = "chrom\tchromStart\tchromEnd\tname\tscore\tstrand\nchr1\t1\t2\tg1\t0\t+\nchr1\t1\t2\tg2\t0\t+\n"
+        with open(os.path.join(cwd, 'annot/G.bed6'), 'w') as f: f.write(bed6_content_g)
 
-    reported_pairs = pd.MultiIndex.from_product([m_idx, g_idx], names=['mt_id', 'gt_id']).to_frame(index=False)
+        # Mock targets
+        with patch('tecpg.cli.tecpg_mlr_qr') as mock_qr, \
+             patch('tecpg.permute.tecpg_mlr_qr_permute') as mock_qr_permute, \
+             patch('tecpg.cli.read_dataframes') as mock_read:
 
-    trans_mask = _compute_trans_mask(reported_pairs, M_annot_n, G_annot_n, 'trans', window_base=1000, downstream=1000, upstream=1000, logger=logger)
+            # Make the dataframes loader return our mocked ones seamlessly without global config messing up
+            mock_read.return_value = {
+                "M.csv": pd.DataFrame({'a': [1,2], 'b': [3,4]}, index=['m1', 'm2']),
+                "G.csv": pd.DataFrame({'a': [1,2], 'b': [3,4]}, index=['g1', 'g2']),
+                "C.csv": pd.DataFrame({'c': [1,2]})
+            }
 
-    # We constructed the cli-shaped fixture such that one has chrom=chrX -> -1, another has chrY -> -2
-    # For a trans mask between chrom -1 and -2, it should be True
-    # The expected mask should match exactly what we anticipate from the hand-known strata
-    # To check the specific mask exactly:
-    m_chroms = M_annot_n.loc[reported_pairs['mt_id'], 'chrom'].values
-    g_chroms = G_annot_n.loc[reported_pairs['gt_id'], 'chrom'].values
+            # Test 1: qr + --all
+            # The top-level group is 'cli', then 'run', then 'mlr'
+            result1 = runner.invoke(cli, ['--root-path', cwd, 'run', 'mlr', '--mlr-method', 'qr', '--all'])
+            if result1.exit_code != 0:
+                print(result1.output)
+            assert result1.exit_code == 0, f"Failed: {result1.exception}"
+            assert mock_qr.call_args.kwargs['M_annot'] is None
+            assert mock_qr.call_args.kwargs['G_annot'] is None
 
-    expected_trans_mask = (m_chroms != g_chroms)
+            # Test 2: qr + --cis
+            result2 = runner.invoke(cli, ['--root-path', cwd, 'run', 'mlr', '--mlr-method', 'qr', '--cis'])
+            assert result2.exit_code == 0, f"Failed: {result2.exception}"
+            assert isinstance(mock_qr.call_args.kwargs['M_annot'], pd.DataFrame)
+            assert isinstance(mock_qr.call_args.kwargs['G_annot'], pd.DataFrame)
 
-    np.testing.assert_array_equal(trans_mask, expected_trans_mask)
+            # Test 3: qr_permute + --all (The FACT-1 fix)
+            result3 = runner.invoke(cli, ['--root-path', cwd, 'run', 'mlr', '--mlr-method', 'qr_permute', '--all'])
+            assert result3.exit_code == 0, f"Failed: {result3.exception}"
+            assert isinstance(mock_qr_permute.call_args.kwargs['M_annot'], pd.DataFrame)
+            assert isinstance(mock_qr_permute.call_args.kwargs['G_annot'], pd.DataFrame)
+            assert mock_qr_permute.call_args.kwargs['output_p_threshold'] is None
+
+            # Test 4: qr_permute + --cis + --output-p-threshold
+            result4 = runner.invoke(cli, ['--root-path', cwd, 'run', 'mlr', '--mlr-method', 'qr_permute', '--cis', '--output-p-threshold', '0.05'])
+            assert result4.exit_code == 0, f"Failed: {result4.exception}"
+            assert isinstance(mock_qr_permute.call_args.kwargs['M_annot'], pd.DataFrame)
+            assert isinstance(mock_qr_permute.call_args.kwargs['G_annot'], pd.DataFrame)
+            assert mock_qr_permute.call_args.kwargs['output_p_threshold'] == 0.05


### PR DESCRIPTION
Implemented BED6 raw annotation ingestion to support running `qr_permute` at region `--all`. Fixed `qr_permute` early failing at `--all` when processing comprehensive chromosome prefixed annotations. Mapped `--output-p-threshold` dynamically. Cleaned up dependencies and integrated fail-closed validations properly into regression suites.

---
*PR created automatically by Jules for task [16227600084633690288](https://jules.google.com/task/16227600084633690288) started by @kordk*