### PR TITLE
Fix empty cis windows for negative-strand genes

### DIFF
--- a/tecpg/helper.py
+++ b/tecpg/helper.py
@@ -349,10 +349,19 @@ def compute_region_mask(region, m_chrom, m_pos, g_chrom, g_pos, g_strand, *,
         # g_strand is int8 at the call sites; window magnitudes (~1e6)
         # overflow int8, so widen before multiplying.
         gs = g_strand.to(torch.int64)
+        # Multiplying by strand flips the window orientation but also reverses
+        # the bounds, which makes a symmetric negative-strand window empty.
+        # Order them so the interval is always valid.
+        lower = torch.minimum(
+            gs * (window_base - upstream), gs * (window_base + downstream)
+        )
+        upper = torch.maximum(
+            gs * (window_base - upstream), gs * (window_base + downstream)
+        )
         return (
             (m_chrom == g_chrom)
-            & (gs * (window_base - upstream) < delta)
-            & (delta < gs * (window_base + downstream))
+            & (lower < delta)
+            & (delta < upper)
         )
     if region == 'trans':
         return m_chrom != g_chrom

--- a/tecpg/regression_full.py
+++ b/tecpg/regression_full.py
@@ -473,15 +473,23 @@ def _regression_full_inner(
                         # G_strand_t is int8; window magnitudes (~1e6)
                         # overflow int8, so widen before multiplying.
                         gs = G_strand_t[index - 1, None].to(torch.int64)
+                        # Multiplying by strand reverses the bounds, which makes
+                        # a symmetric negative-strand window empty. Order them.
+                        lower = torch.minimum(
+                            gs * (window_base - upstream),
+                            gs * (window_base + downstream),
+                        )
+                        upper = torch.maximum(
+                            gs * (window_base - upstream),
+                            gs * (window_base + downstream),
+                        )
                         region_indices_mask = (
                             (G_chrom_t[index - 1, None] == M_chrom_t)
                             .logical_and(
-                                gs * (window_base - upstream)
-                                < G_pos_t[index - 1, None] - M_pos_t
+                                lower < G_pos_t[index - 1, None] - M_pos_t
                             )
                             .logical_and(
-                                G_pos_t[index - 1, None] - M_pos_t
-                                < (gs * (window_base + downstream))
+                                G_pos_t[index - 1, None] - M_pos_t < upper
                             )
                         )
                     elif region == 'trans':

--- a/tests/test_region_mask.py
+++ b/tests/test_region_mask.py
@@ -31,3 +31,17 @@ def test_trans_mask_unchanged():
         window_base=0, upstream=1_000_000, downstream=1_000_000,
     )
     assert [bool(x) for x in mask] == [False, False, False, True]
+
+def test_cis_window_negative_strand():
+    m_chrom, m_pos, g_chrom, g_pos, g_strand = _fixture()
+    mask = compute_region_mask(
+        'cis', m_chrom, m_pos, g_chrom, g_pos, g_strand,
+        window_base=0, upstream=1_000_000, downstream=1_000_000,
+    )
+    # A -strand CpG 100 kb from its gene is inside a symmetric +/-1 Mb window.
+    # With unordered bounds the interval was inverted (empty), so this was False.
+    assert bool(mask[1]) is True
+    # The +strand and exclusion cases are unchanged by the ordering fix.
+    assert bool(mask[0]) is True
+    assert bool(mask[2]) is False
+    assert bool(mask[3]) is False


### PR DESCRIPTION
This PR fixes the bug where negative-strand genes inadvertently got empty cis windows because multiplying their bounds by the negative strand (-1) reversed the logical order of the upper and lower bounds. The fix computes the ordered limits using `torch.minimum` and `torch.maximum` at the points of use in `tecpg/helper.py` and `tecpg/regression_full.py`. It also appends a test to verify proper bounds evaluation for negative strand pairs.

### Proof

**Parent commit (RED)**:
```
tests/test_region_mask.py ..F                                            [100%]

=================================== FAILURES ===================================
_______________________ test_cis_window_negative_strand ________________________

    def test_cis_window_negative_strand():
        m_chrom, m_pos, g_chrom, g_pos, g_strand = _fixture()
        mask = compute_region_mask(
            'cis', m_chrom, m_pos, g_chrom, g_pos, g_strand,
            window_base=0, upstream=1_000_000, downstream=1_000_000,
        )
        # A -strand CpG 100 kb from its gene is inside a symmetric +/-1 Mb window.
        # With unordered bounds the interval was inverted (empty), so this was False.
>       assert bool(mask[1]) is True
E       assert False is True
E        +  where False = bool(tensor(False))

tests/test_region_mask.py:43: AssertionError
```

**With Fix (GREEN)**:
```
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /app
configfile: pytest.ini
plugins: anyio-4.14.2
collected 3 items

tests/test_region_mask.py ...                                            [100%]

============================== 3 passed in 2.67s ===============================
```

### Additional test status

`test_mlr_comparison` and `test_correctness_harness` run green:
```
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /app
configfile: pytest.ini
plugins: anyio-4.14.2
collected 14 items

tests/test_mlr_comparison.py ..                                          [ 14%]
tests/test_correctness_harness.py ............                           [100%]

============================= 14 passed in 43.02s ==============================
```

Full test suite:
```
173 items collected.
================== 173 passed, 1 warning in 128.61s (0:02:08) ==================
```

---
*PR created automatically by Jules for task [12643876096146635282](https://jules.google.com/task/12643876096146635282) started by @kordk*