### PR TITLE
Fix `eval_permute` annotation loading separators and implement NaN-chrom drop policy

### DIFF
--- a/tests/test_eval_permute.py
+++ b/tests/test_eval_permute.py
@@ -264,7 +264,9 @@ def test_canon_chrom_preserves_nan():
     assert pd.isna(res_list[1])
     assert res_list[2] == '2'
     assert res_list[3] == 'X'
-    assert res[1] != 'nan'
+    # pd.NA != 'nan' evaluates to pd.NA, which raises TypeError when asserted.
+    # We just want to ensure it is not the string 'nan'.
+    assert not (isinstance(res[1], str) and res[1] == 'nan')
 
 def test_label_strata_all_dropped_fails_closed():
     m_annot = pd.DataFrame({'name': ['m1', 'm2'], 'chrom': [None, 1]}).set_index('name')

--- a/tests/test_eval_permute.py
+++ b/tests/test_eval_permute.py
@@ -194,11 +194,186 @@ def test_label_strata_value_error():
 
 
 def test_label_strata_nan_chrom():
-    m_annot = pd.DataFrame({'name': ['m1'], 'chrom': [None]}).set_index('name')
-    g_annot = pd.DataFrame({'name': ['g1'], 'chrom': [1]}).set_index('name')
-    output = pd.DataFrame({'mt_id': ['m1'], 'gt_id': ['g1']})
-    with pytest.raises(ValueError, match="NaN chromosome in annotation"):
+    m_annot = pd.DataFrame({'name': ['m1', 'm2', 'm3', 'm4'], 'chrom': [1, 2, None, 4]}).set_index('name')
+    g_annot = pd.DataFrame({'name': ['g1', 'g2', 'g3', 'g4'], 'chrom': [1, 3, 3, None]}).set_index('name')
+    output = pd.DataFrame({'mt_id': ['m1', 'm2', 'm3', 'm4'], 'gt_id': ['g1', 'g2', 'g3', 'g4']})
+    keep, is_cis, is_trans, n_cis, n_trans, n_dropped = ep.label_strata(output, m_annot, g_annot)
+
+    assert n_dropped == 2
+    assert keep.tolist() == [True, True, False, False]
+    assert n_cis == 1
+    assert n_trans == 1
+
+def test_load_annotation_real_bed6_shape(tmp_path):
+    annot_path = tmp_path / "real_bed6.bed"
+    with open(annot_path, "w") as f:
+        f.write("chrom\tchromStart\tchromEnd\tname\tscore\tstrand\n")
+        f.write("chr1\t1\t100\tm1\t0\t+\n")
+        f.write("chr2\t101\t200\tm2\t0\t+\n")
+        f.write("chr3\t201\t300\tm3\t0\t+\n")
+        f.write("chr4\t301\t400\tm4\t0\t+\n")
+        f.write("chr5\t401\t500\tm5\t0\t+\n")
+        f.write("\t501\t600\tm6\t0\t+\n") # Empty chrom
+
+    annot = ep._load_annotation(str(annot_path), "test")
+    assert annot.shape == (6, 5)
+    assert list(annot.columns) == ['chrom', 'chromStart', 'chromEnd', 'score', 'strand']
+    assert annot.index.name == 'name'
+
+def test_load_annotation_bare_int_fallback(tmp_path):
+    annot_path = tmp_path / "bare_int.bed"
+    with open(annot_path, "w") as f:
+        f.write("chrom\tchromStart\tchromEnd\tname\tscore\tstrand\n")
+        f.write("1\t1\t100\tm1\t0\t+\n")
+        f.write("2\t101\t200\tm2\t0\t+\n")
+        f.write("3\t201\t300\tm3\t0\t+\n")
+        f.write("4\t301\t400\tm4\t0\t+\n")
+        f.write("5\t401\t500\tm5\t0\t+\n")
+        f.write("\t501\t600\tm6\t0\t+\n") # Empty chrom
+
+    annot = ep._load_annotation(str(annot_path), "test")
+    assert annot.shape == (6, 5)
+    assert list(annot.columns) == ['chrom', 'chromStart', 'chromEnd', 'score', 'strand']
+    assert annot.index.name == 'name'
+
+def test_load_annotation_missing_name_column_fails_closed(tmp_path):
+    annot_path = tmp_path / "bad.csv"
+    with open(annot_path, "w") as f:
+        f.write("chrom,chromStart,chromEnd,score,strand\n")
+        f.write("chr1,1,100,0,+\n")
+
+    with pytest.raises(ValueError, match="has no 'name' column") as excinfo:
+        ep._load_annotation(str(annot_path), "test")
+    assert "separator mismatch" in str(excinfo.value)
+
+def test_load_annotation_duplicate_names_fails_closed(tmp_path):
+    annot_path = tmp_path / "dup.bed"
+    with open(annot_path, "w") as f:
+        f.write("chrom\tchromStart\tchromEnd\tname\tscore\tstrand\n")
+        f.write("chr1\t1\t100\tm1\t0\t+\n")
+        f.write("chr2\t101\t200\tm1\t0\t+\n")
+
+    with pytest.raises(ValueError, match="is not unique") as excinfo:
+        ep._load_annotation(str(annot_path), "test")
+    assert "(1 duplicated names)" in str(excinfo.value)
+
+def test_canon_chrom_preserves_nan():
+    res = ep._canon_chrom(['chr1', np.nan, '2.0', 'X'], "test")
+    res_list = res.tolist()
+    assert res_list[0] == '1'
+    assert pd.isna(res_list[1])
+    assert res_list[2] == '2'
+    assert res_list[3] == 'X'
+    assert res[1] != 'nan'
+
+def test_label_strata_all_dropped_fails_closed():
+    m_annot = pd.DataFrame({'name': ['m1', 'm2'], 'chrom': [None, 1]}).set_index('name')
+    g_annot = pd.DataFrame({'name': ['g1', 'g2'], 'chrom': [1, None]}).set_index('name')
+    output = pd.DataFrame({'mt_id': ['m1', 'm2'], 'gt_id': ['g1', 'g2']})
+    with pytest.raises(ValueError, match="All reported pairs dropped"):
         ep.label_strata(output, m_annot, g_annot)
