### PR TITLE
Add reservoir auto-convert and permutation-vs-analytic summary tool

### DIFF
--- a/pipelinePermute.sh
+++ b/pipelinePermute.sh
@@ -13,6 +13,7 @@ DATASET="dummy"
 MAPPING="all"
 START_STAGE="all"
 MASTER_PARQUET=""
+USE_RESERVOIR=0
 
 PERMUTE_ARGS=()
 
@@ -30,7 +31,8 @@ while [[ "$#" -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  -h, --help                     Show this help message and exit"
-            echo "      --master-parquet PATH      REQUIRED. Existing mapping output parquet (carries mt_t)"
+            echo "      --master-parquet PATH      REQUIRED (if no --reservoir). Existing mapping output parquet"
+            echo "      --reservoir                REQUIRED (if no --master-parquet). Convert and use sample_reservoir.csv"
             echo "                                 whose (mt_id, gt_id) universe is scored. Must have been"
             echo "                                 mapped from the SAME data_<ds> (same covariate design);"
             echo "                                 qr_permute fail-closes at runtime if the design mismatches."
@@ -57,6 +59,11 @@ while [[ "$#" -gt 0 ]]; do
         --master-parquet)
             MASTER_PARQUET="$2"
             shift 2
+            ;;
+
+        --reservoir)
+            USE_RESERVOIR=1
+            shift
             ;;
         -m|--mapping)
             MAPPING="$2"
@@ -86,22 +93,13 @@ while [[ "$#" -gt 0 ]]; do
     esac
 done
 
-# qr_permute is a post-mapping consumer: the master parquet is required and
-# supplies the observed mt_t and the (mt_id, gt_id) universe. Running the
-# mapping is out of scope for this wrapper -- produce the master first (e.g.
-# pipeline.sh -> output_<ds>/merged.parquet) and pass it here.
-if [ -z "$MASTER_PARQUET" ]; then
-    log "Error: --master-parquet is required."
-    log "  qr_permute consumes an existing mapping output (the master parquet); it does not"
-    log "  recompute the observed statistic. Produce the master first (e.g. via pipeline.sh,"
-    log "  which writes output_<ds>/merged.parquet) and pass it with --master-parquet PATH."
+# qr_permute is a post-mapping consumer: it requires an observed statistic master.
+if [ -z "$MASTER_PARQUET" ] && [ $USE_RESERVOIR -eq 0 ]; then
+    log "Error: Exactly one of --master-parquet or --reservoir is required."
     exit 1
 fi
-
-if [ ! -s "$MASTER_PARQUET" ]; then
-    log "Error: master parquet not found or empty: $MASTER_PARQUET"
-    log "  Check the path. It should be an existing mapping output carrying an 'mt_t' column"
-    log "  (e.g. output_<ds>/merged.parquet from a prior pipeline.sh run)."
+if [ -n "$MASTER_PARQUET" ] && [ $USE_RESERVOIR -eq 1 ]; then
+    log "Error: --master-parquet and --reservoir are mutually exclusive."
     exit 1
 fi
 
@@ -175,6 +173,26 @@ OUT_DIR="output_${DATASET}"
 DATA_DIR="data_${DATASET}"
 ANNOT_DIR="annot_${DATASET}"
 mkdir -p "$OUT_DIR" "$DATA_DIR" "$ANNOT_DIR"
+
+if [ $USE_RESERVOIR -eq 1 ]; then
+    RESERVOIR_CSV="${OUT_DIR}/sample_reservoir.csv"
+    if [ ! -s "$RESERVOIR_CSV" ]; then
+        log "Error: --reservoir passed but $RESERVOIR_CSV not found or empty."
+        log "  Check that mapping was run with --reservoir-count."
+        exit 1
+    fi
+    log "Converting $RESERVOIR_CSV to parquet..."
+    python3 tools/reservoir_to_parquet.py --in "$RESERVOIR_CSV" --out "${OUT_DIR}/reservoir_master.parquet"
+    MASTER_PARQUET="${OUT_DIR}/reservoir_master.parquet"
+fi
+
+if [ ! -s "$MASTER_PARQUET" ]; then
+    log "Error: master parquet not found or empty: $MASTER_PARQUET"
+    log "  Check the path. It should be an existing mapping output carrying an 'mt_t' column"
+    log "  (e.g. output_<ds>/merged.parquet from a prior pipeline.sh run)."
+    exit 1
+fi
+
 
 for f in M.csv G.csv C.csv; do
     [ -s "$DATA_DIR/$f" ] || { log "Error: $DATA_DIR/$f missing or empty. Run ./pipelinePre.sh --dataset $DATASET first."; exit 1; }
