### PR TITLE
chore(eval_permute): demote lambda_excess from stratify verdict gating

### DIFF
--- a/tests/test_eval_permute.py
+++ b/tests/test_eval_permute.py
@@ -483,7 +483,63 @@ def test_stratify_decision_smoke(tmp_path):
 
     with open(out_dir3 / "eval_permute_report.json") as f:
         rep3 = json.load(f)
-    assert rep3['arms']['stratify_decision']['recommendation'] == "inconclusive_cis_signal_confound"
+    # lambda_excess no longer gates the verdict; divergence causes a warrant.
+    assert rep3['arms']['stratify_decision']['recommendation'] == "stratification_warranted"
+
+def test_lambda_excess_does_not_gate(tmp_path):
+    """
+    Demonstrates the demotion of lambda_excess from gating factor.
+    We construct a case where lambda_excess > 0.2 and delta >= 0.5.
+    The verdict should be "stratification_warranted", not an inconclusive confound.
+    """
+    script_path = os.path.join(os.path.dirname(__file__), "..", "tools", "eval_permute.py")
+    df_val = 50
+    rng = np.random.default_rng(42)
+    n = 10000
+
+    m_annot = pd.DataFrame({'name': [f'm{i}' for i in range(n)], 'chrom': [1]*n})
+    g_annot = pd.DataFrame({'name': [f'g{i}' for i in range(n)], 'chrom': [1]*(n//2) + [2]*(n//2)})
+
+    m_annot_path = tmp_path / "m_annot.csv"
+    g_annot_path = tmp_path / "g_annot.csv"
+    m_annot.to_csv(m_annot_path, index=False)
+    g_annot.to_csv(g_annot_path, index=False)
+
+    t_vals = scipy.stats.t.rvs(df_val, size=n, random_state=rng)
+    p_ana = 2.0 * scipy.stats.t.sf(np.abs(t_vals), df_val)
+
+    p_perm = p_ana.copy()
+    p_perm[:n//2] = p_perm[:n//2] * 0.05
+    t_vals_inflated = t_vals.copy()
+    t_vals_inflated[:n//2] = t_vals_inflated[:n//2] * 2.0  # Inflate cis t-values substantially
+
+    output = pd.DataFrame({
+        'mt_id': [f'm{i}' for i in range(n)],
+        'gt_id': [f'g{i}' for i in range(n)],
+        'mt_t': t_vals_inflated,
+        'perm_mt_p': p_perm
+    })
+    out_path = tmp_path / "out.parquet"
+    pq.write_table(pa.Table.from_pandas(output), out_path)
+
+    out_dir = tmp_path / "dir_lambda_gate"
+    subprocess.run([
+        sys.executable, script_path,
+        "--perm-output", str(out_path),
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--df", str(df_val),
+        "--out-dir", str(out_dir)
+    ], check=True)
+
+    with open(out_dir / "eval_permute_report.json") as f:
+        rep = json.load(f)
+
+    strat = rep['arms']['stratify_decision']
+    assert 'recommendation' in strat                         # block executed, not skipped
+    assert abs(strat['delta_median_log10_ratio']) >= 0.5     # divergence present
+    assert strat['lambda_excess'] > 0.2                      # λ still high AND still reported ...
+    assert strat['recommendation'] == "stratification_warranted"   # ... but no longer gates to inconclusive
 
 # ==============================================================================
 # ORACLE 6: SIDECAR-ABSENT SMOKE

--- a/tools/eval_permute.py
+++ b/tools/eval_permute.py
@@ -19,7 +19,6 @@ BULK_LO = 0.05
 BULK_HI = 1.0  # mostly-null band for divergence
 TAIL_P_ANA = 1e-4  # tail band for arm (a)
 TOLERANCE_MEDIAN_LOG10_RATIO_DIFF = 0.5  # |Δ| below this => strata agree
-LAMBDA_EXCESS_CONFOUND_FLAG = 0.2  # (λ_cis − λ_trans) above this => cis signal-contaminated
 
 # Frozen Sidecar Contract: The sidecar .npz is expected to have these exactly.
 # Arrays: bin_edges, hist_counts, overflow_count, total_count, topk_values
@@ -341,13 +340,16 @@ def main():
         stratify['ks_stat'] = float(ks_stat2)
         stratify['ks_p'] = float(ks_p2)
 
+        # lambda_excess is reported as a DESCRIPTIVE diagnostic only. Genomic
+        # inflation (lambda_GC) presumes a mostly-null test space, which eQTM —
+        # and cis in particular — violates: high lambda_cis is expected biology,
+        # not miscalibration, so it must not gate the verdict. The stratify
+        # decision keys on the calibration-divergence effect size (delta) alone.
         lambda_excess = (lambda_cis - lambda_trans) if (lambda_cis is not None and lambda_trans is not None) else 0.0
         stratify['lambda_excess'] = float(lambda_excess)
 
         if abs(delta) < TOLERANCE_MEDIAN_LOG10_RATIO_DIFF:
             rec = "single_global_null_adequate"
-        elif lambda_excess > LAMBDA_EXCESS_CONFOUND_FLAG:
-            rec = "inconclusive_cis_signal_confound"
         else:
             rec = "stratification_warranted"
 


### PR DESCRIPTION
# Chunk: demote `lambda_excess` from the stratify verdict — λ is a diagnostic, not a gate

**Context:** The current script wrongly penalized high `lambda_cis` by assuming a mostly-null test space, causing clean datasets with real cis signals to be misclassified as `inconclusive_cis_signal_confound`. High lambda in cis is an expected biological feature of eQTM, not miscalibration.

**Changes:**
1. Demoted `lambda_excess` from acting as a gate on the `stratify_decision` output.
2. Deleted the string `"inconclusive_cis_signal_confound"` from code and tests.
3. Updated `test_stratify_decision_smoke` Case 3 to test routing to `stratification_warranted`.
4. Added `test_lambda_excess_does_not_gate` as the required invariant to show that large λ is calculated and reported, but the verdict operates off of calibration-divergence (delta) and leads to `stratification_warranted`.

**Deliverables:**
- Both grep strings are completely removed. 
- All python tests pass without errors (collected count 20 tests total: 20 pass before/after logic cleanup).
- The forced fail proof returned:
```
E       AssertionError: assert 'inconclusive...gnal_confound' == 'stratification_warranted'
E         
E         - stratification_warranted
E         + inconclusive_cis_signal_confound
```
- Dev Tip SHA at checkout: `27663d355f453359e500af4e46d0cf6fccef6727`.

---
*PR created automatically by Jules for task [11929369162993132975](https://jules.google.com/task/11929369162993132975) started by @kordk*