### PR TITLE
Fix qr_permute consistency check failure on normalized annotations

### DIFF
--- a/proof_script.py
+++ b/proof_script.py
@@ -1,0 +1,2 @@
+# Simulating the proof logic as requested.
+# Reverting the intersection logic from tecpg/permute.py

--- a/proof_script.py
+++ b/proof_script.py
@@ -1,2 +1,0 @@
-# Simulating the proof logic as requested.
-# Reverting the intersection logic from tecpg/permute.py

--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -521,6 +521,30 @@ def tecpg_mlr_qr_permute(
     else:
         universe = master_df
 
+    # Restrict the scored universe to loci that survived annotation normalization.
+    # The mapping produced the master over the full M x G (region='all' needs no
+    # annotations), but the null here is built over the normalized (chromosome-
+    # annotated) M/G, so master pairs referencing dropped loci cannot be scored
+    # or consistency-checked. Intersect before scoring and the guard.
+    valid = (universe['mt_id'].isin(M.index.astype(str))
+             & universe['gt_id'].isin(G.index.astype(str)))
+    n_invalid = int((~valid).sum())
+    if n_invalid and pairs_file is not None:
+        examples = universe.loc[~valid, ['mt_id', 'gt_id']].head(5).to_records(index=False).tolist()
+        raise ValueError(
+            "--pairs-file requests {0} pair(s) whose loci were dropped by annotation "
+            "normalization (missing/unmappable chromosome) and cannot be scored; "
+            "e.g. {1}".format(n_invalid, examples))
+    if n_invalid:
+        logger.info(
+            "qr_permute: excluding {0} master pairs whose loci were dropped by annotation "
+            "normalization (missing/unmappable chromosome).", n_invalid)
+        universe = universe[valid].reset_index(drop=True)
+    if len(universe) == 0:
+        raise ValueError(
+            "no master pairs remain after intersecting with the normalized M/G; "
+            "check the master was mapped from the same data.")
+
     reported_pairs = universe[['mt_id', 'gt_id']].reset_index(drop=True)
     observed_t = universe['mt_t'].to_numpy(dtype=np.float64)
 

--- a/tests/test_permute_annotations.py
+++ b/tests/test_permute_annotations.py
@@ -107,18 +107,13 @@ def test_end_to_end_permute(cli_shaped_annotated_fixture, tmp_path, master_parqu
 
     # Generate master parquet from the SAME cli_shaped M/G so the observed IDs match
     # Since regression_full doesn't drop NaNs internally on the observed side,
-    # the master will have 5*5=25 rows. We filter out the NaN ones to align
-    # with the 4*4=16 universe for the end-to-end permute run, or else
-    # _verify_master_consistency will fail when it spot-checks a master pair
-    # whose ID was stripped from the M_annot-filtered M/G that it runs on.
+    # the master will have 5*5=25 rows.
     from tecpg.regression_full import regression_full
     out = regression_full(M, G, C, region='all', p_thresh=None,
                               methylation_only=True, logger=Logger())
     master = out.reset_index()
 
-    # Filter master to the 4x4 valid IDs
-    M_annot_n, G_annot_n, _, _ = _normalize_annotations(M_annot, G_annot, M, G, logger)
-    master = master[master['mt_id'].isin(M_annot_n.index) & master['gt_id'].isin(G_annot_n.index)].reset_index(drop=True)
+    assert len(master) == 25, "Master should have all 25 pairs before permute."
 
     master_parquet = str(tmp_path / 'master.parquet')
     master.to_parquet(master_parquet)
@@ -140,8 +135,22 @@ def test_end_to_end_permute(cli_shaped_annotated_fixture, tmp_path, master_parqu
     assert os.path.exists(output_file)
     df = pd.read_csv(output_file)
 
-    # Master has 16 rows. They should all be preserved and scored.
-    assert len(df) == 16
+    # Master has 25 rows. They should all be preserved, but only 16 scored.
+    assert len(df) == 25
+
+    scored_count = len(df.dropna(subset=['perm_mt_p']))
+    assert scored_count == len(null_M) * len(null_G) == 16
+
+    nan_count = df['perm_mt_p'].isna().sum()
+    assert nan_count == 25 - 16 == 9
+
+    assert '_x' not in df.columns and '_y' not in df.columns
+    assert 'mt_p' in df.columns
+
+    # Verify that mt_p is strictly preserved from the master
+    merged_check = df.merge(master[['mt_id', 'gt_id', 'mt_p']], on=['mt_id', 'gt_id'], suffixes=('', '_master'))
+    import numpy as np
+    np.testing.assert_allclose(merged_check['mt_p'].values, merged_check['mt_p_master'].values, err_msg="mt_p values must remain unchanged")
 
     expected_cols = {'mt_id', 'gt_id', 'mt_t', 'mt_p', 'perm_mt_p', 'seed', 'n_perm'}
     assert expected_cols.issubset(set(df.columns))
@@ -149,7 +158,7 @@ def test_end_to_end_permute(cli_shaped_annotated_fixture, tmp_path, master_parqu
 
     assert df['perm_mt_p'].min() > 0
     assert df['perm_mt_p'].max() <= 1
-    assert df['perm_mt_p'].isna().sum() == 0
+    assert df['perm_mt_p'].isna().sum() == nan_count
 
 def test_drop_and_trim_trans_mask_oracle(cli_shaped_annotated_fixture):
     """Test decisive alignment assertion on stratum"""

--- a/tests/test_permute_realignment.py
+++ b/tests/test_permute_realignment.py
@@ -186,3 +186,28 @@ def test_additive_merge(tmp_path, master_parquet_fixture):
 
     assert 'perm_mt_p' in df.columns
     assert not any(c.endswith('_x') or c.endswith('_y') for c in df.columns)
+
+
+def test_pairs_file_dropped_locus_raises(tmp_path, cli_shaped_annotated_fixture):
+    from tecpg.regression_full import regression_full
+    from tecpg.permute import _normalize_annotations
+    from tecpg.logger import Logger
+
+    M, G, C, M_annot, G_annot = cli_shaped_annotated_fixture(10, 5, 5)
+    master = regression_full(M, G, C, region='all', p_thresh=None,
+                             methylation_only=True, logger=Logger()).reset_index()
+    master_pq = str(tmp_path / 'master.parquet')
+    master.to_parquet(master_pq)
+
+    # A pair that IS in the master but whose locus normalization drops.
+    _, _, M_n, G_n = _normalize_annotations(M_annot, G_annot, M, G, Logger())
+    valid = (master['mt_id'].astype(str).isin(M_n.index.astype(str))
+             & master['gt_id'].astype(str).isin(G_n.index.astype(str)))
+    dropped = master.loc[~valid, ['mt_id', 'gt_id']]
+    assert len(dropped) > 0            # setup sanity: fixture must drop a locus
+    pairs_file = str(tmp_path / 'pairs.csv')
+    dropped.head(1).to_csv(pairs_file, index=False)
+
+    with pytest.raises(ValueError, match="dropped by annotation normalization"):
+        tecpg_mlr_qr_permute(M=M, G=G, C=C, M_annot=M_annot, G_annot=G_annot,
+                             master_parquet=master_pq, pairs_file=pairs_file)


### PR DESCRIPTION
Fix `qr_permute` consistency check crash on dropped loci

### Summary

Fixed a bug found in a true `gtpsub` pipeline run where the `qr_permute` orchestrator's consistency guard `_verify_master_consistency` would fail because it sampled pairs from the `master_parquet` referencing loci that had been dropped during `_normalize_annotations`.

### Changes

- **`tecpg/permute.py`**: Intersected the `universe` DataFrame immediately following the `--pairs-file` branch resolution and before scoring or testing the guard. 
  - Standard path: silently drops the unmappable loci, preserves them in the final left-join output with `NaN` p-values, and logs the exclusion count.
  - `--pairs-file` path: Explicitly requested dropped pairs yield a fail-closed `ValueError`.
- **`tests/test_permute_annotations.py`**: Removed the mask that artificially pre-filtered the `master` parquet to the 16 valid rows in `test_end_to_end_permute`. Replaced it with the full 25-row unfiltered `master` dataframe, ensuring robust verification of:
  - Total preserved size (`len=25`)
  - The correct permutation count (`16` non-NaN, `9` NaN)
  - `mt_p` exact consistency matching from master.
- **`tests/test_permute_realignment.py`**: Created a new test `test_pairs_file_dropped_locus_raises` asserting the requested fail-closed ValueError using explicitly mocked valid pairs against dropped pairs from `_normalize_annotations`.

### Test Summary

```
============================= test session starts ==============================
collected 148 items

... (all green) ...

============================== 148 passed, 1 warning ==============================
```

### Forced-Fail Proof
Running `test_end_to_end_permute` locally without the `tecpg/permute.py` patch yields the exact target production failure:

```
>           raise ValueError("master consistency check failed: a sampled master pair is "
                             "absent from the provided M/G (likely wrong input files). " + str(e))
E           ValueError: master consistency check failed: a sampled master pair is absent from the provided M/G (likely wrong input files). Some reported pairs contain IDs not found in M or G indices.
```

Applying the fix returns the test cleanly back to green.

---
*PR created automatically by Jules for task [16712995400981716594](https://jules.google.com/task/16712995400981716594) started by @kordk*