@@ -271,4 +289,17 @@ if [ $EXECUTE -eq 1 ]; then
         --out-dir "$OUT_DIR"
 
     log "Finished eval_permute. Report at $OUT_DIR/eval_permute_report.json"
+fi
+
+
+if [ $EXECUTE -eq 1 ]; then
+    log "[3/3] Running summary..."
+    python3 tools/summarize_permute.py \
+        --perm-output "$PERM_OUTPUT" \
+        --report "${OUT_DIR}/eval_permute_report.json" \
+        --df "$DF" \
+        --m-annot "$ANNOT_DIR/M.bed6" \
+        --g-annot "$ANNOT_DIR/G.bed6" \
+        --out-dir "$OUT_DIR"
+    log "Finished summarize_permute."
 fi

--- a/tests/test_reservoir_to_parquet.py
+++ b/tests/test_reservoir_to_parquet.py
@@ -1,0 +1,52 @@
+import pandas as pd
+import pytest
+import subprocess
+import sys
+from pathlib import Path
+
+def test_reservoir_to_parquet_success(tmp_path):
+    csv_path = tmp_path / "sample_reservoir.csv"
+    parquet_path = tmp_path / "reservoir_master.parquet"
+
+    df = pd.DataFrame({
+        "gt_id": ["g1", "g2"],
+        "mt_id": ["m1", "m2"],
+        "mt_t": [1.5, 2.5]
+    })
+    df.to_csv(csv_path, index=False)
+
+    cmd = [
+        sys.executable, "tools/reservoir_to_parquet.py",
+        "--in", str(csv_path),
+        "--out", str(parquet_path)
+    ]
+
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+    assert parquet_path.exists()
+    df_out = pd.read_parquet(parquet_path)
+    assert set(df_out.columns).issuperset({"mt_id", "gt_id", "mt_t"})
+    assert df_out["mt_t"].tolist() == [1.5, 2.5]
+
+def test_reservoir_to_parquet_missing_col(tmp_path):
+    csv_path = tmp_path / "sample_reservoir_bad.csv"
+    parquet_path = tmp_path / "reservoir_master_bad.parquet"
+
+    df = pd.DataFrame({
+        "gt_id": ["g1", "g2"],
+        "mt_id": ["m1", "m2"]
+        # mt_t is missing
+    })
+    df.to_csv(csv_path, index=False)
+
+    cmd = [
+        sys.executable, "tools/reservoir_to_parquet.py",
+        "--in", str(csv_path),
+        "--out", str(parquet_path)
+    ]
+
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    assert res.returncode != 0
+    assert "Reservoir CSV missing required columns" in res.stderr
+    assert "mt_t" in res.stderr

