### PR TITLE
qr_permute: make the master-consistency guard advisory (warn, don't stop) + recalibrate tolerance

### DIFF
--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -407,19 +407,18 @@ def _fit_tail(empirical_p, observed_stats, null_accumulator, logger):
 
 
 def _verify_master_consistency(M, G, C, universe, device, logger,
-                               *, n_sample=256, rtol=1e-4, atol=1e-4, seed=42):
+                               *, n_sample=256, rtol=1e-2, atol=1e-2, seed=42):
     """Sampled equivalence spot-check. Recompute the observed t for a small
     random sample of master pairs from the provided M/G/C and assert it matches
-    the stored mt_t. Fail-closed on divergence (covariate design / df mismatch)
-    or on a sampled pair absent from M/G (wrong input files). O(sample), not
-    O(universe). Constants are provisional; a design mismatch produces O(1)+
-    divergences in t, so atol=1e-4 catches the hazard while absorbing the
-    float32/float64 gap between regression_full and the recompute."""
+    the stored mt_t. This is an advisory guard (warns, never raises). Tolerance
+    is calibrated to the float32 floor between two QR solvers on real data (~1e-2
+    observed on gtpsub)."""
     mt_t = universe['mt_t'].to_numpy(dtype=np.float64)
     finite = np.isfinite(mt_t)
     n_finite = int(finite.sum())
     if n_finite == 0:
-        raise ValueError("master parquet has no finite mt_t to validate against")
+        logger.warning("MASTER CONSISTENCY WARNING -- master parquet has no finite mt_t to validate against.")
+        return
     idx_finite = np.flatnonzero(finite)
     k = min(n_sample, n_finite)
     rng = np.random.default_rng(seed)
@@ -432,14 +431,28 @@ def _verify_master_consistency(M, G, C, universe, device, logger,
             dtype=np.float64,
         )
     except ValueError as e:
-        raise ValueError("master consistency check failed: a sampled master pair is "
-                         "absent from the provided M/G (likely wrong input files). " + str(e))
+        logger.warning("MASTER CONSISTENCY WARNING -- proceeding, but review this:")
+        logger.warning("A sampled master pair is absent from the provided M/G (likely wrong input files).")
+        logger.warning("The master may be from different data, proceeding UNVERIFIED. {0}", str(e))
+        return
     if not np.allclose(recomputed, stored, rtol=rtol, atol=atol, equal_nan=True):
         max_dev = float(np.nanmax(np.abs(recomputed - stored)))
-        raise ValueError("master mt_t is inconsistent with the provided M/G/C over "
-                         "{0} sampled pairs (max|Δt|={1:.3e}); the covariate design/df "
-                         "that produced the master must match the null design.".format(k, max_dev))
-    logger.info("master consistency OK: {0} sampled pairs, max|Δt|={1:.3e}",
+        corr = (float(np.corrcoef(stored, recomputed)[0, 1])
+                if np.nanstd(stored) > 0 else float('nan'))
+        logger.warning("=" * 72)
+        logger.warning("MASTER CONSISTENCY WARNING -- proceeding, but review this:")
+        logger.warning("Stored mt_t vs recomputed differ over {0} sampled pairs:", k)
+        logger.warning("  max|dt|={0:.3e}  corr={1:.6f}  (tol atol={2:.1e} rtol={3:.1e})",
+                       max_dev, corr, atol, rtol)
+        logger.warning("corr ~ 1.0 => benign float32 divergence between the mapping and")
+        logger.warning("permute QR solvers (same algorithm, same df) on real-scale data.")
+        logger.warning("corr well below 1.0, OR a large max|dt|, suggests the master was")
+        logger.warning("mapped with a DIFFERENT covariate design than this run's C -- in")
+        logger.warning("which case the permutation p-values are INVALID.")
+        logger.warning("Verify the master was mapped from the same data/covariates. Continuing.")
+        logger.warning("=" * 72)
+        return
+    logger.info("master consistency OK: {0} sampled pairs, max|dt|={1:.3e}",
                 k, float(np.nanmax(np.abs(recomputed - stored))))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,9 @@ def cli_shaped_annotated_fixture():
 @pytest.fixture
 def master_parquet_fixture(annotated_fixture, tmp_path):
     """Mapping output (a master parquet with mt_t) over the M×G universe,
