### PR TITLE
Fix int8 overflow in cis/distal region mask

### DIFF
--- a/tecpg/helper.py
+++ b/tecpg/helper.py
@@ -346,10 +346,13 @@ def compute_region_mask(region, m_chrom, m_pos, g_chrom, g_pos, g_strand, *,
     """
     if region in ('cis', 'distal'):
         delta = g_pos - m_pos
+        # g_strand is int8 at the call sites; window magnitudes (~1e6)
+        # overflow int8, so widen before multiplying.
+        gs = g_strand.to(torch.int64)
         return (
             (m_chrom == g_chrom)
-            & (g_strand * (window_base - upstream) < delta)
-            & (delta < g_strand * (window_base + downstream))
+            & (gs * (window_base - upstream) < delta)
+            & (delta < gs * (window_base + downstream))
         )
     if region == 'trans':
         return m_chrom != g_chrom

--- a/tecpg/regression_full.py
+++ b/tecpg/regression_full.py
@@ -470,19 +470,18 @@ def _regression_full_inner(
                         # The None in the index of the G tensors makes
                         # the shape of the tensor suitable to broadcast
                         # to the shape of the M tensors
+                        # G_strand_t is int8; window magnitudes (~1e6)
+                        # overflow int8, so widen before multiplying.
+                        gs = G_strand_t[index - 1, None].to(torch.int64)
                         region_indices_mask = (
                             (G_chrom_t[index - 1, None] == M_chrom_t)
                             .logical_and(
-                                G_strand_t[index - 1, None]
-                                * (window_base - upstream)
+                                gs * (window_base - upstream)
                                 < G_pos_t[index - 1, None] - M_pos_t
                             )
                             .logical_and(
                                 G_pos_t[index - 1, None] - M_pos_t
-                                < (
-                                    G_strand_t[index - 1, None]
-                                    * (window_base + downstream)
-                                )
+                                < (gs * (window_base + downstream))
                             )
                         )
                     elif region == 'trans':

--- a/tests/test_region_mask.py
+++ b/tests/test_region_mask.py
@@ -1,0 +1,33 @@
+import torch
+from tecpg.helper import compute_region_mask
+
+
+def _fixture():
+    m_chrom = torch.tensor([1, 1, 1, 2], dtype=torch.int8)
+    g_chrom = torch.tensor([1, 1, 1, 1], dtype=torch.int8)
+    m_pos = torch.tensor([900_000, 900_000, 1_000_000, 900_000], dtype=torch.int32)
+    g_pos = torch.tensor([1_000_000, 1_000_000, 3_000_000, 1_000_000], dtype=torch.int32)
+    g_strand = torch.tensor([1, -1, 1, 1], dtype=torch.int8)
+    return m_chrom, m_pos, g_chrom, g_pos, g_strand
+
+
+def test_cis_window_no_int8_overflow():
+    m_chrom, m_pos, g_chrom, g_pos, g_strand = _fixture()
+    mask = compute_region_mask(
+        'cis', m_chrom, m_pos, g_chrom, g_pos, g_strand,
+        window_base=0, upstream=1_000_000, downstream=1_000_000,
+    )
+    # A +strand CpG 100 kb from its gene is inside a +/-1 Mb window.
+    # Under the int8 overflow the effective window was ~+/-64 bp, so this was False.
+    assert bool(mask[0]) is True
+    assert bool(mask[2]) is False   # 2 Mb away -> outside the window
+    assert bool(mask[3]) is False   # different chromosome -> never cis
+
+
+def test_trans_mask_unchanged():
+    m_chrom, m_pos, g_chrom, g_pos, g_strand = _fixture()
+    mask = compute_region_mask(
+        'trans', m_chrom, m_pos, g_chrom, g_pos, g_strand,
+        window_base=0, upstream=1_000_000, downstream=1_000_000,
+    )
+    assert [bool(x) for x in mask] == [False, False, False, True]


### PR DESCRIPTION
Fixes an `int8` overflow bug in the `cis`/`distal` region mask calculation.

When the int8 strand tensor was multiplied by the window boundaries (~1e6), it overflowed, causing the effective window size to collapse to ~64bp instead of the requested ~1Mb. This change casts the strand tensor to `torch.int64` just before the multiplication at both call sites (`tecpg/helper.py` and `tecpg/regression_full.py`).

**RED (Before the fix):**
```
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /app
configfile: pytest.ini
plugins: anyio-4.14.2
collected 2 items

tests/test_region_mask.py F.                                             [100%]

=================================== FAILURES ===================================
_______________________ test_cis_window_no_int8_overflow _______________________

    def test_cis_window_no_int8_overflow():
        m_chrom, m_pos, g_chrom, g_pos, g_strand = _fixture()
        mask = compute_region_mask(
            'cis', m_chrom, m_pos, g_chrom, g_pos, g_strand,
            window_base=0, upstream=1_000_000, downstream=1_000_000,
        )
        # A +strand CpG 100 kb from its gene is inside a +/-1 Mb window.
        # Under the int8 overflow the effective window was ~+/-64 bp, so this was False.
>       assert bool(mask[0]) is True
E       assert False is True
E        +  where False = bool(tensor(False))

tests/test_region_mask.py:22: AssertionError
```

**GREEN (After the fix):**
```
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /app
configfile: pytest.ini
plugins: anyio-4.14.2
collected 2 items

tests/test_region_mask.py ..                                             [100%]

============================== 2 passed in 2.15s ===============================
```

Full test suite passes (172 collected, 172 passed), specifically verifying that `tests/test_mlr_comparison.py` (qr ≡ regression_full) and `tests/test_correctness_harness.py` (fingerprint, `region='all'`) pass cleanly.

---
*PR created automatically by Jules for task [5806420763059801637](https://jules.google.com/task/5806420763059801637) started by @kordk*