### PR TITLE
Refactor chromosome canonicalization to shared torch-free module

### DIFF
--- a/tecpg/chrom.py
+++ b/tecpg/chrom.py
@@ -1,0 +1,15 @@
+import pandas as pd
+
+def canonicalize_chrom(s: pd.Series) -> pd.Series:
+    """Canonicalize a chromosome column to signed numeric codes.
+    Integer dtype passes through unchanged. Strings: strip a leading 'chr'
+    (case-insensitive), uppercase, coerce numerals; map X/Y/MT/M -> -1/-2/-3/-3;
+    anything unmappable (scaffolds, NaN) -> NaN (caller drops via dropna)."""
+    if pd.api.types.is_integer_dtype(s):
+        return s
+    s = s.astype('string').str.strip()
+    s = s.str.replace(r'^chr', '', regex=True, case=False)
+    s = s.str.upper()
+    num = pd.to_numeric(s, errors='coerce')
+    spec = s.map({'X': -1, 'Y': -2, 'MT': -3, 'M': -3})
+    return num.fillna(spec)

--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -19,22 +19,13 @@ TOPK_CAPACITY = 10_000
 
 
 def _normalize_annotations(M_annot, G_annot, M, G, logger):
-    def map_chrom(s):
-        # Allow pass-through of integer columns
-        if pd.api.types.is_integer_dtype(s):
-            return s
-        s = s.astype('string').str.strip()
-        s = s.str.replace(r'^chr', '', regex=True, case=False)
-        s = s.str.upper()
-        num = pd.to_numeric(s, errors='coerce')
-        spec = s.map({'X': -1, 'Y': -2, 'MT': -3, 'M': -3})
-        return num.fillna(spec)
+    from .chrom import canonicalize_chrom
 
     M_annot_n = M_annot.copy()
     G_annot_n = G_annot.copy()
 
