### PR TITLE
Summarize permute: consume region authority and render 7-way table

### DIFF
--- a/tests/test_summarize_permute.py
+++ b/tests/test_summarize_permute.py
@@ -113,7 +113,7 @@ def test_assign_family_region_consumed_no_crash(monkeypatch):
     def raise_if_called(*args, **kwargs):
         raise AssertionError("label_strata must not be called on the region path")
 
-    monkeypatch.setattr("tools.summarize_permute.eval_label_strata", raise_if_called, raising=False)
+    monkeypatch.setattr("eval_permute.label_strata", raise_if_called)
 
     # Missing annotations doesn't matter because region is present
     df_out, strat_mode = assign_family(df, "dummy_m.bed6", "dummy_g.bed6")

--- a/tests/test_summarize_permute.py
+++ b/tests/test_summarize_permute.py
@@ -5,7 +5,7 @@ import sys
 import pandas as pd
 import numpy as np
 
-from tools.summarize_permute import build_summary_text
+from tools.summarize_permute import build_summary_text, assign_family
 
 def test_build_summary_text_populated():
     report = {
@@ -60,6 +60,152 @@ def test_build_summary_text_missing():
     text = build_summary_text(report)
     assert "skipped due to insufficient data" in text
     assert "bulk not computed" in text
+
+def test_build_summary_text_per_region():
+    report = {
+        "metadata": {
+            "n_pairs_input": 100,
+            "n_pairs_dropped_unmappable_chrom": 0,
+            "n_pairs_scored": 100,
+            "n_by_region": {
+                "TRANS": 50, "DISTAL5": 10, "DISTAL3": 10,
+                "CIS5": 5, "PROMOTER": 5, "GENEBODY": 10, "CIS3": 10
+            }
+        },
+        "arms": {
+            "stratify_decision": {
+                "mode": "per_region",
+                "per_region": {
+                    "TRANS": {"status": "reference", "n_bulk": 50},
+                    "DISTAL5": {"status": "ok", "n_bulk": 10, "median_log10_ratio": 0.0027, "delta_vs_trans": 0.01, "mw_p": 0.5, "lambda": 1.01},
+                    "DISTAL3": {"status": "ok", "n_bulk": 10, "median_log10_ratio": 0.003, "delta_vs_trans": 0.01, "mw_p": 0.5, "lambda": 1.02},
+                    "CIS5": {"status": "insufficient_data", "n_bulk": 5},
+                    "PROMOTER": {"status": "insufficient_data", "n_bulk": 5},
+                    "GENEBODY": {"status": "insufficient_data", "n_bulk": 10},
+                    "CIS3": {"status": "insufficient_data", "n_bulk": 10}
+                },
+                "recommendation": "insufficient_near_gene_coverage",
+                "divergent_regions": []
+            }
+        }
+    }
+
+    text = build_summary_text(report)
+
+    for r in ["TRANS", "DISTAL5", "DISTAL3", "CIS5", "PROMOTER", "GENEBODY", "CIS3"]:
+        assert r in text, f"Region {r} should be in the summary text"
+
+    assert "insufficient_near_gene_coverage" in text
+    assert "0.0027" in text
+
+    assert "same-chromosome" not in text
+    assert "(Cis:" not in text
+
+def test_assign_family_region_consumed_no_crash(monkeypatch):
+    df = pd.DataFrame({
+        "mt_id": ["m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8"],
+        "gt_id": ["g1", "g2", "g3", "g4", "g5", "g6", "g7", "g8"],
+        "mt_t": [1.0] * 8,
+        "perm_mt_p": [0.1] * 8,
+        "region": ["TRANS", "DISTAL5", "CIS5", "PROMOTER", "GENEBODY", "CIS3", "DISTAL3", None]
+    })
+
+    def raise_if_called(*args, **kwargs):
+        raise AssertionError("label_strata must not be called on the region path")
+
+    monkeypatch.setattr("tools.summarize_permute.eval_label_strata", raise_if_called, raising=False)
+
+    # Missing annotations doesn't matter because region is present
+    df_out, strat_mode = assign_family(df, "dummy_m.bed6", "dummy_g.bed6")
+
+    assert strat_mode == 'region'
+    assert len(df_out) == 7  # None dropped
+    assert set(df_out['family'].unique()).issubset({"trans", "distal", "near_gene"})
+
+def test_assign_family_fallback_tolerates_missing_annotations(tmp_path):
+    df = pd.DataFrame({
+        "mt_id": ["m1", "m_missing"],
+        "gt_id": ["g1", "g_missing"]
+    })
+
+    m_annot_path = tmp_path / "M.bed6"
+    g_annot_path = tmp_path / "G.bed6"
+
+    m_annot = pd.DataFrame({
+        'chrom': ["chr1"], 'chromStart': [1], 'chromEnd': [10],
+        'name': ["m1"], 'score': [0], 'strand': ["+"]
+    })
+    m_annot.to_csv(m_annot_path, sep="\t", header=True, index=False)
+
+    g_annot = pd.DataFrame({
+        'chrom': ["chr1"], 'chromStart': [1], 'chromEnd': [10],
+        'name': ["g1"], 'score': [0], 'strand': ["+"]
+    })
+    g_annot.to_csv(g_annot_path, sep="\t", header=True, index=False)
+
+    df_out, strat_mode = assign_family(df, m_annot_path, g_annot_path)
+
+    assert strat_mode == 'family2'
+    assert len(df_out) == 1
+    assert "m_missing" not in df_out["mt_id"].values
+    assert set(df_out['family'].unique()).issubset({"trans", "near_gene"})
+
+def test_end_to_end_region_parquet_exit0(tmp_path):
+    report_path = tmp_path / "eval_permute_report.json"
+    perm_path = tmp_path / "permutation_results.parquet"
+    out_dir = tmp_path / "out"
+    m_annot_path = tmp_path / "M.bed6"
+    g_annot_path = tmp_path / "G.bed6"
+
+    report_data = {
+        "metadata": {"n_pairs_input": 10},
+        "arms": {
+            "calibration": {"all": {"bulk_spearman_corr": 0.9, "bulk_median_abs_log_ratio": 0.1}}
+        }
+    }
+
+    with open(report_path, "w") as f:
+        json.dump(report_data, f)
+
+    df = pd.DataFrame({
+        "mt_id": ["m1", "m2"],
+        "gt_id": ["g1", "g2"],
+        "mt_t": [1.0, 2.0],
+        "perm_mt_p": [0.1, 0.05],
+        "region": ["TRANS", "CIS5"]
+    })
+    df.to_parquet(perm_path)
+
+    # Incomplete annotations - m2/g2 missing
+    m_annot = pd.DataFrame({
+        'chrom': ["chr1"], 'chromStart': [1], 'chromEnd': [10],
+        'name': ["m1"], 'score': [0], 'strand': ["+"]
+    })
+    m_annot.to_csv(m_annot_path, sep="\t", header=True, index=False)
+
+    g_annot = pd.DataFrame({
+        'chrom': ["chr2"], 'chromStart': [1], 'chromEnd': [10],
+        'name': ["g1"], 'score': [0], 'strand': ["+"]
+    })
+    g_annot.to_csv(g_annot_path, sep="\t", header=True, index=False)
+
+    cmd = [
+        sys.executable, "tools/summarize_permute.py",
+        "--perm-output", str(perm_path),
+        "--report", str(report_path),
+        "--df", "100",
+        "--m-annot", str(m_annot_path),
+        "--g-annot", str(g_annot_path),
+        "--out-dir", str(out_dir)
+    ]
+
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+    assert (out_dir / "permute_vs_analytic_summary.md").exists()
+    assert (out_dir / "qq_perm_vs_analytic.png").exists()
+    assert (out_dir / "dist_overlap_p.png").exists()
+    assert (out_dir / "dist_tstat.png").exists()
 
 def test_smoke_summarize_permute(tmp_path):
     report_path = tmp_path / "eval_permute_report.json"

--- a/tools/summarize_permute.py
+++ b/tools/summarize_permute.py
@@ -13,6 +13,10 @@ import pandas as pd
 import scipy.stats
 import pyarrow.parquet as pq
 
+# Add tools directory to path to allow importing eval_permute
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from eval_permute import CANONICAL_REGIONS, NEAR_GENE_REGIONS
+
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 logger = logging.getLogger(__name__)
 
@@ -21,9 +25,20 @@ def build_summary_text(report_dict: dict) -> str:
     lines.append("# Permutation vs Analytic p-value Summary\n")
 
     meta = report_dict.get("metadata", {})
+    strat_decision = report_dict.get("arms", {}).get("stratify_decision", {})
+    per_region = strat_decision.get("per_region")
+
     lines.append(f"**Pairs Input:** {meta.get('n_pairs_input', 'N/A')}")
     lines.append(f"**Pairs Dropped (Unmappable):** {meta.get('n_pairs_dropped_unmappable_chrom', 'N/A')}")
-    lines.append(f"**Pairs Scored:** {meta.get('n_pairs_scored', 'N/A')} (Cis: {meta.get('n_cis', 'N/A')}, Trans: {meta.get('n_trans', 'N/A')})")
+
+    if per_region is not None:
+        n_by_reg = meta.get("n_by_region", {})
+        n_near = sum(n_by_reg.get(r, 0) for r in NEAR_GENE_REGIONS)
+        n_dist = sum(n_by_reg.get(r, 0) for r in ["DISTAL5", "DISTAL3"])
+        n_trans = n_by_reg.get("TRANS", 0)
+        lines.append(f"**Pairs Scored:** {meta.get('n_pairs_scored', 'N/A')} (near-gene: {n_near}, distal: {n_dist}, trans: {n_trans})")
+    else:
+        lines.append(f"**Pairs Scored:** {meta.get('n_pairs_scored', 'N/A')} (Cis: {meta.get('n_cis', 'N/A')}, Trans: {meta.get('n_trans', 'N/A')})")
 
     lines.append("\n## Calibration Agreement")
     calib = report_dict.get("arms", {}).get("calibration", {})
@@ -40,31 +55,70 @@ def build_summary_text(report_dict: dict) -> str:
         else:
             lines.append(f"- **{stratum.capitalize()}:** bulk not computed (master appears threshold-filtered)")
 
-    lines.append("\n## Null Sanity & Stratification")
-    sanity = report_dict.get("arms", {}).get("null_sanity", {})
-    lines.append(f"- **λ_trans:** {sanity.get('lambda_trans', 'N/A')}")
-    lines.append(f"- **λ_cis:** {sanity.get('lambda_cis', 'N/A')}")
+    if per_region is not None:
+        lines.append("\n## Regional Stratification")
+        lines.append("| region | n | n_bulk | status | median|log10 ratio| | Δ vs TRANS | MW p | λ |")
+        lines.append("|---|---|---|---|---|---|---|---|")
 
-    strat = report_dict.get("arms", {}).get("stratify_decision", {})
-    if strat.get("status") == "skipped_insufficient_data":
-        lines.append("- **Verdict:** skipped due to insufficient data (master appears threshold-filtered)")
+        n_by_reg = meta.get("n_by_region", {})
+        for R in CANONICAL_REGIONS:
+            r_data = per_region.get(R, {})
+            n_pairs = n_by_reg.get(R, 0)
+            status = r_data.get("status", "N/A")
+            n_bulk = r_data.get("n_bulk", "N/A")
+
+            if status in ("insufficient_data", "N/A"):
+                lines.append(f"| {R} | {n_pairs} | {n_bulk} | {status} | — | — | — | — |")
+            else:
+                med = r_data.get("median_log10_ratio")
+                delta = r_data.get("delta_vs_trans")
+                mwp = r_data.get("mw_p")
+                lam = r_data.get("lambda")
+
+                med_str = f"{med:.4f}" if isinstance(med, float) else med
+                delta_str = f"{delta:.4f}" if isinstance(delta, float) else delta
+                mwp_str = f"{mwp:.2e}" if isinstance(mwp, float) else mwp
+                lam_str = f"{lam:.4f}" if isinstance(lam, float) else lam
+
+                lines.append(f"| {R} | {n_pairs} | {n_bulk} | {status} | {med_str} | {delta_str} | {mwp_str} | {lam_str} |")
+
+        rec = strat_decision.get("recommendation", "N/A")
+        div_regions = strat_decision.get("divergent_regions", [])
+        div_str = ", ".join(div_regions) if div_regions else "none"
+        lines.append(f"\n**Verdict:** `{rec}`")
+        lines.append(f"Divergent regions: {div_str}")
+
+        lines.append("\n## Caveat")
+        if rec == "insufficient_near_gene_coverage":
+            lines.append("> The near-gene regions fell below the coverage floor in the reservoir, so the cis-window verdict is deferred to a gene-anchored enrichment run. TRANS and both DISTAL strata serve as the powered, calibrated reference.")
+        else:
+            lines.append("> A `single_global_null_adequate` verdict is not a substitute for a gene-anchored cis-window run.")
     else:
-        rec = strat.get("recommendation", "N/A")
-        delta = strat.get("delta_median_log10_ratio", "N/A")
-        test_p = strat.get("test_p", "N/A")
-        ks_p = strat.get("ks_p", "N/A")
+        lines.append("\n## Null Sanity & Stratification")
+        sanity = report_dict.get("arms", {}).get("null_sanity", {})
+        lines.append(f"- **λ_trans:** {sanity.get('lambda_trans', 'N/A')}")
+        lines.append(f"- **λ_cis:** {sanity.get('lambda_cis', 'N/A')}")
 
-        delta_str = f"{delta:.4f}" if isinstance(delta, float) else delta
-        test_p_str = f"{test_p:.2e}" if isinstance(test_p, float) else test_p
-        ks_p_str = f"{ks_p:.2e}" if isinstance(ks_p, float) else ks_p
+        strat = report_dict.get("arms", {}).get("stratify_decision", {})
+        if strat.get("status") == "skipped_insufficient_data":
+            lines.append("- **Verdict:** skipped due to insufficient data (master appears threshold-filtered)")
+        else:
+            rec = strat.get("recommendation", "N/A")
+            delta = strat.get("delta_median_log10_ratio", "N/A")
+            test_p = strat.get("test_p", "N/A")
+            ks_p = strat.get("ks_p", "N/A")
 
-        lines.append(f"- **Verdict:** `{rec}`")
-        lines.append(f"  - Delta median log10 ratio: {delta_str}")
-        lines.append(f"  - Mann-Whitney p: {test_p_str}")
-        lines.append(f"  - KS p: {ks_p_str}")
+            delta_str = f"{delta:.4f}" if isinstance(delta, float) else delta
+            test_p_str = f"{test_p:.2e}" if isinstance(test_p, float) else test_p
+            ks_p_str = f"{ks_p:.2e}" if isinstance(ks_p, float) else ks_p
 
-    lines.append("\n## Caveat")
-    lines.append("> cis here = same-chromosome (uniform sample), a weak proxy for the cis window; a `single_global_null_adequate` verdict is not a substitute for a gene-anchored cis-window run.")
+            lines.append(f"- **Verdict:** `{rec}`")
+            lines.append(f"  - Delta median log10 ratio: {delta_str}")
+            lines.append(f"  - Mann-Whitney p: {test_p_str}")
+            lines.append(f"  - KS p: {ks_p_str}")
+
+        lines.append("\n## Caveat")
+        lines.append("> cis here = same-chromosome (uniform sample), a weak proxy for the cis window; a `single_global_null_adequate` verdict is not a substitute for a gene-anchored cis-window run.")
 
     lines.append("\n## Figures")
     lines.append("- `qq_perm_vs_analytic.png`: QQ scatter of analytic vs permuted p-values.")
@@ -72,6 +126,52 @@ def build_summary_text(report_dict: dict) -> str:
     lines.append("- `dist_tstat.png`: Distribution of the observed t-statistic.")
 
     return "\n".join(lines)
+
+def _family_of(region):
+    if region == 'TRANS':
+        return 'trans'
+    if region in NEAR_GENE_REGIONS:
+        return 'near_gene'
+    return 'distal'
+
+def assign_family(df, m_annot_path=None, g_annot_path=None):
+    if 'region' in df.columns:
+        keep = ~df['region'].isna()
+        n_drop = int((~keep).sum())
+        if n_drop:
+            logger.info("Drop site summarize.region: dropped null-region pairs: {0} -> {1} ({2} dropped)"
+                        .format(len(df), int(keep.sum()), n_drop))
+        df = df.loc[keep].reset_index(drop=True)
+        invalid = set(df['region'].unique()) - set(CANONICAL_REGIONS)
+        if invalid:
+            raise ValueError("summarize_permute: unexpected region labels: {0}".format(sorted(invalid)))
+        df['family'] = df['region'].map(_family_of)
+        return df, 'region'
+
+    if m_annot_path and g_annot_path:
+        from eval_permute import label_strata as eval_label_strata, _load_annotation
+        m_annot = _load_annotation(m_annot_path, 'M')
+        g_annot = _load_annotation(g_annot_path, 'G')
+
+        m_ok = m_annot.index.astype(str).get_indexer(df['mt_id'].astype(str)) != -1
+        g_ok = g_annot.index.astype(str).get_indexer(df['gt_id'].astype(str)) != -1
+        ann_keep = m_ok & g_ok
+        n_unann = int((~ann_keep).sum())
+        if n_unann:
+            logger.info("Drop site summarize.annot: dropped pairs missing from annotations: {0} -> {1} ({2} dropped)"
+                        .format(len(df), int(ann_keep.sum()), n_unann))
+        df = df.loc[ann_keep].reset_index(drop=True)
+
+        _keep, is_cis, is_trans, _nc, _nt, _nd = eval_label_strata(df, m_annot, g_annot)
+        df['family'] = np.where(is_cis, 'near_gene', np.where(is_trans, 'trans', 'dropped'))
+
+        # Also drop unmappable-chrom dropped by label_strata's own keep mask
+        valid = (df['family'] != 'dropped') & _keep
+        df = df.loc[valid].reset_index(drop=True)
+        return df, 'family2'
+
+    df['family'] = 'all'
+    return df, 'all'
 
 def downsample_preserving_tail(df, n_points=15000, seed=42):
     if len(df) <= n_points:
@@ -121,16 +221,7 @@ def main():
 
     df['p_ana'] = 2.0 * scipy.stats.t.sf(np.abs(df['mt_t'].astype(np.float64)), args.df)
 
-    has_annot = args.m_annot and args.g_annot
-    if has_annot:
-        from eval_permute import label_strata as eval_label_strata, _load_annotation
-        m_annot = _load_annotation(args.m_annot, 'M')
-        g_annot = _load_annotation(args.g_annot, 'G')
-        _keep, is_cis, is_trans, _nc, _nt, _nd = eval_label_strata(df, m_annot, g_annot)
-        df['stratum'] = np.where(is_cis, 'cis', np.where(is_trans, 'trans', 'dropped'))
-        df = df[df['stratum'] != 'dropped'].copy()
-    else:
-        df['stratum'] = 'all'
+    df, strat_mode = assign_family(df, args.m_annot, args.g_annot)
 
     df_plot = downsample_preserving_tail(df)
 
@@ -140,13 +231,17 @@ def main():
     logger.info("Plotting qq_perm_vs_analytic.png...")
     plt.figure(figsize=(8, 8))
 
-    if has_annot:
-        cis_mask = df_plot['stratum'] == 'cis'
-        trans_mask = df_plot['stratum'] == 'trans'
+    if strat_mode in ('region', 'family2'):
+        trans_mask = df_plot['family'] == 'trans'
+        distal_mask = df_plot['family'] == 'distal'
+        near_gene_mask = df_plot['family'] == 'near_gene'
+
         plt.scatter(df_plot.loc[trans_mask, 'neg_log10_p_ana'], df_plot.loc[trans_mask, 'neg_log10_p_perm'],
-                    alpha=0.5, label='Trans', color='blue', s=10, rasterized=True)
-        plt.scatter(df_plot.loc[cis_mask, 'neg_log10_p_ana'], df_plot.loc[cis_mask, 'neg_log10_p_perm'],
-                    alpha=0.5, label='Cis', color='orange', s=10, rasterized=True)
+                    alpha=0.5, label='Trans', color='gray', s=10, rasterized=True)
+        plt.scatter(df_plot.loc[distal_mask, 'neg_log10_p_ana'], df_plot.loc[distal_mask, 'neg_log10_p_perm'],
+                    alpha=0.5, label='Distal', color='green', s=10, rasterized=True)
+        plt.scatter(df_plot.loc[near_gene_mask, 'neg_log10_p_ana'], df_plot.loc[near_gene_mask, 'neg_log10_p_perm'],
+                    alpha=0.5, label='Near Gene', color='orange', s=10, rasterized=True)
         plt.legend()
     else:
         plt.scatter(df_plot['neg_log10_p_ana'], df_plot['neg_log10_p_perm'],


### PR DESCRIPTION
Summarize permute: consume region authority and render 7-way table

This commit updates `summarize_permute.py` to correctly parse out region
information if it's found in the `permutation_results.parquet` output table
avoiding a crash caused when non-canonical IDs not found in the annotations
would hit `label_strata`'s strict filtering, making `summarize` strictly
tolerant of these values by prefiltering them and using positional logger calls
to document drops.

Tests:
7 collected tests, successfully green on py3.10 linux environment.
Tested: E2E region smoke test avoiding exit 1 (green) -> Forced-fail: modified `res.returncode == 0` -> red -> green.
Tested: E2E fallback tolerant missing (green) -> Forced-fail: disabled unannotated pre-filter, causing `eval_permute.label_strata` to raise correctly -> red -> green.
Tested: Value oracle per-region table rendering (green) -> Forced-fail: changed string `0.0027` to `999.99` in test output validation -> red -> green.
Tested: Assign family region consumed monkeypatched check (green) -> Forced-fail: routed region-present check into fallback path, triggering `label_strata` assertion raise correctly -> red -> green.

---
*PR created automatically by Jules for task [4456817266170149428](https://jules.google.com/task/4456817266170149428) started by @kordk*