### PR TITLE
Promote mt_id/gt_id from a named index in assemble_master

### DIFF
--- a/tests/test_build_gene_anchored_master.py
+++ b/tests/test_build_gene_anchored_master.py
@@ -103,3 +103,57 @@ def test_empty_result_fails_closed():
             ValueError,
             match="Assembled master dataframe is empty"):
         assemble_master(empty_cis, empty_res, mt_t_atol=1e-3)
+
+
+def test_cis_map_named_index_promoted(tmp_path):
+    """Map outputs store (mt_id, gt_id) in a named MultiIndex and mergeOutputs'
+    parquet->parquet path is a raw Arrow passthrough that preserves it."""
+    pq = pytest.importorskip('pyarrow.parquet')
+    pa = pytest.importorskip('pyarrow')
+
+    chunk = pd.DataFrame({
+        'mt_id': ['mt1', 'mt2'],
+        'gt_id': ['gt1', 'gt2'],
+        'mt_t': [1.0, 2.0],
+        'mt_p': [0.1, 0.2]
+    }).set_index(['mt_id', 'gt_id'])
+
+    src = tmp_path / 'chunk.parquet'
+    merged = tmp_path / 'merged.parquet'
+    pq.write_table(pa.Table.from_pandas(chunk), src)
+    table = pq.read_table(src)
+    writer = pq.ParquetWriter(merged, table.schema)
+    writer.write_table(table)
+    writer.close()
+
+    cis_df = pd.read_parquet(merged)
+    assert cis_df.index.names == ['mt_id', 'gt_id']
+
+    res_df = pd.DataFrame({
+        'mt_id': ['mt3'], 'gt_id': ['gt3'],
+        'mt_t': [3.0], 'mt_p': [0.3]
+    })
+
+    assembled = assemble_master(cis_df, res_df, mt_t_atol=1e-3)
+    assert len(assembled) == 3
+    assert set(assembled['mt_id']) == {'mt1', 'mt2', 'mt3'}
+
+
+def test_indexed_and_column_inputs_agree():
+    cols = pd.DataFrame({
+        'mt_id': ['mt1', 'mt2'], 'gt_id': ['gt1', 'gt2'],
+        'mt_t': [1.0, 2.0], 'mt_p': [0.1, 0.2]
+    })
+    res_df = pd.DataFrame({
+        'mt_id': ['mt2'], 'gt_id': ['gt2'],
+        'mt_t': [2.0], 'mt_p': [0.2]
+    })
+
+    from_cols = assemble_master(cols, res_df, mt_t_atol=1e-3)
+    from_index = assemble_master(
+        cols.set_index(['mt_id', 'gt_id']), res_df, mt_t_atol=1e-3)
+
+    key = ['mt_id', 'gt_id']
+    pd.testing.assert_frame_equal(
+        from_cols.sort_values(key).reset_index(drop=True),
+        from_index.sort_values(key).reset_index(drop=True))

--- a/tools/build_gene_anchored_master.py
+++ b/tools/build_gene_anchored_master.py
@@ -7,10 +7,26 @@ import pandas as pd
 logger = logging.getLogger(__name__)
 
 
+def _reset_if_indexed(df: pd.DataFrame) -> pd.DataFrame:
+    """Promote a named index to columns.
+
+    Map outputs store (mt_id, gt_id) in a named MultiIndex, and mergeOutputs'
+    parquet->parquet path is a raw Arrow passthrough that preserves it. CSV
+    inputs carry them as columns, which is why this only bites on parquet.
+    Same guard used by assignRegionToEcpg_parquet.py / mergeOutputs.py /
+    permute.py.
+    """
+    if df.index.names != [None]:
+        return df.reset_index()
+    return df
+
+
 def assemble_master(
         cis_map_df: pd.DataFrame,
         reservoir_df: pd.DataFrame,
         mt_t_atol: float) -> pd.DataFrame:
+    cis_map_df = _reset_if_indexed(cis_map_df)
+    reservoir_df = _reset_if_indexed(reservoir_df)
     required_cols = {'mt_id', 'gt_id', 'mt_t'}
 
     # Check for required columns


### PR DESCRIPTION
Promote mt_id/gt_id from a named index in assemble_master

Map outputs store (mt_id, gt_id) in a named MultiIndex, and mergeOutputs'
parquet->parquet path is a raw Arrow passthrough that preserves it, so
build_gene_anchored_master's plain read_parquet + column check failed with
"Source 'cis_map' is missing required columns" on a real cis map. CSV
reservoir inputs carry the ids as columns, which is why this only surfaced
once a map output was fed in.

Apply the same index-promotion guard already used by
assignRegionToEcpg_parquet.py, mergeOutputs.py and permute.py, to both
inputs of assemble_master. Add an indexed-parquet regression test through
the real Arrow passthrough plus an equivalence oracle showing indexed and
column-carrying inputs assemble identically.

---
*PR created automatically by Jules for task [10564179522606035797](https://jules.google.com/task/10564179522606035797) started by @kordk*