--- a/tests/test_summarize_permute.py
+++ b/tests/test_summarize_permute.py
@@ -1,0 +1,127 @@
+import json
+import os
+import subprocess
+import sys
+import pandas as pd
+import numpy as np
+
+from tools.summarize_permute import build_summary_text
+
+def test_build_summary_text_populated():
+    report = {
+        "metadata": {
+            "n_pairs_input": 100,
+            "n_pairs_dropped_unmappable_chrom": 10,
+            "n_pairs_scored": 90,
+            "n_cis": 40,
+            "n_trans": 50
+        },
+        "arms": {
+            "calibration": {
+                "all": {"bulk_spearman_corr": 0.99, "bulk_median_abs_log_ratio": 0.01},
+                "cis": {"bulk_spearman_corr": 0.98, "bulk_median_abs_log_ratio": 0.02},
+                "trans": {"bulk_spearman_corr": 0.97, "bulk_median_abs_log_ratio": 0.03}
+            },
+            "null_sanity": {
+                "lambda_trans": 1.05,
+                "lambda_cis": 1.10
+            },
+            "stratify_decision": {
+                "recommendation": "stratification_warranted",
+                "delta_median_log10_ratio": 0.5,
+                "test_p": 1e-4,
+                "ks_p": 1e-5
+            }
+        }
+    }
+
+    text = build_summary_text(report)
+    assert "stratification_warranted" in text, "Verdict should be included in the text"
+    assert "0.0200" in text, "Cis median difference should be formatted and included"
+    assert "1.05" in text, "lambda_trans should be included"
+
+def test_build_summary_text_missing():
+    report = {
+        "metadata": {
+            "n_pairs_input": 100,
+            "n_pairs_dropped_unmappable_chrom": 0,
+            "n_pairs_scored": 100,
+            "n_cis": 0,
+            "n_trans": 0
+        },
+        "arms": {
+            "calibration": {},
+            "null_sanity": {},
+            "stratify_decision": {
+                "status": "skipped_insufficient_data"
+            }
+        }
+    }
+    text = build_summary_text(report)
+    assert "skipped due to insufficient data" in text
+    assert "bulk not computed" in text
+
+def test_smoke_summarize_permute(tmp_path):
+    report_path = tmp_path / "eval_permute_report.json"
+    perm_path = tmp_path / "permutation_results.parquet"
+    out_dir = tmp_path / "out"
+    m_annot_path = tmp_path / "M.bed6"
+    g_annot_path = tmp_path / "G.bed6"
+
+    report_data = {
+        "metadata": {"n_pairs_input": 10},
+        "arms": {
+            "calibration": {"all": {"bulk_spearman_corr": 0.9, "bulk_median_abs_log_ratio": 0.1}},
+            "null_sanity": {"lambda_trans": 1.0, "lambda_cis": 1.0},
+            "stratify_decision": {"recommendation": "single_global_null_adequate", "delta_median_log10_ratio": 0.0, "test_p": 0.5, "ks_p": 0.5}
+        }
+    }
+
+    with open(report_path, "w") as f:
+        json.dump(report_data, f)
+
+    df = pd.DataFrame({
+        "mt_id": ["m1", "m2", "m3"],
+        "gt_id": ["g1", "g2", "g3"],
+        "mt_t": [1.0, 2.0, 3.0],
+        "perm_mt_p": [0.1, 0.05, 0.01]
+    })
+    df.to_parquet(perm_path)
+
+    m_annot = pd.DataFrame({
+        0: ["chr1", "chr2", "chr3"],
+        1: [1, 2, 3],
+        2: [10, 20, 30],
+        3: ["m1", "m2", "m3"],
+        4: [0, 0, 0],
+        5: ["+", "+", "+"]
+    })
+    m_annot.to_csv(m_annot_path, sep="\t", header=False, index=False)
+
+    g_annot = pd.DataFrame({
+        0: ["chr1", "chr2", "chr4"],
+        1: [1, 2, 3],
+        2: [10, 20, 30],
+        3: ["g1", "g2", "g3"],
+        4: [0, 0, 0],
+        5: ["+", "+", "+"]
+    })
+    g_annot.to_csv(g_annot_path, sep="\t", header=False, index=False)
+
+    cmd = [
+        sys.executable, "tools/summarize_permute.py",
+        "--perm-output", str(perm_path),
+        "--report", str(report_path),
+        "--df", "100",
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--out-dir", str(out_dir)
+    ]
+
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+    assert (out_dir / "permute_vs_analytic_summary.md").exists()
+    assert (out_dir / "qq_perm_vs_analytic.png").exists()
+    assert (out_dir / "dist_overlap_p.png").exists()
+    assert (out_dir / "dist_tstat.png").exists()