-    M_annot_n['chrom'] = map_chrom(M_annot_n['chrom'])
-    G_annot_n['chrom'] = map_chrom(G_annot_n['chrom'])
+    M_annot_n['chrom'] = canonicalize_chrom(M_annot_n['chrom'])
+    G_annot_n['chrom'] = canonicalize_chrom(G_annot_n['chrom'])
 
     G_annot_n['strand'] = pd.to_numeric(G_annot_n['strand'].replace({'+': 1, '-': -1}), errors='coerce')
 

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -202,6 +202,7 @@ def _tecpg_mlr_qr_inner(
         logger.info('Initializing region filtration')
         G_loci_before = len(G.index)
         G_annot = G_annot.drop(columns=['chromEnd', 'score']).reindex(G.index)
+        import pandas as pd
         G_annot['chrom'] = canonicalize_chrom(G_annot['chrom'])
         G_annot['strand'] = pd.to_numeric(G_annot['strand'].replace({'+': 1, '-': -1}), errors='coerce')
         G_annot = G_annot.dropna()

--- a/tecpg/processing.py
+++ b/tecpg/processing.py
@@ -197,14 +197,14 @@ def _tecpg_mlr_qr_inner(
 
     # Prepare annotation tensors if region filtration is used
     if region != 'all':
+        from .chrom import canonicalize_chrom
+
         logger.info('Initializing region filtration')
         G_loci_before = len(G.index)
-        G_annot = (
-            G_annot.drop(columns=['chromEnd', 'score'])
-            .reindex(G.index)
-            .replace({'X': -1, 'Y': -2, '+': 1, '-': -1})
-            .dropna()
-        )
+        G_annot = G_annot.drop(columns=['chromEnd', 'score']).reindex(G.index)
+        G_annot['chrom'] = canonicalize_chrom(G_annot['chrom'])
+        G_annot['strand'] = pd.to_numeric(G_annot['strand'].replace({'+': 1, '-': -1}), errors='coerce')
+        G_annot = G_annot.dropna()
         logger.info(
             'Drop site processing.region_filtration[G_annot]: dropped gene '
             'expression loci with missing/unmappable annotation '
@@ -212,12 +212,9 @@ def _tecpg_mlr_qr_inner(
             G_loci_before, len(G_annot), G_loci_before - len(G_annot),
         )
         M_loci_before = len(M.index)
-        M_annot = (
-            M_annot.drop(columns=['chromEnd', 'score', 'strand'])
-            .reindex(M.index)
-            .replace({'X': -1, 'Y': -2})
-            .dropna()
-        )
+        M_annot = M_annot.drop(columns=['chromEnd', 'score', 'strand']).reindex(M.index)
+        M_annot['chrom'] = canonicalize_chrom(M_annot['chrom'])
+        M_annot = M_annot.dropna()
         logger.info(
             'Drop site processing.region_filtration[M_annot]: dropped '
             'methylation loci with missing/unmappable annotation '

--- a/tests/test_chrom.py
+++ b/tests/test_chrom.py
@@ -1,0 +1,74 @@
+import pandas as pd
+import numpy as np
+from tecpg.chrom import canonicalize_chrom
+
+def test_canonicalize_chrom_battery():
+    # Value oracle for canonicalize_chrom
+
+    def check_equality(out, expected_values, s_name):
+        expected = pd.Series(expected_values, name=s_name)
+        # Use Int64 if no float values except nan, or let pandas handle it, but allow casting expected to match out dtype
+        pd.testing.assert_series_equal(out, expected.astype(out.dtype))
+
+    # 1. Standard mapping and normal strings
+    s = pd.Series(['chr19', 'chrX', 'chrY', 'chr2'])
+    out = canonicalize_chrom(s)
+    check_equality(out, [19.0, -1.0, -2.0, 2.0], s.name)
+
+    # 2. Bare variants
+    s = pd.Series(['19', 'X', 'Y'])
+    out = canonicalize_chrom(s)
+    check_equality(out, [19.0, -1.0, -2.0], s.name)
+
+    # 3. Mixed case
+    s = pd.Series(['CHR19', 'chrx'])
+    out = canonicalize_chrom(s)
+    check_equality(out, [19.0, -1.0], s.name)
+
+    # 4. Mito
+    s = pd.Series(['chrM', 'MT', 'chrMT'])
+    out = canonicalize_chrom(s)
+    check_equality(out, [-3.0, -3.0, -3.0], s.name)
+
+    # 5. Integer passthrough
+    s = pd.Series([1, 2, 3], dtype=int)
+    out = canonicalize_chrom(s)
+    pd.testing.assert_series_equal(out, pd.Series([1, 2, 3], dtype=int, name=s.name))
+
+    # 6. Unmappable / Scaffolds / None
+    s = pd.Series(['chr19', None, 'scaffold_1'])
+    out = canonicalize_chrom(s)
+    check_equality(out, [19.0, np.nan, np.nan], s.name)
+
+    # 7. Additional cases requested: np.nan, pd.NA, float, whitespace padding, empty strings, alt-contigs
+    s = pd.Series([np.nan, pd.NA, 19.0, ' chr19 ', '', 'chr22_KI270879v1_alt'])
+    out = canonicalize_chrom(s)
+    check_equality(out, [np.nan, np.nan, 19.0, 19.0, np.nan, np.nan], s.name)
+
+def test_canonicalize_matches_legacy_map_chrom():
+    # Behavior-preservation oracle for the permute refactor
+    def map_chrom(s):
+        if pd.api.types.is_integer_dtype(s):
+            return s
+        s = s.astype('string').str.strip()
+        s = s.str.replace(r'^chr', '', regex=True, case=False)
+        s = s.str.upper()
+        num = pd.to_numeric(s, errors='coerce')
+        spec = s.map({'X': -1, 'Y': -2, 'MT': -3, 'M': -3})
+        return num.fillna(spec)
+
+    # Combine all test cases into one comprehensive battery
+    battery = pd.Series([
+        'chr19', 'chrX', 'chrY', 'chr2',
+        '19', 'X', 'Y',
+        'CHR19', 'chrx',
+        'chrM', 'MT', 'chrMT',
+        1, 2, 3,
+        'chr19', None, 'scaffold_1',
+        np.nan, pd.NA, 19.0, ' chr19 ', '', 'chr22_KI270879v1_alt'
+    ])
+
+    legacy_out = map_chrom(battery)
+    new_out = canonicalize_chrom(battery)
+
+    pd.testing.assert_series_equal(new_out, legacy_out)


### PR DESCRIPTION
This PR extracts the chromosome canonicalization logic from `permute.py` into a shared, torch-free module `tecpg/chrom.py` as `canonicalize_chrom`. It updates both `permute.py` and `processing.py` to use this new function. The refactor in `processing.py` correctly canonicalizes `chr`-prefixed annotation files prior to integer casting in the `region != 'all'` pathway (the cis/distal map), fixing a crash on real cohorts like GTP/MESA.

Note:
* The shared `canonicalize_chrom` function is torch-free, so it is testable locally without a GPU environment. 
* All permute byte-identity contracts are maintained, and the `region == 'all'` path is intentionally untouched, preserving the existing pipeline fingerprint.
* Evidence of test robustness includes a behavior-preservation oracle comparing `canonicalize_chrom` to the exact legacy closure on tricky edge cases (`np.nan`, `pd.NA`, whitespace-padded, mixed case, alt-contigs) across both Pandas 2.x and 3.x.
* **Acceptance check for klabdev:** A `--cis` write-all map on the chr-prefixed GTP annotations that previously raised `ValueError` should now complete.

---
*PR created automatically by Jules for task [11965645984301192433](https://jules.google.com/task/11965645984301192433) started by @kordk*