-    for the realigned qr_permute consume path."""
+    for the realigned qr_permute consume path.
+    Note: Production uses `tecpg_mlr_qr` (QR), but this fixture uses `regression_full`
+    to avoid heavy plumbing. The tolerance is calibrated from real qr-mapped runs."""
     def _make(sample_size=20, m_rows=6, g_rows=5, seed=42, region='all'):
         from tecpg.regression_full import regression_full
         from tecpg.logger import Logger

--- a/tests/test_permute_realignment.py
+++ b/tests/test_permute_realignment.py
@@ -87,15 +87,16 @@ def test_three_way_equivalence_oracle(tmp_path, master_parquet_fixture):
     np.testing.assert_allclose(t_read, t_recompute, rtol=1e-4, atol=1e-4)
     np.testing.assert_allclose(t_read, t_ols, rtol=1e-4, atol=1e-4)
 
-def test_consistency_guard_passes(master_parquet_fixture):
+def test_consistency_guard_passes(master_parquet_fixture, capsys):
     """6b. Consistency guard - pass."""
     master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=10, g_rows=10)
 
     logger = Logger()
-    # Should run cleanly without raising
+    # Should run cleanly without raising and without warnings
     _verify_master_consistency(M, G, C, master_df, None, logger, seed=42)
+    assert "MASTER CONSISTENCY WARNING" not in capsys.readouterr().out
 
-def test_consistency_guard_fail_design(master_parquet_fixture):
+def test_consistency_guard_fail_design(master_parquet_fixture, capsys):
     """6b. Consistency guard - fail-design."""
     master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=10, g_rows=10)
 
@@ -103,10 +104,10 @@ def test_consistency_guard_fail_design(master_parquet_fixture):
     C_perturbed = C.copy()
     C_perturbed['dummy'] = np.random.rand(len(C))
 
-    with pytest.raises(ValueError, match="master mt_t is inconsistent with the provided M/G/C"):
-        _verify_master_consistency(M, G, C_perturbed, master_df, None, Logger(), seed=42)
+    _verify_master_consistency(M, G, C_perturbed, master_df, None, Logger(), seed=42)
+    assert "MASTER CONSISTENCY WARNING" in capsys.readouterr().out
 
-def test_consistency_guard_fail_data(master_parquet_fixture):
+def test_consistency_guard_fail_data(master_parquet_fixture, capsys):
     """6b. Consistency guard - fail-data."""
     master_parquet, M, G, C, M_annot, G_annot, master_df = master_parquet_fixture(sample_size=30, m_rows=10, g_rows=10)
 
@@ -114,8 +115,8 @@ def test_consistency_guard_fail_data(master_parquet_fixture):
     M_disjoint = M.copy()
     M_disjoint.index = [f"disjoint_m{i}" for i in range(len(M))]
 
-    with pytest.raises(ValueError, match="master consistency check failed"):
-        _verify_master_consistency(M_disjoint, G, C, master_df, None, Logger(), seed=42)
+    _verify_master_consistency(M_disjoint, G, C, master_df, None, Logger(), seed=42)
+    assert "MASTER CONSISTENCY WARNING" in capsys.readouterr().out
 
 def test_pairs_file_subset(tmp_path, master_parquet_fixture):
     """6c. --pairs-file subset."""


### PR DESCRIPTION
- Modified `_verify_master_consistency` to warn instead of raise on all failure paths.
- Updated default tolerance limits to `1e-2` for `rtol` and `atol` to account for float32 divergence on real-data runs.
- Updated unit tests in `test_permute_realignment.py` to use `capsys` and assert warning text.
- Re-verified forced fail output locally before committing.

---
*PR created automatically by Jules for task [1142368802668652687](https://jules.google.com/task/1142368802668652687) started by @kordk*