### PR TITLE
Fix QC report original vs processed dataset comparison

### DIFF
--- a/pipelinePre.sh
+++ b/pipelinePre.sh
@@ -105,8 +105,6 @@ else
         mv annot/* "$ANNOT_DIR/"
         rmdir data annot
         mv "$DATA_DIR/C.csv" "$DATA_DIR/C_orig.csv"
-        cp "$DATA_DIR/M.csv" "$DATA_DIR/M_orig.csv"
-        cp "$DATA_DIR/G.csv" "$DATA_DIR/G_orig.csv"
     elif [ "$DATASET" == "gtp" ] || [ "$DATASET" == "gtpsub" ]; then
         log "Downloading GTP data..."
         echo "y" | python3 -m tecpg data gtp --yes
@@ -116,10 +114,10 @@ else
             log "Subsampling gtpsub loci..."
             python3 tools/subsample_loci.py "$DATA_DIR/M.csv" "$DATA_DIR/M.csv" "$GTPSUB_M_LOCI" --seed "$GTPSUB_SEED"
             python3 tools/subsample_loci.py "$DATA_DIR/G.csv" "$DATA_DIR/G.csv" "$GTPSUB_G_LOCI" --seed "$GTPSUB_SEED"
+            python3 tools/subsample_loci.py "$DATA_DIR/M_orig.csv" "$DATA_DIR/M_orig.csv" "$GTPSUB_M_LOCI" --seed "$GTPSUB_SEED"
+            python3 tools/subsample_loci.py "$DATA_DIR/G_orig.csv" "$DATA_DIR/G_orig.csv" "$GTPSUB_G_LOCI" --seed "$GTPSUB_SEED"
         fi
         mv "$DATA_DIR/C.csv" "$DATA_DIR/C_orig.csv"
-        cp "$DATA_DIR/M.csv" "$DATA_DIR/M_orig.csv"
-        cp "$DATA_DIR/G.csv" "$DATA_DIR/G_orig.csv"
         # For GTP, assuming the demo annots are used
         if [ -f "demo/annoEPIC_comprehensive.hg19.bed6" ]; then
             cp demo/annoEPIC_comprehensive.hg19.bed6 "$ANNOT_DIR/M.bed6"
@@ -138,8 +136,6 @@ else
         echo "y" | python3 -m tecpg data mesa
         mv data/* "$DATA_DIR/"
         mv "$DATA_DIR/C.csv" "$DATA_DIR/C_orig.csv"
-        cp "$DATA_DIR/M.csv" "$DATA_DIR/M_orig.csv"
-        cp "$DATA_DIR/G.csv" "$DATA_DIR/G_orig.csv"
         # For MESA, assuming appropriate demo annots are used if available
         # Or fall back to EPIC/HT12 for now
         if [ -f "demo/annoEPIC_comprehensive.hg19.bed6" ]; then

--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -1568,7 +1568,7 @@ def dummy(
     annotation = not no_annotation
 
     dataframes = generate_data(
-        samples, meth_rows, gene_rows, annotation=annotation, seed=seed
+        samples, meth_rows, gene_rows, annotation=annotation, seed=seed, return_orig=True
     )
     file_names = [data['meth_file'], data['gene_file'], data['covar_file'], 'M_orig.csv', 'G_orig.csv']
     data_path = os.path.join(data['root_path'], data['input_dir'])

--- a/tecpg/cli.py
+++ b/tecpg/cli.py
@@ -1570,14 +1570,14 @@ def dummy(
     dataframes = generate_data(
         samples, meth_rows, gene_rows, annotation=annotation, seed=seed
     )
-    file_names = [data['meth_file'], data['gene_file'], data['covar_file']]
+    file_names = [data['meth_file'], data['gene_file'], data['covar_file'], 'M_orig.csv', 'G_orig.csv']
     data_path = os.path.join(data['root_path'], data['input_dir'])
-    save_dataframes(dataframes[:3], data_path, file_names, **logger)
+    save_dataframes(dataframes[:5], data_path, file_names, **logger)
     if annotation:
         file_names = [data['meth_annot'], data['gene_annot']]
         data_path = os.path.join(data['root_path'], data['annot_dir'])
         save_dataframes(
-            dataframes[3:],
+            dataframes[5:],
             data_path,
             file_names,
             sep='\t',

--- a/tecpg/gtp.py
+++ b/tecpg/gtp.py
@@ -125,7 +125,7 @@ def process_gtp(
     drop_na: bool = True,
     *,
     logger: Logger = Logger(),
-) -> Tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
+) -> Tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
     """
     Processes the gtp dataframes (Methylation Beta Values, Gene
     Expression Values, and Covariate Matrix). Drops unneeded columns (of
@@ -152,6 +152,10 @@ def process_gtp(
     logger.info(f'  Min: {G.min().min():.4f}, Max: {G.max().max():.4f}')
     logger.info('Data diagnostics for Methylation (M):')
     logger.info(f'  Min: {M.min().min():.4f}, Max: {M.max().max():.4f}')
+
+    # Make copies of the dataframes before modifying them for dropping NaNs and normalization
+    M_orig = M.copy()
+    G_orig = G.copy()
 
     if drop_na:
         G_start = len(G)
@@ -211,8 +215,10 @@ def process_gtp(
     M = M.reindex(sorted(M.columns, key=int), axis=1)
     G = G.reindex(sorted(G.columns, key=int), axis=1)
     C = C.reindex(sorted(C.index, key=int), axis=0)
+    M_orig = M_orig.reindex(sorted(M_orig.columns, key=int), axis=1)
+    G_orig = G_orig.reindex(sorted(G_orig.columns, key=int), axis=1)
 
-    return M, G, C
+    return M, G, C, M_orig, G_orig
 
 
 def get_covariates(
@@ -241,7 +247,7 @@ def generate_data(
     drop_na: bool = True,
     *,
     logger: Logger = Logger(),
-) -> Tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
+) -> Tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
     """
     Generates methylation beta values, gene expression values, and
     covariates pandas.DataFrames. Returns a tuple of these three
@@ -279,9 +285,9 @@ def save_gtp_data(
     data = generate_data(gtp_path, simplify_covar, drop_na, **logger)
     logger.info('Saving into {0}', data_path)
     if file_names is None:
-        save_dataframes(data, data_path, **logger)
+        save_dataframes(list(data), data_path, **logger)
     else:
-        save_dataframes(data, data_path, file_names, **logger)
+        save_dataframes(list(data), data_path, file_names, **logger)
 
     kennedy_filename = GTP_KENNEDY_URL[0]
     kennedy_src = os.path.join(gtp_path, kennedy_filename)

--- a/tecpg/import_data.py
+++ b/tecpg/import_data.py
@@ -15,15 +15,18 @@ data_path = os.path.join(data['root_path'], data['input_dir'])
 def save_dataframes(
     dataframes: List[pandas.DataFrame],
     output_dir: str = data_path,
-    file_names: List[str] = itertools.chain(
-        ('M.csv', 'G.csv', 'P.csv'), itertools.count(1)
-    ),
+    file_names: Optional[List[str]] = None,
     save_func: Callable = pandas.DataFrame.to_csv,
     *args,
     logger: Logger = Logger(),
     clear_dir: bool = True,
     **kwargs,
 ) -> None:
+    if file_names is None:
+        file_names = list(itertools.islice(
+            itertools.chain(('M.csv', 'G.csv', 'C.csv', 'M_orig.csv', 'G_orig.csv'), itertools.count(1)),
+            len(dataframes)
+        ))
     """
     Saves any number of dataframes to an output_dir, with file_names for
     each file. Default file names count up from one for as many files
@@ -38,8 +41,8 @@ def save_dataframes(
 
     logger.start_timer('info', 'Saving {0} dataframes...', len(dataframes))
     for df, file_name in zip(dataframes, file_names):
-        logger.time('Saving {i}/{0}: {1}', len(dataframes), file_name)
-        file_path = os.path.join(output_dir, file_name)
+        logger.time('Saving {i}/{0}: {1}', len(dataframes), str(file_name))
+        file_path = os.path.join(output_dir, str(file_name))
         save_func(
             df,
             file_path,

--- a/tecpg/mesa.py
+++ b/tecpg/mesa.py
@@ -104,7 +104,7 @@ def process_mesa(
     drop_na: bool = True,
     *,
     logger: Logger = Logger(),
-) -> Tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
+) -> Tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
     """
     Processes the mesa dataframes (Methylation Beta Values, Gene
     Expression Values, and Covariate Matrix). Drops unneeded columns (of
@@ -152,6 +152,10 @@ def process_mesa(
     logger.info(f'  Min: {G.min().min():.4f}, Max: {G.max().max():.4f}')
     logger.info('Data diagnostics for Methylation (M):')
     logger.info(f'  Min: {M.min().min():.4f}, Max: {M.max().max():.4f}')
+
+    # Make copies of the dataframes before modifying them for dropping NaNs and normalization
+    M_orig = M.copy()
+    G_orig = G.copy()
 
     if drop_na:
         G_start = len(G)
@@ -213,8 +217,10 @@ def process_mesa(
     M = M.reindex(sorted(M.columns, key=int), axis=1)
     G = G.reindex(sorted(G.columns, key=int), axis=1)
     C = C.reindex(sorted(C.index, key=int), axis=0)
+    M_orig = M_orig.reindex(sorted(M_orig.columns, key=int), axis=1)
+    G_orig = G_orig.reindex(sorted(G_orig.columns, key=int), axis=1)
 
-    return M, G, C
+    return M, G, C, M_orig, G_orig
 
 
 def get_covariates(
@@ -243,7 +249,7 @@ def generate_data(
     drop_na: bool = True,
     *,
     logger: Logger = Logger(),
-) -> Tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
+) -> Tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
     """
     Generates methylation beta values, gene expression values, and
     covariates pandas.DataFrames. Returns a tuple of these three
@@ -284,9 +290,9 @@ def save_mesa_data(
     data = generate_data(mesa_path, simplify_covar, drop_na, **logger)
     logger.info('Saving into {0}', data_path)
     if file_names is None:
-        save_dataframes(data, data_path, **logger)
+        save_dataframes(list(data), data_path, **logger)
     else:
-        save_dataframes(data, data_path, file_names, **logger)
+        save_dataframes(list(data), data_path, file_names, **logger)
 
     kennedy_filename = MESA_KENNEDY_URL[0]
     kennedy_src = os.path.join(mesa_path, kennedy_filename)

--- a/tecpg/test_data.py
+++ b/tecpg/test_data.py
@@ -92,6 +92,7 @@ def generate_data(
     g_rows: int,
     annotation: bool = False,
     seed: Optional[int] = None,
+    return_orig: bool = False,
 ) -> (
     Tuple[
         pandas.DataFrame,
@@ -162,7 +163,9 @@ def generate_data(
     C = generate_from_template(person_codes, covariate_template)
 
     if not annotation:
-        return M, G, C, M_orig, G_orig
+        if return_orig:
+            return M, G, C, M_orig, G_orig
+        return M, G, C
 
     def annotation_template(codes: List[str]) -> Dict[str, Any]:
         return {
@@ -181,4 +184,6 @@ def generate_data(
         g_row_codes, annotation_template(g_row_codes), True
     )
 
-    return M, G, C, M_orig, G_orig, M_annot, G_annot
+    if return_orig:
+        return M, G, C, M_orig, G_orig, M_annot, G_annot
+    return M, G, C, M_annot, G_annot

--- a/tecpg/test_data.py
+++ b/tecpg/test_data.py
@@ -97,8 +97,12 @@ def generate_data(
         pandas.DataFrame,
         pandas.DataFrame,
         pandas.DataFrame,
+        pandas.DataFrame,
+        pandas.DataFrame,
     ]
     | Tuple[
+        pandas.DataFrame,
+        pandas.DataFrame,
         pandas.DataFrame,
         pandas.DataFrame,
         pandas.DataFrame,
@@ -130,6 +134,9 @@ def generate_data(
         person_codes, g_row_codes, randrange(-1, 100, rng=rng)
     )
 
+    M_orig = M.copy()
+    G_orig = G.copy()
+
     import numpy as np
     G = G.clip(lower=0)
     G = np.log2(G + 1)
@@ -155,7 +162,7 @@ def generate_data(
     C = generate_from_template(person_codes, covariate_template)
 
     if not annotation:
-        return M, G, C
+        return M, G, C, M_orig, G_orig
 
     def annotation_template(codes: List[str]) -> Dict[str, Any]:
         return {
@@ -174,4 +181,4 @@ def generate_data(
         g_row_codes, annotation_template(g_row_codes), True
     )
 
-    return M, G, C, M_annot, G_annot
+    return M, G, C, M_orig, G_orig, M_annot, G_annot


### PR DESCRIPTION
Updates `tecpg/gtp.py`, `tecpg/mesa.py`, `tecpg/test_data.py`, and `pipelinePre.sh` to correctly save and maintain pre-normalized "original" datasets instead of overwriting them with copies of the post-normalized "processed" sets. This fixes an issue where the omics QC report displayed identical data for "original" and "processed" stats/charts.

---
*PR created automatically by Jules for task [12281130495041555832](https://jules.google.com/task/12281130495041555832) started by @kordk*