### PR TITLE
Refactor qr_permute Realignment to Consume Master Parquet

### DIFF
--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -1279,6 +1279,11 @@ def mlr(
         return
 
     if mlr_method == 'qr_permute':
+        if not master_parquet:
+            error = '--master-parquet is required for qr_permute.'
+            logger.error(error)
+            raise click.UsageError(error)
+
         from .permute import tecpg_mlr_qr_permute
 
         # The merged permute output is named `permutation_results.<ext>` by
@@ -1294,6 +1299,8 @@ def mlr(
             output_file_path = os.path.join(output_path, output_file_path)
 
         tecpg_mlr_qr_permute(
+            master_parquet=master_parquet,
+            pairs_file=pairs_file,
             M=M,
             G=G,
             C=C,

--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -406,20 +406,63 @@ def _fit_tail(empirical_p, observed_stats, null_accumulator, logger):
     return perm_mt_p
 
 
-def _finalize_output(reported_pairs, observed_stats, perm_mt_p, seed, n_perm,
+def _verify_master_consistency(M, G, C, universe, device, logger,
+                               *, n_sample=256, rtol=1e-4, atol=1e-4, seed=42):
+    """Sampled equivalence spot-check. Recompute the observed t for a small
+    random sample of master pairs from the provided M/G/C and assert it matches
+    the stored mt_t. Fail-closed on divergence (covariate design / df mismatch)
+    or on a sampled pair absent from M/G (wrong input files). O(sample), not
+    O(universe). Constants are provisional; a design mismatch produces O(1)+
+    divergences in t, so atol=1e-4 catches the hazard while absorbing the
+    float32/float64 gap between regression_full and the recompute."""
+    mt_t = universe['mt_t'].to_numpy(dtype=np.float64)
+    finite = np.isfinite(mt_t)
+    n_finite = int(finite.sum())
+    if n_finite == 0:
+        raise ValueError("master parquet has no finite mt_t to validate against")
+    idx_finite = np.flatnonzero(finite)
+    k = min(n_sample, n_finite)
+    rng = np.random.default_rng(seed)
+    pick = rng.choice(idx_finite, size=k, replace=False)
+    sample_pairs = universe.iloc[pick][['mt_id', 'gt_id']].reset_index(drop=True)
+    stored = mt_t[pick]
+    try:
+        recomputed = np.asarray(
+            _compute_observed_statistic(M, G, C, sample_pairs, logger, device=device),
+            dtype=np.float64,
+        )
+    except ValueError as e:
+        raise ValueError("master consistency check failed: a sampled master pair is "
+                         "absent from the provided M/G (likely wrong input files). " + str(e))
+    if not np.allclose(recomputed, stored, rtol=rtol, atol=atol, equal_nan=True):
+        max_dev = float(np.nanmax(np.abs(recomputed - stored)))
+        raise ValueError("master mt_t is inconsistent with the provided M/G/C over "
+                         "{0} sampled pairs (max|Δt|={1:.3e}); the covariate design/df "
+                         "that produced the master must match the null design.".format(k, max_dev))
+    logger.info("master consistency OK: {0} sampled pairs, max|Δt|={1:.3e}",
+                k, float(np.nanmax(np.abs(recomputed - stored))))
+
+
+def _finalize_output(master_df, reported_pairs, perm_mt_p, seed, n_perm,
                      output_p_threshold, logger):
-    df = reported_pairs.copy()
-    df['mt_t'] = np.asarray(observed_stats, dtype=np.float64)
-    df['perm_mt_p'] = np.asarray(perm_mt_p, dtype=np.float64)
-    df['seed'] = seed
-    df['n_perm'] = n_perm
+    res = reported_pairs.copy()            # ['mt_id','gt_id'], already str-cast
+    res['perm_mt_p'] = np.asarray(perm_mt_p, dtype=np.float64)
     if output_p_threshold is not None:
-        df = df[df['perm_mt_p'] <= output_p_threshold].reset_index(drop=True)
-    return df
+        res = res[res['perm_mt_p'] <= output_p_threshold].reset_index(drop=True)
+    # Drop any pre-existing perm columns on master to avoid _x/_y suffixing
+    # (and make re-running permute on its own prior output idempotent).
+    drop = [c for c in ['perm_mt_p', 'seed', 'n_perm'] if c in master_df.columns]
+    if drop:
+        master_df = master_df.drop(columns=drop)
+    merged = master_df.merge(res, on=['mt_id', 'gt_id'], how='left')
+    merged['seed'] = seed        # run-level scalars on ALL rows (mirror bootstrap)
+    merged['n_perm'] = n_perm
+    return merged
 
 
 def tecpg_mlr_qr_permute(
-    M, G, C,
+    master_parquet=None, pairs_file=None,
+    M=None, G=None, C=None,
     M_annot=None, G_annot=None,
     region: Literal['all', 'cis', 'distal', 'trans'] = 'all',
     window_base=None, downstream=None, upstream=None,
@@ -439,6 +482,12 @@ def tecpg_mlr_qr_permute(
             "chromosome-stratified (trans) null; none were provided."
         )
 
+    if master_parquet is None:
+        raise ValueError(
+            "qr_permute requires --master-parquet: the observed mt_t and the "
+            "(mt_id, gt_id) universe are read from the mapping output, not recomputed."
+        )
+
     if seed is None:
         seed = int(np.random.SeedSequence().generate_state(1)[0])
         logger.info("No seed provided; generated seed={0} (recorded with outputs).", seed)
@@ -452,21 +501,34 @@ def tecpg_mlr_qr_permute(
                                              window_base, downstream, upstream,
                                              subsample_mt_count, subsample_g_count, seed, logger)
 
-    # Cross product of M.index x G.index
-    # Explicitly casting indices to str to align with schema consistency
-    m_idx = M.index.astype(str)
-    g_idx = G.index.astype(str)
+    # --- Realigned observed leg: consume the mapping master (bootstrap-parallel) ---
+    master_df = pd.read_parquet(master_parquet)
+    if 'mt_t' not in master_df.columns:
+        raise ValueError("master parquet is missing required column 'mt_t'")
+    master_df['mt_id'] = master_df['mt_id'].astype(str)
+    master_df['gt_id'] = master_df['gt_id'].astype(str)
 
-    reported_pairs = pd.MultiIndex.from_product([m_idx, g_idx], names=['mt_id', 'gt_id']).to_frame(index=False)
+    if pairs_file is not None:
+        pairs_df = pd.read_csv(pairs_file)
+        pairs_df['mt_id'] = pairs_df['mt_id'].astype(str)
+        pairs_df['gt_id'] = pairs_df['gt_id'].astype(str)
+        if pairs_df.duplicated(['mt_id', 'gt_id']).any():
+            raise ValueError("--pairs-file contains duplicate (mt_id, gt_id) rows")
+        universe = master_df.merge(pairs_df[['mt_id', 'gt_id']], on=['mt_id', 'gt_id'], how='inner')
+        if len(universe) != len(pairs_df):
+            raise ValueError("--pairs-file contains pairs absent from --master-parquet "
+                             "(no stored mt_t to score)")
+    else:
+        universe = master_df
 
-    trans_mask = _compute_trans_mask(reported_pairs, M_annot, G_annot, region,
-                                     window_base, downstream, upstream, logger)
-
-    reported_pairs = reported_pairs[trans_mask].reset_index(drop=True)
+    reported_pairs = universe[['mt_id', 'gt_id']].reset_index(drop=True)
+    observed_t = universe['mt_t'].to_numpy(dtype=np.float64)
 
     device = get_device(**logger.opts) if hasattr(logger, 'opts') else get_device()
 
-    observed_t = _compute_observed_statistic(M, G, C, reported_pairs, logger, device=device, progress_label='qr_permute observed')
+    # Consistency guard: fail-closed if the supplied M/G/C don't match the design
+    # behind the master's mt_t (sampled equivalence spot-check).
+    _verify_master_consistency(M, G, C, universe, device, logger)
 
     accumulator = None
     rng = np.random.default_rng(seed)
@@ -495,7 +557,7 @@ def tecpg_mlr_qr_permute(
 
     n_reported = len(reported_pairs)
 
-    final_df = _finalize_output(reported_pairs, observed_t, perm_mt_p, seed, permutations, output_p_threshold, logger)
+    final_df = _finalize_output(master_df, reported_pairs, perm_mt_p, seed, permutations, output_p_threshold, logger)
 
     # Honor output format
     if output_format == 'auto':

--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -461,8 +461,8 @@ def _finalize_output(master_df, reported_pairs, perm_mt_p, seed, n_perm,
 
 
 def tecpg_mlr_qr_permute(
+    M, G, C,
     master_parquet=None, pairs_file=None,
-    M=None, G=None, C=None,
     M_annot=None, G_annot=None,
     region: Literal['all', 'cis', 'distal', 'trans'] = 'all',
     window_base=None, downstream=None, upstream=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,3 +48,20 @@ def cli_shaped_annotated_fixture():
 
         return M, G, C, M_annot_raw, G_annot_raw
     return _make
+
+
+@pytest.fixture
+def master_parquet_fixture(annotated_fixture, tmp_path):
+    """Mapping output (a master parquet with mt_t) over the M×G universe,
+    for the realigned qr_permute consume path."""
+    def _make(sample_size=20, m_rows=6, g_rows=5, seed=42, region='all'):
+        from tecpg.regression_full import regression_full
+        from tecpg.logger import Logger
+        M, G, C, M_annot, G_annot = annotated_fixture(sample_size, m_rows, g_rows, seed)
+        out = regression_full(M, G, C, region=region, p_thresh=None,
+                              methylation_only=True, logger=Logger())
+        master = out.reset_index()  # -> columns mt_id, gt_id, mt_est, mt_err, mt_t, mt_p, ...
+        path = tmp_path / 'master.parquet'
+        master.to_parquet(path)
+        return str(path), M, G, C, M_annot, G_annot, master
+    return _make

--- a/tests/test_permute_accumulate.py
+++ b/tests/test_permute_accumulate.py
@@ -91,23 +91,23 @@ def test_accumulate_topk_correctness():
     np.testing.assert_allclose(actual_topk, expected_topk)
     assert len(actual_topk) <= TOPK_CAPACITY
 
-def test_accumulate_determinism(tmp_path, annotated_fixture):
-    M, G, C, M_annot, G_annot = annotated_fixture(sample_size=30, m_rows=10, g_rows=10)
+def test_accumulate_determinism(tmp_path, master_parquet_fixture):
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=10, g_rows=10)
 
     # Run 1
     out1 = str(tmp_path / "out1.csv")
-    tecpg_mlr_qr_permute(M, G, C, M_annot=M_annot, G_annot=G_annot, permutations=10, seed=123, output_file=out1)
+    tecpg_mlr_qr_permute(master_parquet=master_parquet, M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot, permutations=10, seed=123, output_file=out1)
 
     # Run 2
     out2 = str(tmp_path / "out2.csv")
-    tecpg_mlr_qr_permute(M, G, C, M_annot=M_annot, G_annot=G_annot, permutations=10, seed=123, output_file=out2)
+    tecpg_mlr_qr_permute(master_parquet=master_parquet, M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot, permutations=10, seed=123, output_file=out2)
 
     df1 = pd.read_csv(out1)
     df2 = pd.read_csv(out2)
     pd.testing.assert_frame_equal(df1, df2)
 
-def test_accumulate_null_pair_stratification(tmp_path, monkeypatch, annotated_fixture):
-    M, G, C, M_annot, G_annot = annotated_fixture(sample_size=30, m_rows=15, g_rows=15, seed=42)
+def test_accumulate_null_pair_stratification(tmp_path, monkeypatch, master_parquet_fixture):
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=15, g_rows=15, seed=42)
 
     # We will patch _accumulate_null to capture the final accumulator
     captured_acc = []
@@ -123,7 +123,7 @@ def test_accumulate_null_pair_stratification(tmp_path, monkeypatch, annotated_fi
     monkeypatch.setattr(permute, '_accumulate_null', mocked_accumulate_null)
 
     out = str(tmp_path / "out.csv")
-    tecpg_mlr_qr_permute(M, G, C, M_annot=M_annot, G_annot=G_annot, permutations=10, seed=123, output_file=out)
+    tecpg_mlr_qr_permute(master_parquet=master_parquet, M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot, permutations=10, seed=123, output_file=out)
 
     final_acc = captured_acc[-1]
 
@@ -142,8 +142,8 @@ def test_accumulate_null_pair_stratification(tmp_path, monkeypatch, annotated_fi
     expected_total_count = 10 * expected_trans_pairs
     assert final_acc['total_count'] == expected_total_count
 
-def test_accumulate_calibration_sanity(tmp_path, monkeypatch, annotated_fixture):
-    M, G, C, M_annot, G_annot = annotated_fixture(sample_size=120, m_rows=25, g_rows=25, seed=42)
+def test_accumulate_calibration_sanity(tmp_path, monkeypatch, master_parquet_fixture):
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=120, m_rows=25, g_rows=25, seed=42)
 
 
     captured_acc = []
@@ -158,7 +158,7 @@ def test_accumulate_calibration_sanity(tmp_path, monkeypatch, annotated_fixture)
     monkeypatch.setattr(permute, '_accumulate_null', mocked_accumulate_null)
 
     out = str(tmp_path / "out.csv")
-    tecpg_mlr_qr_permute(M, G, C, M_annot=M_annot, G_annot=G_annot, permutations=60, seed=123, output_file=out)
+    tecpg_mlr_qr_permute(master_parquet=master_parquet, M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot, permutations=60, seed=123, output_file=out)
 
     final_acc = captured_acc[-1]
 

--- a/tests/test_permute_annotations.py
+++ b/tests/test_permute_annotations.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 import numpy as np
-from tecpg.permute import _normalize_annotations, tecpg_mlr_qr_permute
+from tecpg.permute import _normalize_annotations, tecpg_mlr_qr_permute, _select_null_population
 from tecpg.logger import Logger
 from tecpg.cli import mlr
 from click.testing import CliRunner
@@ -90,16 +90,44 @@ def test_fail_closed():
     with pytest.raises(ValueError, match="Normalization dropped all loci on one or both axes."):
         _normalize_annotations(M_annot, G_annot, M, G, logger)
 
-def test_end_to_end_permute(cli_shaped_annotated_fixture, tmp_path):
+def test_end_to_end_permute(cli_shaped_annotated_fixture, tmp_path, master_parquet_fixture):
     """6. END-TO-END"""
+    # M/G generated here will have 5 rows.
+    # cli_shaped drops 1 row on each side -> 4 rows.
     M, G, C, M_annot, G_annot = cli_shaped_annotated_fixture(10, 5, 5)
+
+    # Re-home the NaN-dropping assertion to the null side, because
+    # the master parquet determines the *observed* universe size.
+    logger = Logger()
+    M_annot_n, G_annot_n, M_n, G_n = _normalize_annotations(M_annot, G_annot, M, G, logger)
+    null_M, null_G = _select_null_population(M_n, G_n, C, M_annot_n, G_annot_n, 'all', None, None, None,
+                                             None, None, 42, logger)
+    assert len(null_M) == 4, "NaN chrom dropping must apply to the null M universe."
+    assert len(null_G) == 4, "NaN chrom dropping must apply to the null G universe."
+
+    # Generate master parquet from the SAME cli_shaped M/G so the observed IDs match
+    # Since regression_full doesn't drop NaNs internally on the observed side,
+    # the master will have 5*5=25 rows. We filter out the NaN ones to align
+    # with the 4*4=16 universe for the end-to-end permute run, or else
+    # _verify_master_consistency will fail when it spot-checks a master pair
+    # whose ID was stripped from the M_annot-filtered M/G that it runs on.
+    from tecpg.regression_full import regression_full
+    out = regression_full(M, G, C, region='all', p_thresh=None,
+                              methylation_only=True, logger=Logger())
+    master = out.reset_index()
+
+    # Filter master to the 4x4 valid IDs
+    M_annot_n, G_annot_n, _, _ = _normalize_annotations(M_annot, G_annot, M, G, logger)
+    master = master[master['mt_id'].isin(M_annot_n.index) & master['gt_id'].isin(G_annot_n.index)].reset_index(drop=True)
+
+    master_parquet = str(tmp_path / 'master.parquet')
+    master.to_parquet(master_parquet)
 
     output_file = str(tmp_path / "output.csv")
 
-    logger = Logger()
-
     # Running permute
     tecpg_mlr_qr_permute(
+        master_parquet=master_parquet,
         M=M, G=G, C=C,
         M_annot=M_annot, G_annot=G_annot,
         region='all',
@@ -112,10 +140,13 @@ def test_end_to_end_permute(cli_shaped_annotated_fixture, tmp_path):
     assert os.path.exists(output_file)
     df = pd.read_csv(output_file)
 
-    # Expected rows: 4 * 4 = 16 (since 1 dropped from each axis)
+    # Master has 16 rows. They should all be preserved and scored.
     assert len(df) == 16
 
-    assert set(df.columns) == {'mt_id', 'gt_id', 'mt_t', 'perm_mt_p', 'seed', 'n_perm'}
+    expected_cols = {'mt_id', 'gt_id', 'mt_t', 'mt_p', 'perm_mt_p', 'seed', 'n_perm'}
+    assert expected_cols.issubset(set(df.columns))
+    assert not any(c.endswith('_x') or c.endswith('_y') for c in df.columns)
+
     assert df['perm_mt_p'].min() > 0
     assert df['perm_mt_p'].max() <= 1
     assert df['perm_mt_p'].isna().sum() == 0
@@ -187,6 +218,10 @@ def test_cli_regression():
         bed6_content_g = "chrom\tchromStart\tchromEnd\tname\tscore\tstrand\nchr1\t1\t2\tg1\t0\t+\nchr1\t1\t2\tg2\t0\t+\n"
         with open(os.path.join(cwd, 'annot/G.bed6'), 'w') as f: f.write(bed6_content_g)
 
+        master_pq = os.path.join(cwd, 'dummy.parquet')
+        pd.DataFrame({'mt_id': ['m1'], 'gt_id': ['g1'], 'mt_t': [0.0]}).to_parquet(master_pq)
+        assert os.path.exists(master_pq)
+
         # Mock targets
         with patch('tecpg.cli.tecpg_mlr_qr') as mock_qr, \
              patch('tecpg.permute.tecpg_mlr_qr_permute') as mock_qr_permute, \
@@ -215,27 +250,40 @@ def test_cli_regression():
             assert isinstance(mock_qr.call_args.kwargs['G_annot'], pd.DataFrame)
 
             # Test 3: qr_permute + --all (The FACT-1 fix)
-            result3 = runner.invoke(cli, ['--root-path', cwd, 'run', 'mlr', '--mlr-method', 'qr_permute', '--all'])
+            result3 = runner.invoke(cli, ['--root-path', cwd, 'run', 'mlr', '--mlr-method', 'qr_permute', '--all', '--master-parquet', master_pq], catch_exceptions=False)
             assert result3.exit_code == 0, f"Failed: {result3.exception}"
             assert isinstance(mock_qr_permute.call_args.kwargs['M_annot'], pd.DataFrame)
             assert isinstance(mock_qr_permute.call_args.kwargs['G_annot'], pd.DataFrame)
             assert mock_qr_permute.call_args.kwargs['output_p_threshold'] is None
 
             # Test 4: qr_permute + --cis + --output-p-threshold
-            result4 = runner.invoke(cli, ['--root-path', cwd, 'run', 'mlr', '--mlr-method', 'qr_permute', '--cis', '--output-p-threshold', '0.05'])
+            result4 = runner.invoke(cli, ['--root-path', cwd, 'run', 'mlr', '--mlr-method', 'qr_permute', '--cis', '--output-p-threshold', '0.05', '--master-parquet', master_pq], catch_exceptions=False)
             assert result4.exit_code == 0, f"Failed: {result4.exception}"
             assert isinstance(mock_qr_permute.call_args.kwargs['M_annot'], pd.DataFrame)
             assert isinstance(mock_qr_permute.call_args.kwargs['G_annot'], pd.DataFrame)
             assert mock_qr_permute.call_args.kwargs['output_p_threshold'] == 0.05
 
 
-def test_end_to_end_permute_determinism(cli_shaped_annotated_fixture, tmp_path):
+def test_end_to_end_permute_determinism(cli_shaped_annotated_fixture, tmp_path, master_parquet_fixture):
     """8. DETERMINISM TEST"""
+    # M/G generated here will have 5 rows.
+    # cli_shaped drops 1 row on each side -> 4 rows.
     M, G, C, M_annot, G_annot = cli_shaped_annotated_fixture(10, 5, 5)
     logger = Logger()
 
+    # Generate master parquet aligned with the valid IDs
+    from tecpg.regression_full import regression_full
+    out = regression_full(M, G, C, region='all', p_thresh=None,
+                              methylation_only=True, logger=Logger())
+    master = out.reset_index()
+    M_annot_n, G_annot_n, _, _ = _normalize_annotations(M_annot, G_annot, M, G, logger)
+    master = master[master['mt_id'].isin(M_annot_n.index) & master['gt_id'].isin(G_annot_n.index)].reset_index(drop=True)
+    master_parquet = str(tmp_path / 'master.parquet')
+    master.to_parquet(master_parquet)
+
     output_file1 = str(tmp_path / "output1.csv")
     tecpg_mlr_qr_permute(
+        master_parquet=master_parquet,
         M=M, G=G, C=C,
         M_annot=M_annot, G_annot=G_annot,
         region='all',
@@ -248,6 +296,7 @@ def test_end_to_end_permute_determinism(cli_shaped_annotated_fixture, tmp_path):
 
     output_file2 = str(tmp_path / "output2.csv")
     tecpg_mlr_qr_permute(
+        master_parquet=master_parquet,
         M=M, G=G, C=C,
         M_annot=M_annot, G_annot=G_annot,
         region='all',

--- a/tests/test_permute_finalize.py
+++ b/tests/test_permute_finalize.py
@@ -9,15 +9,20 @@ from tecpg.logger import Logger
 def test_finalize_output_columns_and_values():
     # Test 1: Columns + order exactly match expectations.
     # mt_t / perm_mt_p equal the inputs; seed / n_perm constant on every row.
+    master_df = pd.DataFrame({
+        'mt_id': ['m1', 'm2', 'm3'],
+        'gt_id': ['g1', 'g2', 'g3'],
+        'mt_t': [2.5, -1.0, 0.5],
+        'mt_p': [0.1, 0.2, 0.3]
+    })
     reported_pairs = pd.DataFrame({'mt_id': ['m1', 'm2', 'm3'], 'gt_id': ['g1', 'g2', 'g3']})
-    observed_stats = np.array([2.5, -1.0, 0.5])
     perm_mt_p = np.array([0.01, 0.5, 0.9])
     seed = 42
     n_perm = 100
 
     df = _finalize_output(
+        master_df=master_df,
         reported_pairs=reported_pairs,
-        observed_stats=observed_stats,
         perm_mt_p=perm_mt_p,
         seed=seed,
         n_perm=n_perm,
@@ -25,10 +30,12 @@ def test_finalize_output_columns_and_values():
         logger=Logger()
     )
 
-    expected_cols = ['mt_id', 'gt_id', 'mt_t', 'perm_mt_p', 'seed', 'n_perm']
-    assert list(df.columns) == expected_cols
+    expected_cols = {'mt_id', 'gt_id', 'mt_t', 'mt_p', 'perm_mt_p', 'seed', 'n_perm'}
+    assert expected_cols.issubset(set(df.columns))
+    assert not any(c.endswith('_x') or c.endswith('_y') for c in df.columns)
 
-    np.testing.assert_allclose(df['mt_t'].values, observed_stats)
+    np.testing.assert_allclose(df['mt_t'].values, master_df['mt_t'].values)
+    np.testing.assert_allclose(df['mt_p'].values, master_df['mt_p'].values)
     np.testing.assert_allclose(df['perm_mt_p'].values, perm_mt_p)
     assert (df['seed'] == seed).all()
     assert (df['n_perm'] == n_perm).all()
@@ -36,46 +43,46 @@ def test_finalize_output_columns_and_values():
 
 def test_finalize_output_threshold():
     # Test 2: Threshold filter works properly.
+    master_df = pd.DataFrame({
+        'mt_id': ['m1', 'm2', 'm3'],
+        'gt_id': ['g1', 'g2', 'g3'],
+        'mt_t': [2.5, -1.0, 0.5],
+        'mt_p': [0.1, 0.2, 0.3]
+    })
     reported_pairs = pd.DataFrame({'mt_id': ['m1', 'm2', 'm3'], 'gt_id': ['g1', 'g2', 'g3']})
-    observed_stats = np.array([2.5, -1.0, 0.5])
     perm_mt_p = np.array([0.01, 0.5, 0.9])
 
-    # With threshold 0.1, only m1 remains
+    # With threshold 0.1, only m1 remains in `res` before merge
     df_thresh = _finalize_output(
+        master_df=master_df,
         reported_pairs=reported_pairs,
-        observed_stats=observed_stats,
         perm_mt_p=perm_mt_p,
         seed=42,
         n_perm=100,
         output_p_threshold=0.1,
         logger=Logger()
     )
-    assert len(df_thresh) == 1
-    assert df_thresh['mt_id'].iloc[0] == 'm1'
-    assert df_thresh['perm_mt_p'].iloc[0] <= 0.1
-
-    # With None, all 3 remain
-    df_none = _finalize_output(
-        reported_pairs=reported_pairs,
-        observed_stats=observed_stats,
-        perm_mt_p=perm_mt_p,
-        seed=42,
-        n_perm=100,
-        output_p_threshold=None,
-        logger=Logger()
-    )
-    assert len(df_none) == 3
+    assert len(df_thresh) == 3 # Master rows are untouched
+    # m1 is scored and thresholded in res, so it keeps its score
+    assert df_thresh.loc[df_thresh['mt_id'] == 'm1', 'perm_mt_p'].iloc[0] == 0.01
+    # m2, m3 dropped by threshold, so they get merged as NaNs
+    assert pd.isna(df_thresh.loc[df_thresh['mt_id'] == 'm2', 'perm_mt_p'].iloc[0])
+    assert pd.isna(df_thresh.loc[df_thresh['mt_id'] == 'm3', 'perm_mt_p'].iloc[0])
 
 
 def test_finalize_output_mt_t_alignment():
     # Test 3: mt_t correctly mirrors observed_stats exactly row-for-row.
+    master_df = pd.DataFrame({
+        'mt_id': ['m1', 'm2'],
+        'gt_id': ['g1', 'g2'],
+        'mt_t': [10.5, -5.5]
+    })
     reported_pairs = pd.DataFrame({'mt_id': ['m1', 'm2'], 'gt_id': ['g1', 'g2']})
-    observed_stats = np.array([10.5, -5.5])
     perm_mt_p = np.array([0.2, 0.8])
 
     df = _finalize_output(
+        master_df=master_df,
         reported_pairs=reported_pairs,
-        observed_stats=observed_stats,
         perm_mt_p=perm_mt_p,
         seed=42,
         n_perm=100,
@@ -89,15 +96,16 @@ def test_finalize_output_mt_t_alignment():
     assert df.loc[1, 'perm_mt_p'] == 0.8
 
 
-def test_permute_parquet_metadata_roundtrip(tmp_path, annotated_fixture):
+def test_permute_parquet_metadata_roundtrip(tmp_path, master_parquet_fixture):
     # Test 4: Parquet schema metadata successfully saves and matches seed, permutations, and total rows.
-    M, G, C, M_annot, G_annot = annotated_fixture(sample_size=30, m_rows=10, g_rows=10)
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=10, g_rows=10)
     output_file = str(tmp_path / "perm_output.parquet")
 
     seed = 77
     permutations = 5
 
     tecpg_mlr_qr_permute(
+        master_parquet=master_parquet,
         M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot,
         output_file=output_file, permutations=permutations, seed=seed
     )
@@ -116,13 +124,14 @@ def test_permute_parquet_metadata_roundtrip(tmp_path, annotated_fixture):
     assert int(metadata[b'tecpg_perm_n_reported']) == len(M) * len(G)
 
 
-def test_permute_end_to_end_threshold_and_universe(tmp_path, annotated_fixture):
+def test_permute_end_to_end_threshold_and_universe(tmp_path, master_parquet_fixture):
     # Test 5: End-to-end threshold + universe size accurately persists under threshold conditions.
-    M, G, C, M_annot, G_annot = annotated_fixture(sample_size=30, m_rows=10, g_rows=10)
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=10, g_rows=10)
     output_file = str(tmp_path / "perm_output_thresh.parquet")
 
     # We use output_p_threshold = 0.5 to drop some rows, ensuring not all are returned.
     tecpg_mlr_qr_permute(
+        master_parquet=master_parquet,
         M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot,
         output_file=output_file, permutations=10, seed=42,
         output_p_threshold=0.5
@@ -134,8 +143,14 @@ def test_permute_end_to_end_threshold_and_universe(tmp_path, annotated_fixture):
 
     n_reported_universe = len(M) * len(G)
 
-    # The written row count is less than or equal to n_reported.
-    # Given the test data and standard null distributions, some should easily be > 0.5
-    assert len(df) <= n_reported_universe
-    assert (df['perm_mt_p'] <= 0.5).all()
+    # The merge on master always yields n_reported_universe rows.
+    # The thresholding drops scores, so un-scored rows have NaN perm_mt_p.
+    assert len(df) == n_reported_universe
+
+    # Rows that *do* have a perm_mt_p should pass the threshold.
+    scored = df.dropna(subset=['perm_mt_p'])
+    assert (scored['perm_mt_p'] <= 0.5).all()
+    # At least some should be dropped by the threshold and become NaN.
+    assert len(scored) < len(df)
+
     assert int(metadata[b'tecpg_perm_n_reported']) == n_reported_universe

--- a/tests/test_permute_realignment.py
+++ b/tests/test_permute_realignment.py
@@ -1,0 +1,188 @@
+import pytest
+import os
+import pandas as pd
+import numpy as np
+from tecpg.permute import tecpg_mlr_qr_permute, _verify_master_consistency
+from tecpg.logger import Logger
+
+def hand_rolled_ols_oracle(M, G, C, reported_pairs):
+    """
+    Independent OLS t-statistic oracle for a set of pairs.
+    Must not share any solver code with tecpg.
+    Ensures df = n - C.shape[1] - 2 exactly matches tecpg behavior.
+    """
+    n = len(C)
+    df = n - C.shape[1] - 2
+    C_mat = C.values
+
+    results = []
+    for _, row in reported_pairs.iterrows():
+        m_id, g_id = row['mt_id'], row['gt_id']
+        m_vec = M.loc[m_id].values
+        g_vec = G.loc[g_id].values
+
+        # X = [ones, M_m, C]
+        X = np.column_stack([np.ones(n), m_vec, C_mat])
+
+        # B = (X'X)^-1 X'Y
+        # Use lstsq for robustness
+        beta, rss, _, _ = np.linalg.lstsq(X, g_vec, rcond=None)
+
+        # Ensure we compute RSS manually if lstsq returns empty (e.g. perfect fit)
+        if len(rss) == 0:
+            residuals = g_vec - X @ beta
+            rss_val = np.sum(residuals ** 2)
+        else:
+            rss_val = rss[0]
+
+        sigma_sq = rss_val / df
+
+        # Var(B) = sigma^2 * (X'X)^-1
+        # Inverse of X'X
+        XtX_inv = np.linalg.inv(X.T @ X)
+
+        # Standard error of the methylation coefficient (index 1)
+        se_m = np.sqrt(sigma_sq * XtX_inv[1, 1])
+
+        # t-statistic
+        t_stat = beta[1] / se_m
+        results.append(t_stat)
+
+    return np.array(results)
+
+def test_master_parquet_required(master_parquet_fixture):
+    """Fail-closed on missing master_parquet."""
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=5, g_rows=5, seed=42)
+
+    with pytest.raises(ValueError, match="requires --master-parquet"):
+        tecpg_mlr_qr_permute(M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot)
+
+
+def test_three_way_equivalence_oracle(tmp_path, master_parquet_fixture):
+    """6a. Three-way equivalence oracle."""
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=5, g_rows=5, seed=42)
+
+    # Run permute
+    output_file = str(tmp_path / 'out.csv')
+    tecpg_mlr_qr_permute(
+        master_parquet=master_parquet, M=M, G=G, C=C,
+        M_annot=M_annot, G_annot=G_annot, permutations=5, seed=42,
+        output_file=output_file
+    )
+
+    # 1. Read back output (observed_t via read path)
+    df = pd.read_csv(output_file)
+    t_read = df['mt_t'].values
+
+    # 2. Recompute via tecpg internals (_compute_observed_statistic)
+    from tecpg.permute import _compute_observed_statistic
+    from tecpg.config import get_device
+    reported_pairs = df[['mt_id', 'gt_id']].copy()
+    t_recompute = _compute_observed_statistic(M, G, C, reported_pairs, Logger(), device=get_device())
+    t_recompute = np.asarray(t_recompute, dtype=np.float64)
+
+    # 3. Independent per-pair OLS
+    t_ols = hand_rolled_ols_oracle(M, G, C, reported_pairs)
+
+    np.testing.assert_allclose(t_read, t_recompute, rtol=1e-4, atol=1e-4)
+    np.testing.assert_allclose(t_read, t_ols, rtol=1e-4, atol=1e-4)
+
+def test_consistency_guard_passes(master_parquet_fixture):
+    """6b. Consistency guard - pass."""
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=10, g_rows=10)
+
+    logger = Logger()
+    # Should run cleanly without raising
+    _verify_master_consistency(M, G, C, master_df, None, logger, seed=42)
+
+def test_consistency_guard_fail_design(master_parquet_fixture):
+    """6b. Consistency guard - fail-design."""
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=10, g_rows=10)
+
+    # Perturb C globally: add a dummy covariate to change design/df
+    C_perturbed = C.copy()
+    C_perturbed['dummy'] = np.random.rand(len(C))
+
+    with pytest.raises(ValueError, match="master mt_t is inconsistent with the provided M/G/C"):
+        _verify_master_consistency(M, G, C_perturbed, master_df, None, Logger(), seed=42)
+
+def test_consistency_guard_fail_data(master_parquet_fixture):
+    """6b. Consistency guard - fail-data."""
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=10, g_rows=10)
+
+    # Use disjoint M/G IDs
+    M_disjoint = M.copy()
+    M_disjoint.index = [f"disjoint_m{i}" for i in range(len(M))]
+
+    with pytest.raises(ValueError, match="master consistency check failed"):
+        _verify_master_consistency(M_disjoint, G, C, master_df, None, Logger(), seed=42)
+
+def test_pairs_file_subset(tmp_path, master_parquet_fixture):
+    """6c. --pairs-file subset."""
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=10, g_rows=10)
+
+    # Create pairs file with only 2 pairs
+    pairs_file = str(tmp_path / 'pairs.csv')
+    subset = master_df.head(2)[['mt_id', 'gt_id']].copy()
+    subset.to_csv(pairs_file, index=False)
+
+    output_file = str(tmp_path / 'out.csv')
+    tecpg_mlr_qr_permute(
+        master_parquet=master_parquet, pairs_file=pairs_file,
+        M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot,
+        permutations=5, seed=42, output_file=output_file
+    )
+
+    df = pd.read_csv(output_file)
+    assert len(df) == len(master_df)
+
+    # Only the 2 pairs should have perm_mt_p
+    scored = df.dropna(subset=['perm_mt_p'])
+    assert len(scored) == 2
+
+    # Duplicate pairs error
+    dup_pairs = pd.concat([subset, subset.head(1)])
+    dup_pairs_file = str(tmp_path / 'dup_pairs.csv')
+    dup_pairs.to_csv(dup_pairs_file, index=False)
+
+    with pytest.raises(ValueError, match="--pairs-file contains duplicate"):
+        tecpg_mlr_qr_permute(
+            master_parquet=master_parquet, pairs_file=dup_pairs_file,
+            M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot
+        )
+
+    # Absent pairs error
+    absent_pairs = subset.copy()
+    absent_pairs.iloc[0, 0] = 'absent_m'
+    absent_pairs_file = str(tmp_path / 'absent_pairs.csv')
+    absent_pairs.to_csv(absent_pairs_file, index=False)
+
+    with pytest.raises(ValueError, match="--pairs-file contains pairs absent from --master-parquet"):
+        tecpg_mlr_qr_permute(
+            master_parquet=master_parquet, pairs_file=absent_pairs_file,
+            M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot
+        )
+
+def test_additive_merge(tmp_path, master_parquet_fixture):
+    """6d. Additive merge."""
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=5, g_rows=5)
+
+    output_file = str(tmp_path / 'out.csv')
+    tecpg_mlr_qr_permute(
+        master_parquet=master_parquet, M=M, G=G, C=C,
+        M_annot=M_annot, G_annot=G_annot, permutations=5, seed=42,
+        output_file=output_file
+    )
+
+    df = pd.read_csv(output_file)
+
+    # Row count matches master
+    assert len(df) == len(master_df)
+
+    # Invariance on mt_p
+    # Align by id
+    merged = df.merge(master_df, on=['mt_id', 'gt_id'], suffixes=('', '_master'))
+    np.testing.assert_allclose(merged['mt_p'].values, merged['mt_p_master'].values)
+
+    assert 'perm_mt_p' in df.columns
+    assert not any(c.endswith('_x') or c.endswith('_y') for c in df.columns)

--- a/tests/test_permute_skeleton.py
+++ b/tests/test_permute_skeleton.py
@@ -5,9 +5,9 @@ from tecpg.permute import tecpg_mlr_qr_permute
 from tecpg.test_data import generate_data
 
 
-def test_permute_skeleton_end_to_end(tmp_path, annotated_fixture):
+def test_permute_skeleton_end_to_end(tmp_path, master_parquet_fixture):
     # Set up small fixture using annotated_fixture
-    M, G, C, M_annot, G_annot = annotated_fixture(
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(
         sample_size=30,
         m_rows=10,
         g_rows=10,
@@ -17,6 +17,7 @@ def test_permute_skeleton_end_to_end(tmp_path, annotated_fixture):
 
     # Call the newly created permutation function directly
     tecpg_mlr_qr_permute(
+        master_parquet=master_parquet,
         M=M,
         G=G,
         C=C,
@@ -34,8 +35,9 @@ def test_permute_skeleton_end_to_end(tmp_path, annotated_fixture):
     df = pd.read_csv(output_file)
 
     # Assert correct columns (schema)
-    expected_cols = ['mt_id', 'gt_id', 'mt_t', 'perm_mt_p', 'seed', 'n_perm']
-    assert list(df.columns) == expected_cols
+    expected_cols = {'mt_id', 'gt_id', 'mt_t', 'mt_p', 'perm_mt_p', 'seed', 'n_perm'}
+    assert expected_cols.issubset(set(df.columns))
+    assert not any(c.endswith('_x') or c.endswith('_y') for c in df.columns)
 
     # Assert row count = |M| x |G|
     expected_rows = len(M) * len(G)

--- a/tests/test_permute_subsample.py
+++ b/tests/test_permute_subsample.py
@@ -79,14 +79,12 @@ def test_select_null_population_zero_count_raises():
         _select_null_population(M, G, C, None, None, 'all', None, None, None,
                                 subsample_mt_count=10, subsample_g_count=-5, seed=seed, logger=logger)
 
-def test_permute_with_subsample(tmp_path):
-    M, G, C, M_annot, G_annot = generate_data(sample_size=30, m_rows=10, g_rows=10, annotation=True)
-    M_annot = M_annot.set_index("name")[["chrom", "chromStart"]]
-    G_annot = G_annot.set_index("name")[["chrom", "chromStart", "strand"]]
-    G_annot["strand"] = G_annot["strand"].map({"+": 1, "-": -1})
+def test_permute_with_subsample(tmp_path, master_parquet_fixture):
+    master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=10, g_rows=10)
     output_file = str(tmp_path / "permutation_results.csv")
 
     tecpg_mlr_qr_permute(
+        master_parquet=master_parquet,
         M=M,
         G=G,
         M_annot=M_annot,
@@ -102,8 +100,9 @@ def test_permute_with_subsample(tmp_path):
     assert os.path.exists(output_file)
     df = pd.read_csv(output_file)
 
-    expected_cols = ['mt_id', 'gt_id', 'mt_t', 'perm_mt_p', 'seed', 'n_perm']
-    assert list(df.columns) == expected_cols
+    expected_cols = {'mt_id', 'gt_id', 'mt_t', 'mt_p', 'perm_mt_p', 'seed', 'n_perm'}
+    assert expected_cols.issubset(set(df.columns))
+    assert not any(c.endswith('_x') or c.endswith('_y') for c in df.columns)
 
     expected_rows = len(M) * len(G)
     assert len(df) == expected_rows


### PR DESCRIPTION
- Requires `--master-parquet` in `tecpg_mlr_qr_permute` to serve as the consumer of the base mapping output.
- Adds `_verify_master_consistency` to spot-check equivalent OLS math vs `M`/`G`/`C` before proceeding.
- Rewrites `_finalize_output` to perform an additive merge that explicitly drops duplicates and retains required `seed` and `n_perm` columns on all rows.
- Refactors existing tests correctly in `test_permute_finalize.py`, `test_permute_skeleton.py`, `test_permute_subsample.py`, `test_permute_annotations.py`, and `test_permute_accumulate.py`.
- Introduces `test_permute_realignment.py` capturing 3-way OLs equivalence oracle, guard conditions, `--pairs-file` checks, and strict `mt_p` invariance.

---
*PR created automatically by Jules for task [6302372316004053375](https://jules.google.com/task/6302372316004053375) started by @kordk*