--- a/tools/reservoir_to_parquet.py
+++ b/tools/reservoir_to_parquet.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import pandas as pd
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert sample_reservoir.csv to reservoir_master.parquet")
+    parser.add_argument("--in", dest="in_file", required=True, help="Input CSV file (e.g., sample_reservoir.csv)")
+    parser.add_argument("--out", dest="out_file", required=True, help="Output parquet file")
+
+    args = parser.parse_args()
+
+    try:
+        df = pd.read_csv(args.in_file)
+    except FileNotFoundError:
+        logger.error(f"Input file not found: {args.in_file}")
+        sys.exit(1)
+    except pd.errors.EmptyDataError:
+        logger.error(f"Input file is empty: {args.in_file}")
+        sys.exit(1)
+
+    required_cols = {'mt_id', 'gt_id', 'mt_t'}
+    missing = required_cols - set(df.columns)
+
+    if missing:
+        raise ValueError(f"Reservoir CSV missing required columns: {missing}")
+
+    df.to_parquet(args.out_file, index=False)
+    logger.info(f"Successfully converted {args.in_file} to {args.out_file}")
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        sys.exit(1)

--- a/tools/summarize_permute.py
+++ b/tools/summarize_permute.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import logging
+import os
+import sys
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import scipy.stats
+import pyarrow.parquet as pq
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger(__name__)
+
+def label_strata(output, m_annot, g_annot):
+    # Same as eval_permute.py
+    def norm_chrom(s):
+        isna = s.isna()
+        s = s.astype(str)
+        s = s.str.replace(r'^chr', '', regex=True, case=False)
+        s = s.str.upper()
+        s = s.mask(isna, other=pd.NA)
+        return s.to_numpy(dtype=object)
+
+    m_chrom = norm_chrom(m_annot['chrom'])
+    g_chrom = norm_chrom(g_annot['chrom'])
+
+    m_mapped = m_annot.index.astype(str).get_indexer(output['mt_id'].astype(str))
+    g_mapped = g_annot.index.astype(str).get_indexer(output['gt_id'].astype(str))
+
+    if (m_mapped == -1).any() or (g_mapped == -1).any():
+        raise ValueError("Reported mt_id/gt_id missing from annotations.")
+
+    is_cis = (m_chrom[m_mapped] == g_chrom[g_mapped]) & (~pd.isna(m_chrom[m_mapped]))
+
+    # Cis window is not re-derived here, using simple chrom match to replicate eval's fallback
+    strata = np.where(is_cis, 'cis', 'trans')
+
+    # Handle missing chromosomes
+    unmappable = pd.isna(m_chrom[m_mapped]) | pd.isna(g_chrom[g_mapped])
+    strata[unmappable] = 'dropped'
+
+    return strata
+
+def build_summary_text(report_dict: dict) -> str:
+    lines = []
+    lines.append("# Permutation vs Analytic p-value Summary\n")
+
+    meta = report_dict.get("metadata", {})
+    lines.append(f"**Pairs Input:** {meta.get('n_pairs_input', 'N/A')}")
+    lines.append(f"**Pairs Dropped (Unmappable):** {meta.get('n_pairs_dropped_unmappable_chrom', 'N/A')}")
+    lines.append(f"**Pairs Scored:** {meta.get('n_pairs_scored', 'N/A')} (Cis: {meta.get('n_cis', 'N/A')}, Trans: {meta.get('n_trans', 'N/A')})")
+
+    lines.append("\n## Calibration Agreement")
+    calib = report_dict.get("arms", {}).get("calibration", {})
+
+    for stratum in ["all", "cis", "trans"]:
+        c = calib.get(stratum)
+        if c:
+            spearman = c.get("bulk_spearman_corr")
+            median_diff = c.get("bulk_median_abs_log_ratio")
+            if spearman is not None and median_diff is not None:
+                lines.append(f"- **{stratum.capitalize()}:** in the null bulk, permutation and analytic p agree well (median |log10 ratio| = {median_diff:.4f}); Spearman = {spearman:.4f}")
+            else:
+                lines.append(f"- **{stratum.capitalize()}:** bulk not computed (master appears threshold-filtered)")
+        else:
+            lines.append(f"- **{stratum.capitalize()}:** bulk not computed (master appears threshold-filtered)")
+
+    lines.append("\n## Null Sanity & Stratification")
+    sanity = report_dict.get("arms", {}).get("null_sanity", {})
+    lines.append(f"- **λ_trans:** {sanity.get('lambda_trans', 'N/A')}")
+    lines.append(f"- **λ_cis:** {sanity.get('lambda_cis', 'N/A')}")
+
+    strat = report_dict.get("arms", {}).get("stratify_decision", {})
+    if strat.get("status") == "skipped_insufficient_data":
+        lines.append("- **Verdict:** skipped due to insufficient data (master appears threshold-filtered)")
+    else:
+        rec = strat.get("recommendation", "N/A")
+        delta = strat.get("delta_median_log10_ratio", "N/A")
+        test_p = strat.get("test_p", "N/A")
+        ks_p = strat.get("ks_p", "N/A")
+
+        delta_str = f"{delta:.4f}" if isinstance(delta, float) else delta
+        test_p_str = f"{test_p:.2e}" if isinstance(test_p, float) else test_p
+        ks_p_str = f"{ks_p:.2e}" if isinstance(ks_p, float) else ks_p
+
+        lines.append(f"- **Verdict:** `{rec}`")
+        lines.append(f"  - Delta median log10 ratio: {delta_str}")
+        lines.append(f"  - Mann-Whitney p: {test_p_str}")
+        lines.append(f"  - KS p: {ks_p_str}")
+
+    lines.append("\n## Caveat")
+    lines.append("> cis here = same-chromosome (uniform sample), a weak proxy for the cis window; a `single_global_null_adequate` verdict is not a substitute for a gene-anchored cis-window run.")
+
+    lines.append("\n## Figures")
+    lines.append("- `qq_perm_vs_analytic.png`: QQ scatter of analytic vs permuted p-values.")
+    lines.append("- `dist_overlap_p.png`: Overlapping distributions of analytic and permuted p-values.")
+    lines.append("- `dist_tstat.png`: Distribution of the observed t-statistic.")
+
+    return "\n".join(lines)
+
+def downsample_preserving_tail(df, n_points=15000, seed=42):
+    if len(df) <= n_points:
+        return df
+
+    np.random.seed(seed)
+
+    # Define tail points: top 1% by -log10 p_ana
+    tail_n = max(int(n_points * 0.1), 1)
+    bulk_n = n_points - tail_n
+
+    df_sorted = df.sort_values(by='p_ana', ascending=True)
+
+    tail_actual = min(tail_n, len(df_sorted))
+    df_tail = df_sorted.head(tail_actual)
+
+    df_bulk_pool = df_sorted.iloc[tail_actual:]
+    if len(df_bulk_pool) > bulk_n:
+        df_bulk = df_bulk_pool.sample(n=bulk_n, random_state=seed)
+    else:
+        df_bulk = df_bulk_pool
+
+    return pd.concat([df_tail, df_bulk])
+
+def main():
+    parser = argparse.ArgumentParser(description="Summarize Permutation vs Analytic P-values")
+    parser.add_argument("--perm-output", required=True, help="Path to permutation_results.parquet")
+    parser.add_argument("--report", required=True, help="Path to eval_permute_report.json")
+    parser.add_argument("--df", type=int, required=True, help="Degrees of freedom")
+    parser.add_argument("--m-annot", help="Optional path to M.bed6")
+    parser.add_argument("--g-annot", help="Optional path to G.bed6")
+    parser.add_argument("--out-dir", required=True, help="Output directory")
+
+    args = parser.parse_args()
+
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    with open(args.report, 'r') as f:
+        report = json.load(f)
+
+    summary_text = build_summary_text(report)
+    with open(os.path.join(args.out_dir, "permute_vs_analytic_summary.md"), "w") as f:
+        f.write(summary_text)
+
+    logger.info("Reading permutation results...")
+    df = pq.read_table(args.perm_output).to_pandas()
+
+    df['p_ana'] = 2.0 * scipy.stats.t.sf(np.abs(df['mt_t'].astype(np.float64)), args.df)
+
+    has_annot = args.m_annot and args.g_annot
+    if has_annot:
+        m_annot = pd.read_csv(args.m_annot, sep=None, engine='python', index_col=3, header=None, names=['chrom', 'chromStart', 'chromEnd', 'name', 'score', 'strand'])
+        g_annot = pd.read_csv(args.g_annot, sep=None, engine='python', index_col=3, header=None, names=['chrom', 'chromStart', 'chromEnd', 'name', 'score', 'strand'])
+        df['stratum'] = label_strata(df, m_annot, g_annot)
+        df = df[df['stratum'] != 'dropped'].copy()
+    else:
+        df['stratum'] = 'all'
+
+    df_plot = downsample_preserving_tail(df)
+
+    df_plot['neg_log10_p_ana'] = -np.log10(df_plot['p_ana'].clip(lower=1e-300))
+    df_plot['neg_log10_p_perm'] = -np.log10(df_plot['perm_mt_p'].clip(lower=1e-300))
+
+    logger.info("Plotting qq_perm_vs_analytic.png...")
+    plt.figure(figsize=(8, 8))
+
+    if has_annot:
+        cis_mask = df_plot['stratum'] == 'cis'
+        trans_mask = df_plot['stratum'] == 'trans'
+        plt.scatter(df_plot.loc[trans_mask, 'neg_log10_p_ana'], df_plot.loc[trans_mask, 'neg_log10_p_perm'],
+                    alpha=0.5, label='Trans', color='blue', s=10, rasterized=True)
+        plt.scatter(df_plot.loc[cis_mask, 'neg_log10_p_ana'], df_plot.loc[cis_mask, 'neg_log10_p_perm'],
+                    alpha=0.5, label='Cis', color='orange', s=10, rasterized=True)
+        plt.legend()
+    else:
+        plt.scatter(df_plot['neg_log10_p_ana'], df_plot['neg_log10_p_perm'],
+                    alpha=0.5, color='gray', s=10, rasterized=True)
+
+    max_val = max(df_plot['neg_log10_p_ana'].max(), df_plot['neg_log10_p_perm'].max())
+    plt.plot([0, max_val], [0, max_val], 'k--', alpha=0.8)
+
+    plt.xlabel('-log10(Analytic p-value)')
+    plt.ylabel('-log10(Permutation p-value)')
+    plt.title('QQ Plot: Permutation vs Analytic')
+    plt.tight_layout()
+    plt.savefig(os.path.join(args.out_dir, "qq_perm_vs_analytic.png"), dpi=300)
+    plt.close()
+
+    logger.info("Plotting dist_overlap_p.png...")
+    plt.figure(figsize=(10, 6))
+    bins = np.linspace(0, 1, 100)
+    plt.hist(df['p_ana'], bins=bins, alpha=0.5, label='Analytic', density=True, color='blue')
+    plt.hist(df['perm_mt_p'].dropna(), bins=bins, alpha=0.5, label='Permutation', density=True, color='orange')
+    plt.xlabel('p-value')
+    plt.ylabel('Density')
+    plt.title('P-value Distribution Overlap')
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(os.path.join(args.out_dir, "dist_overlap_p.png"), dpi=300)
+    plt.close()
+
+    logger.info("Plotting dist_tstat.png...")
+    plt.figure(figsize=(10, 6))
+    plt.hist(df['mt_t'], bins=100, alpha=0.7, color='purple')
+    plt.xlabel('t-statistic')
+    plt.ylabel('Count')
+    plt.title('Distribution of Observed t-statistic')
+    plt.tight_layout()
+    plt.savefig(os.path.join(args.out_dir, "dist_tstat.png"), dpi=300)
+    plt.close()
+
+    logger.info("Summary complete.")
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        sys.exit(1)


### PR DESCRIPTION
Implemented Part 1 (`tools/summarize_permute.py`) and Part 2 (`tools/reservoir_to_parquet.py` + `pipelinePermute.sh` update) for parsing the permutation report and automatically converting the reservoir to parquet. Added tests with forced-failure assertions for both tools. Re-verified everything in bash.

---
*PR created automatically by Jules for task [3540880189998791917](https://jules.google.com/task/3540880189998791917) started by @kordk*