+
+def test_main_alignment_after_drop(tmp_path):
+    df_val = 50
+    m_annot = pd.DataFrame({'name': ['m1', 'm2', 'm3', 'm4'], 'chrom': [1, 2, None, 4]})
+    g_annot = pd.DataFrame({'name': ['g1', 'g2', 'g3', 'g4'], 'chrom': [1, 3, 3, None]})
+
+    m_annot_path = tmp_path / "m_annot.bed"
+    g_annot_path = tmp_path / "g_annot.bed"
+    m_annot.to_csv(m_annot_path, sep="\t", index=False)
+    g_annot.to_csv(g_annot_path, sep="\t", index=False)
+
+    t_vals = [2.0, -1.5, 999.0, 999.0]
+    p_perm = [0.05, 0.15, 0.0, 0.0]
+
+    output = pd.DataFrame({
+        'mt_id': ['m1', 'm2', 'm3', 'm4'],
+        'gt_id': ['g1', 'g2', 'g3', 'g4'],
+        'mt_t': t_vals,
+        'perm_mt_p': p_perm
+    })
+
+    out_path = tmp_path / "out.parquet"
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    pq.write_table(pa.Table.from_pandas(output), out_path)
+
+    out_dir = tmp_path / "dir"
+    script_path = os.path.join(os.path.dirname(__file__), "../tools/eval_permute.py")
+
+    subprocess.run([
+        "python", script_path,
+        "--perm-output", str(out_path),
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--df", str(df_val),
+        "--out-dir", str(out_dir)
+    ], check=True)
+
+    with open(out_dir / "eval_permute_report.json") as f:
+        rep = json.load(f)
+
+    assert rep['metadata']['n_pairs_input'] == 4
+    assert rep['metadata']['n_pairs_dropped_unmappable_chrom'] == 2
+    assert rep['metadata']['n_pairs_scored'] == 2
+    assert rep['metadata']['n_pairs_scored'] == rep['metadata']['n_cis'] + rep['metadata']['n_trans']
+
+    import scipy.stats
+    expected_p_ana = 2.0 * scipy.stats.t.sf(np.abs([2.0, -1.5]), df_val)
+    expected_neg_log = -np.log10(expected_p_ana)
+    actual_neg_log = rep['arms']['calibration']['qq_data']['neg_log10_p_ana']
+
+    assert np.allclose(actual_neg_log[:2], expected_neg_log[:2])
+
+def test_report_carries_drop_counts(tmp_path):
+    df_val = 50
+    m_annot = pd.DataFrame({'name': ['m1', 'm2'], 'chrom': [1, 2]})
+    g_annot = pd.DataFrame({'name': ['g1', 'g2'], 'chrom': [1, 3]})
+
+    m_annot_path = tmp_path / "m_annot.bed"
+    g_annot_path = tmp_path / "g_annot.bed"
+    m_annot.to_csv(m_annot_path, sep="\t", index=False)
+    g_annot.to_csv(g_annot_path, sep="\t", index=False)
+
+    t_vals = [2.0, -1.5]
+    p_perm = [0.05, 0.15]
+
+    output = pd.DataFrame({
+        'mt_id': ['m1', 'm2'],
+        'gt_id': ['g1', 'g2'],
+        'mt_t': t_vals,
+        'perm_mt_p': p_perm
+    })
+
+    out_path = tmp_path / "out.parquet"
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    pq.write_table(pa.Table.from_pandas(output), out_path)
+
+    out_dir = tmp_path / "dir"
+    script_path = os.path.join(os.path.dirname(__file__), "../tools/eval_permute.py")
+
+    subprocess.run([
+        "python", script_path,
+        "--perm-output", str(out_path),
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--df", str(df_val),
+        "--out-dir", str(out_dir)
+    ], check=True)
+
+    with open(out_dir / "eval_permute_report.json") as f:
+        rep = json.load(f)
+
+    assert 'n_pairs_input' in rep['metadata']
+    assert 'n_pairs_dropped_unmappable_chrom' in rep['metadata']
+    assert 'n_pairs_scored' in rep['metadata']
+    assert 'n_pairs' not in rep['metadata']
+
+    assert rep['metadata']['n_pairs_input'] == 2
+    assert rep['metadata']['n_pairs_dropped_unmappable_chrom'] == 0
+    assert rep['metadata']['n_pairs_scored'] == 2
+
 def test_stratify_decision_smoke(tmp_path):
     """
     Construct one synthetic case where cis == trans (expect "single_global_null_adequate")

--- a/tools/eval_permute.py
+++ b/tools/eval_permute.py
@@ -96,12 +96,13 @@ def compute_calibration_stats(t_vals, p_perm, p_ana, is_bulk, is_tail):
 
 def _canon_chrom(arr, which):
     s = pd.Series(arr)
-    if s.isna().any():
-        raise ValueError(f"{which}: NaN chromosome in annotation")
+    isna = s.isna()                # BEFORE astype(str) — afterwards NaN is 'nan' and isna() is blind
     s = s.astype(str).str.strip()
-    s = s.str.replace(r'\.0$', '', regex=True)              # 1.0 -> 1
+    s = s.str.replace(r'\.0$', '', regex=True)              # 1.0 -> 1  (pandas NA inference -> float64)
     s = s.str.replace(r'^chr', '', regex=True, case=False)  # chr1 -> 1
-    return s.str.upper().to_numpy()                         # x -> X
+    s = s.str.upper()                                       # x -> X
+    s = s.mask(isna, other=pd.NA)                           # restore NaN; never the string 'nan'
+    return s.to_numpy(dtype=object)
 
 def label_strata(output, m_annot, g_annot):
     m_mapped = m_annot.index.astype(str).get_indexer(output['mt_id'].astype(str))
@@ -113,17 +114,55 @@ def label_strata(output, m_annot, g_annot):
     m_chrom = _canon_chrom(m_annot.iloc[m_mapped]['chrom'].to_numpy(), 'm_annot')
     g_chrom = _canon_chrom(g_annot.iloc[g_mapped]['chrom'].to_numpy(), 'g_annot')
 
+    keep = ~(pd.isna(m_chrom) | pd.isna(g_chrom))
+    n_dropped = int((~keep).sum())
 
-    is_cis = (m_chrom == g_chrom)
-    is_trans = ~is_cis
+    if not keep.any():
+        raise ValueError(
+            "All reported pairs dropped: every pair has an unmappable chromosome "
+            "on at least one axis. Check that --m-annot/--g-annot match the run."
+        )
 
-    return is_cis, is_trans, int(is_cis.sum()), int(is_trans.sum())
+    is_cis = np.zeros(len(output), dtype=bool)
+    is_cis[keep] = (m_chrom[keep] == g_chrom[keep])
+    is_trans = keep & ~is_cis
+
+    return keep, is_cis, is_trans, int(is_cis.sum()), int(is_trans.sum()), n_dropped
 
 def calculate_genomic_inflation(t_vals):
     """Arm A.c: Genomic Inflation Lambda"""
     median_t_sq = np.median(t_vals**2)
     expected_median_chi2 = scipy.stats.chi2.ppf(0.5, 1)
     return float(median_t_sq / expected_median_chi2)
+
+def _load_annotation(path, which):
+    # tecpg convention: sniff the separator. BED6 is TAB; fallbacks may differ.
+    annot = pd.read_csv(path, sep=None, engine='python')
+
+    if 'name' not in annot.columns:
+        raise ValueError(
+            "{0}: annotation at {1} has no 'name' column; found columns {2}. "
+            "Expected a BED6 with header (chrom chromStart chromEnd name score strand). "
+            "A single mashed column indicates a separator mismatch."
+            .format(which, path, list(annot.columns))
+        )
+    if 'chrom' not in annot.columns:
+        raise ValueError(
+            "{0}: annotation at {1} has no 'chrom' column; found columns {2}. "
+            "Expected a BED6 with header (chrom chromStart chromEnd name score strand). "
+            "A single mashed column indicates a separator mismatch."
+            .format(which, path, list(annot.columns))
+        )
+
+    annot = annot.set_index('name')
+
+    if not annot.index.is_unique:
+        n_dup = int(annot.index.duplicated().sum())
+        raise ValueError(
+            "{0}: annotation index is not unique ({1} duplicated names); "
+            "get_indexer requires a unique index.".format(which, n_dup)
+        )
+    return annot
 
 def main():
     parser = argparse.ArgumentParser(description="Phase 3 standalone read-only permutation-evaluation diagnostic")
@@ -157,14 +196,8 @@ def main():
         else:
             output = pd.read_csv(args.perm_output)
 
-        m_annot = pd.read_csv(args.m_annot)
-        g_annot = pd.read_csv(args.g_annot)
-
-        # Replicate annotated_fixture logic
-        if 'name' in m_annot.columns:
-            m_annot = m_annot.set_index('name')
-        if 'name' in g_annot.columns:
-            g_annot = g_annot.set_index('name')
+        m_annot = _load_annotation(args.m_annot, '--m-annot')
+        g_annot = _load_annotation(args.g_annot, '--g-annot')
 
     except Exception as e:
         print(f"Error loading inputs: {e}", file=sys.stderr)
@@ -179,12 +212,21 @@ def main():
         print(f"Error: Missing columns in permutation output. Requires {required_cols}", file=sys.stderr)
         sys.exit(1)
 
+    n_pairs_input = len(output)
 
     try:
-        is_cis, is_trans, n_cis, n_trans = label_strata(output, m_annot, g_annot)
+        keep, is_cis, is_trans, n_cis, n_trans, n_dropped = label_strata(output, m_annot, g_annot)
     except ValueError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
+
+    if n_dropped:
+        print("Drop site eval_permute.label_strata[reported_pairs]: dropped pairs with "
+              "unmappable chromosome: {0} -> {1} ({2} dropped)"
+              .format(n_pairs_input, int(keep.sum()), n_dropped), file=sys.stderr)
+        output = output.loc[keep].reset_index(drop=True)
+        is_cis = is_cis[keep]
+        is_trans = is_trans[keep]
 
     # -------------------------------------------------------------------------
     # Core Data Extraction
@@ -203,7 +245,9 @@ def main():
 
     report = {
         "metadata": {
-            "n_pairs": len(t),
+            "n_pairs_input": n_pairs_input,
+            "n_pairs_dropped_unmappable_chrom": n_dropped,
+            "n_pairs_scored": len(t),
             "n_cis": n_cis,
             "n_trans": n_trans,
             "df": df_val,


### PR DESCRIPTION
- The previous implementation silently skipped over valid annotations missing a `'name'` column when read with commas (as BED6 files are TAB-separated), leading to misattributed index mapping errors downstream. The new custom `_load_annotation` corrects this by sniffing separators using pandas and asserting presence of essential structural elements cleanly, preventing misdiagnosis.
- Corrected the application flow for string replacement in `_canon_chrom` to retain actual missing types like `pd.NA` for `NaN` chromosomes rather than allowing `.astype(str)` to convert it to the literal string `'nan'`.
- Implemented a drop-and-report policy within `eval_permute.py` allowing proper handling of `NaN` chromosomes during run calibration rather than halting entirely, reporting proper lengths in the updated structured JSON output.

---
*PR created automatically by Jules for task [18071138747726084454](https://jules.google.com/task/18071138747726084454) started by @kordk*