### PR TITLE
Add analytic p precision, pair density, gene span and TSS distance modules

### DIFF
--- a/tests/test_permute_qc_report.py
+++ b/tests/test_permute_qc_report.py
@@ -288,7 +288,11 @@ def test_schema_conformance_independent_oracle():
     # Assert that every requested key via .get('key') is a known valid key
     # (ignoring purely structural missing-check lookups if they aren't meant to be in the JSON,
     # but in our script, all .get calls are for real keys).
+
+    # We ignore module import gets in sys.modules.get
     for key in requested_keys:
+        if "assignRegionToEcpg_parquet" in key or "tools.assignRegionToEcpg_parquet" in key:
+            continue
         assert key in known_valid_keys, f"Reader asks for missing/wrong key: {key}"
 
 
@@ -480,3 +484,394 @@ def test_provenance_metadata_lookups(sample_report):
     html = mod.table_html
     assert "[0.05, 1.0]" in html
     assert "p_ana &lt; 0.0001" in html
+
+
+def test_analytic_p_precision_detects_decade_gap():
+    import numpy as np
+    import pandas as pd
+    from tools.permute_qc_report import build_analytic_p_precision_module
+
+    # Empty decade 6, populated 5 and 7
+    # -log10(p) decades 5, 6, 7 mean p values around 1e-5, 1e-6, 1e-7
+    # Decade 5: -log10(p) in [5, 6) -> p in (1e-6, 1e-5]
+    # Decade 6: -log10(p) in [6, 7) -> p in (1e-7, 1e-6]
+    # Decade 7: -log10(p) in [7, 8) -> p in (1e-8, 1e-7]
+
+    p_vals = np.array([10**(-5.5), 10**(-7.5)])
+    t_vals = np.array([5.0, 7.0])  # just need some valid numbers, we'll force p_recomputed to be close enough
+
+    # we don't care about the true relation for the gap test, but we need to pass max_abs_log_ratio check
+    import scipy.stats
+    p_recomputed = 2 * scipy.stats.t.sf(np.abs(t_vals), 100)
+    # we can just spoof it so p_vals equals p_recomputed exactly to isolate gap test
+    df = pd.DataFrame({'mt_t': t_vals, 'mt_p': p_recomputed})
+    # now let's make p_vals give the decades we want
+    # say t=4.5 -> p ~ 1e-5, t=5.5 -> p ~ 1e-7
+    # let's just use scipy.stats to find t that gives these p
+    t1 = scipy.stats.t.isf(10**(-5.5) / 2, 100)
+    t2 = scipy.stats.t.isf(10**(-7.5) / 2, 100)
+
+    df = pd.DataFrame({'mt_t': [t1, t2], 'mt_p': [10**(-5.5), 10**(-7.5)]})
+    mod = build_analytic_p_precision_module({'metadata': {'df': 100}}, df)
+
+    assert mod.status == 'WARN'
+    assert "6" in mod.table_html
+
+    # Smoothly decreasing
+    t3 = scipy.stats.t.isf(10**(-6.5) / 2, 100)
+    df_smooth = pd.DataFrame({'mt_t': [t1, t3, t2], 'mt_p': [10**(-5.5), 10**(-6.5), 10**(-7.5)]})
+    mod_smooth = build_analytic_p_precision_module({'metadata': {'df': 100}}, df_smooth)
+
+    assert mod_smooth.status == 'PASS'
+
+
+def test_analytic_p_precision_detects_storage_mismatch():
+    import numpy as np
+    import pandas as pd
+    import scipy.stats
+    from tools.permute_qc_report import build_analytic_p_precision_module
+
+    t_vals = np.array([2.0, 3.0])
+    p_true = 2 * scipy.stats.t.sf(t_vals, 100)
+
+    df_good = pd.DataFrame({'mt_t': t_vals, 'mt_p': p_true})
+    mod_good = build_analytic_p_precision_module({'metadata': {'df': 100}}, df_good)
+    assert mod_good.status == 'PASS'
+
+    p_bad = p_true * 2  # log10(2) ~ 0.301, > 0.1
+    df_bad = pd.DataFrame({'mt_t': t_vals, 'mt_p': p_bad})
+    mod_bad = build_analytic_p_precision_module({'metadata': {'df': 100}}, df_bad)
+    assert mod_bad.status == 'WARN'
+
+
+def test_analytic_p_precision_info_without_parquet():
+    from tools.permute_qc_report import build_analytic_p_precision_module
+    mod = build_analytic_p_precision_module({'metadata': {'df': 100}}, None)
+    assert mod.status == 'INFO'
+    assert mod.interpretation == "Not evaluated: --perm-output not supplied."
+
+
+def test_cis_pair_density_warns_on_collapsed_window():
+    import pandas as pd
+    from tools.permute_qc_report import build_cis_pair_density_module
+    from eval_permute import NEAR_GENE_REGIONS
+
+    # fewer near-gene pairs than genes -> median < 1
+    # 5 genes, 2 near-gene pairs
+    # Note NEAR_GENE_REGIONS doesn't include DISTAL5, DISTAL3 usually (they are not "near").
+    # Actually NEAR_GENE_REGIONS = ['PROMOTER', 'CIS5', 'CIS3', 'GENEBODY'] usually.
+    df_warn = pd.DataFrame({
+        'gt_id': ['g1', 'g2', 'g3', 'g4', 'g5'],
+        'region': ['PROMOTER', 'PROMOTER', 'TRANS', 'TRANS', 'TRANS']
+    })
+    mod_warn = build_cis_pair_density_module({}, df_warn)
+    assert mod_warn.status == 'WARN'
+
+    df_pass = pd.DataFrame({
+        'gt_id': ['g1', 'g2', 'g1', 'g2'],
+        'region': ['PROMOTER', 'PROMOTER', 'CIS3', 'CIS3']
+    })
+    mod_pass = build_cis_pair_density_module({}, df_pass)
+    assert mod_pass.status == 'PASS', f"Expected PASS, got {mod_pass.status}: {mod_pass.table_html}"
+
+
+def test_cis_pair_density_quantiles():
+    import pandas as pd
+    from tools.permute_qc_report import build_cis_pair_density_module
+
+    # 10 genes, pairs per gene: 1 to 10
+    gt_ids = []
+    regions = []
+    for i in range(1, 11):
+        gt_ids.extend([f'g{i}'] * i)
+        regions.extend(['PROMOTER'] * i)
+
+    df = pd.DataFrame({'gt_id': gt_ids, 'region': regions})
+    mod = build_cis_pair_density_module({}, df)
+
+    assert mod.status == 'PASS'
+    assert "1, 3, 5, 7, 9, 10" in mod.table_html  # (1, 3.25(int->3), 5.5(int->5), 7.75(int->7), 9.1(int->9), 10)
+
+
+def test_gene_span_warns_when_mostly_short():
+    from tools.permute_qc_report import build_gene_span_distribution_module
+    import tools.assignRegionToEcpg_parquet as A
+    PROMOTER_DOWNSTREAM_DISTANCE = A.PROMOTER_DOWNSTREAM_DISTANCE
+
+    # 3 short, 1 long -> 75% short -> WARN
+    gene_annot_warn = {
+        'g1': {'chromStart': 100, 'chromEnd': 100 + PROMOTER_DOWNSTREAM_DISTANCE - 10},
+        'g2': {'chromStart': 100, 'chromEnd': 100 + PROMOTER_DOWNSTREAM_DISTANCE - 10},
+        'g3': {'chromStart': 100, 'chromEnd': 100 + PROMOTER_DOWNSTREAM_DISTANCE - 10},
+        'g4': {'chromStart': 100, 'chromEnd': 100 + PROMOTER_DOWNSTREAM_DISTANCE + 1000},
+    }
+    mod_warn = build_gene_span_distribution_module({}, None, gene_annot_warn, None)
+    assert mod_warn.status == 'WARN'
+
+    # 2 short, 2 long -> 50% short -> PASS (threshold is > 50%)
+    gene_annot_pass = {
+        'g1': {'chromStart': 100, 'chromEnd': 100 + PROMOTER_DOWNSTREAM_DISTANCE - 10},
+        'g2': {'chromStart': 100, 'chromEnd': 100 + PROMOTER_DOWNSTREAM_DISTANCE - 10},
+        'g3': {'chromStart': 100, 'chromEnd': 100 + PROMOTER_DOWNSTREAM_DISTANCE + 1000},
+        'g4': {'chromStart': 100, 'chromEnd': 100 + PROMOTER_DOWNSTREAM_DISTANCE + 1000},
+    }
+    mod_pass = build_gene_span_distribution_module({}, None, gene_annot_pass, None)
+    assert mod_pass.status == 'PASS', f"Expected PASS, got {mod_pass.status}: {mod_pass.table_html}"
+
+
+def test_gene_span_uses_imported_threshold(monkeypatch):
+    import sys
+    sys.path.insert(0, 'tools')
+    from tools.permute_qc_report import build_gene_span_distribution_module
+    import assignRegionToEcpg_parquet as A
+
+    monkeypatch.setattr(A, 'PROMOTER_DOWNSTREAM_DISTANCE', 500)
+
+    gene_annot = {
+        'g1': {'chromStart': 100, 'chromEnd': 650},  # span 550, > 500 (patched) but < 2500 (unpatched)
+    }
+
+    mod = build_gene_span_distribution_module({}, None, gene_annot, None)
+    # the text should include 500
+    assert "Genes with span ≤ 500" in mod.table_html
+    # short span count should be 0
+    assert "0 (0.00%)" in mod.table_html
+
+
+def test_tss_distance_signed_convention():
+    import pandas as pd
+    from tools.permute_qc_report import build_tss_distance_module
+
+    df = pd.DataFrame({
+        'mt_id': ['m1', 'm2', 'm3', 'm4'],
+        'gt_id': ['g_plus', 'g_plus', 'g_minus', 'g_minus'],
+        'region': ['DISTAL5', 'DISTAL3', 'DISTAL5', 'DISTAL3']  # just dummy regions
+    })
+
+    # + strand: TSS is start
+    # - strand: TSS is end
+    gene_annot = {
+        'g_plus': {'chrom': 'chr1', 'chromStart': 10000, 'chromEnd': 20000, 'strand': '+'},
+        'g_minus': {'chrom': 'chr1', 'chromStart': 10000, 'chromEnd': 20000, 'strand': '-'}
+    }
+
+    meth_annot = {
+        'm1': {'chrom': 'chr1', 'chromStart': 9000},  # 1kb upstream of g_plus TSS -> d = -1000
+        'm2': {'chrom': 'chr1', 'chromStart': 11000},  # 1kb downstream of g_plus TSS -> d = +1000
+        'm3': {'chrom': 'chr1', 'chromStart': 21000},  # 1kb upstream of g_minus TSS -> (21000-20000)*-1 = -1000
+        'm4': {'chrom': 'chr1', 'chromStart': 19000},  # 1kb downstream of g_minus TSS -> (19000-20000)*-1 = +1000
+    }
+
+    mod = build_tss_distance_module({}, df, gene_annot, meth_annot)
+
+    # We should extract the computed distances somehow, or at least they affect the median.
+    # Since DISTAL5 is both m1 and m3, median for DISTAL5 is -1000
+    # Since DISTAL3 is both m2 and m4, median for DISTAL3 is 1000
+    assert "-1000" in mod.table_html
+    assert "1000" in mod.table_html
+    assert "-1000" not in mod.table_html.split("DISTAL3")[1].split("</tr>")[0]  # ensuring DISTAL3 is not -1000
+
+
+def test_tss_distance_band_violation_warns():
+    import pandas as pd
+    from tools.permute_qc_report import build_tss_distance_module
+    import tools.assignRegionToEcpg_parquet as A
+    PROMOTER_DOWNSTREAM_DISTANCE = A.PROMOTER_DOWNSTREAM_DISTANCE
+
+    # 2 correctly placed, 1 violation -> 33% violation -> WARN
+    df = pd.DataFrame({
+        'mt_id': ['m1', 'm2', 'm3'],
+        'gt_id': ['g1', 'g1', 'g1'],
+        'region': ['PROMOTER', 'PROMOTER', 'PROMOTER']
+    })
+
+    gene_annot = {
+        'g1': {'chrom': 'chr1', 'chromStart': 10000, 'chromEnd': 20000, 'strand': '+'}
+    }
+
+    meth_annot = {
+        'm1': {'chrom': 'chr1', 'chromStart': 10000},  # d=0 (ok)
+        'm2': {'chrom': 'chr1', 'chromStart': 10000 + PROMOTER_DOWNSTREAM_DISTANCE},  # d=PDD (ok)
+        'm3': {'chrom': 'chr1', 'chromStart': 10000 + PROMOTER_DOWNSTREAM_DISTANCE + 1},  # d=PDD+1 (violates)
+    }
+
+    mod_warn = build_tss_distance_module({}, df, gene_annot, meth_annot)
+    assert mod_warn.status == 'WARN'
+    assert "33.33%" in mod_warn.table_html
+
+    meth_annot_pass = {
+        'm1': {'chrom': 'chr1', 'chromStart': 10000},
+        'm2': {'chrom': 'chr1', 'chromStart': 10000},
+        'm3': {'chrom': 'chr1', 'chromStart': 10000},
+    }
+    mod_pass = build_tss_distance_module({}, df, gene_annot, meth_annot_pass)
+    assert mod_pass.status == 'PASS'
+
+
+def test_tss_distance_skips_span_dependent_bands():
+    import pandas as pd
+    from tools.permute_qc_report import build_tss_distance_module
+
+    df = pd.DataFrame({
+        'mt_id': ['m1', 'm2', 'm3'],
+        'gt_id': ['g1', 'g1', 'g1'],
+        'region': ['GENEBODY', 'CIS3', 'DISTAL3']
+    })
+
+    gene_annot = {'g1': {'chrom': 'chr1', 'chromStart': 10000, 'chromEnd': 20000, 'strand': '+'}}
+    meth_annot = {
+        'm1': {'chrom': 'chr1', 'chromStart': 50000},  # d=40000, way off
+        'm2': {'chrom': 'chr1', 'chromStart': 50000},
+        'm3': {'chrom': 'chr1', 'chromStart': 50000},
+    }
+
+    mod = build_tss_distance_module({}, df, gene_annot, meth_annot)
+    assert mod.status == 'PASS'
+
+    # Should render an em dash
+    assert "—" in mod.table_html
+
+
+def test_tss_distance_excludes_cross_chromosome():
+    import pandas as pd
+    from tools.permute_qc_report import build_tss_distance_module
+
+    df = pd.DataFrame({
+        'mt_id': ['m1'],
+        'gt_id': ['g1'],
+        'region': ['PROMOTER']
+    })
+
+    gene_annot = {'g1': {'chrom': 'chr1', 'chromStart': 10000, 'chromEnd': 20000, 'strand': '+'}}
+    meth_annot = {'m1': {'chrom': 'chr2', 'chromStart': 10000}}
+
+    mod = build_tss_distance_module({}, df, gene_annot, meth_annot)
+    # pair is dropped, so count for PROMOTER is 0, outputs N/A
+    assert ("PROMOTER</td>\n      <td style=\"text-align: left;\">0</td>\n      "
+            "<td style=\"text-align: left;\">N/A") in mod.table_html
+
+
+def test_new_modules_never_raise_on_empty_inputs():
+    from tools.permute_qc_report import (
+        build_analytic_p_precision_module,
+        build_cis_pair_density_module,
+        build_gene_span_distribution_module,
+        build_tss_distance_module
+    )
+
+    m1 = build_analytic_p_precision_module({})
+    assert m1.status == 'INFO'
+
+    m2 = build_cis_pair_density_module({})
+    assert m2.status == 'INFO'
+
+    m3 = build_gene_span_distribution_module({})
+    assert m3.status == 'INFO'
+
+    m4 = build_tss_distance_module({})
+    assert m4.status == 'INFO'
+
+
+def test_all_builders_accept_four_arguments():
+    from tools.permute_qc_report import (
+        build_run_provenance_module,
+        build_region_composition_module,
+        build_bulk_calibration_module,
+        build_calibration_direction_module,
+        build_stratification_module,
+        build_verdict_robustness_module,
+        build_permutation_resolution_module,
+        build_tail_behaviour_module,
+        build_analytic_p_precision_module,
+        build_cis_pair_density_module,
+        build_gene_span_distribution_module,
+        build_tss_distance_module
+    )
+
+    builders = [
+        build_run_provenance_module,
+        build_region_composition_module,
+        build_bulk_calibration_module,
+        build_calibration_direction_module,
+        build_stratification_module,
+        build_verdict_robustness_module,
+        build_permutation_resolution_module,
+        build_tail_behaviour_module,
+        build_analytic_p_precision_module,
+        build_cis_pair_density_module,
+        build_gene_span_distribution_module,
+        build_tss_distance_module
+    ]
+
+    report = {'metadata': {}, 'arms': {'calibration': {}, 'null_sanity': {}, 'resolution': {}}}
+
+    for b in builders:
+        try:
+            b(report, None, None, None)
+        except Exception as e:
+            # We don't care if it fails with KeyError on empty report internals,
+            # we just care it doesn't fail on TypeError (missing arguments)
+            if isinstance(e, TypeError) and "takes" in str(e):
+                raise AssertionError(f"{b.__name__} raised TypeError: {e}")
+
+
+def test_report_generates_with_no_optional_inputs(monkeypatch):
+    import sys
+    import json
+    import os
+    import tempfile
+
+    # We write a dummy valid report and run main with only --report, --dataset, --out
+    with tempfile.TemporaryDirectory() as td:
+        rep_path = os.path.join(td, 'rep.json')
+        with open(rep_path, 'w') as f:
+            json.dump({'metadata': {}, 'arms': {'calibration': {}, 'null_sanity': {}, 'resolution': {}}}, f)
+
+        out_path = os.path.join(td, 'out.html')
+
+        args = ['permute_qc_report.py', '--report', rep_path, '--dataset', 'dummy', '--out', out_path]
+        monkeypatch.setattr(sys, 'argv', args)
+
+        import tools.permute_qc_report as q
+        # This will sys.exit(0) on success, so we catch it
+        try:
+            q.main()
+        except SystemExit as e:
+            assert e.code == 0
+
+        with open(out_path, 'r') as f:
+            content = f.read()
+
+        assert "Analytic P Precision" in content
+        assert "Cis Pair Density" in content
+        assert "Gene Span Distribution" in content
+        assert "TSS Distance by Region" in content
+
+
+def test_tss_distance_sampling_deterministic(monkeypatch):
+    import pandas as pd
+    from tools.permute_qc_report import build_tss_distance_module
+    import tools.permute_qc_report as q_module
+
+    monkeypatch.setattr(q_module, 'DISTANCE_SAMPLE_N', 2)
+
+    df = pd.DataFrame({
+        'mt_id': ['m1', 'm2', 'm3', 'm4'],
+        'gt_id': ['g1', 'g1', 'g1', 'g1'],
+        'region': ['PROMOTER', 'PROMOTER', 'PROMOTER', 'PROMOTER']
+    })
+
+    gene_annot = {'g1': {'chrom': 'chr1', 'chromStart': 10000, 'chromEnd': 20000, 'strand': '+'}}
+    meth_annot = {
+        'm1': {'chrom': 'chr1', 'chromStart': 10000},
+        'm2': {'chrom': 'chr1', 'chromStart': 11000},
+        'm3': {'chrom': 'chr1', 'chromStart': 12000},
+        'm4': {'chrom': 'chr1', 'chromStart': 13000},
+    }
+
+    mod1 = build_tss_distance_module({}, df, gene_annot, meth_annot)
+    mod2 = build_tss_distance_module({}, df, gene_annot, meth_annot)
+
+    assert mod1.table_html == mod2.table_html
+    # Pairs Sampled for PROMOTER should be 2 because we sampled 2 out of 4 total pairs
+    assert "PROMOTER</td>\n      <td style=\"text-align: left;\">2</td>" in mod1.table_html

--- a/tools/permute_qc_report.py
+++ b/tools/permute_qc_report.py
@@ -34,6 +34,7 @@ DIRECTION_WARN = 0.01            # |median log10(p_perm/p_ana)| in the bulk
 DIRECTION_FAIL = 0.05
 DELTA_WARN_FRACTION = 0.10       # near-gene |delta| above tolerance*this warns
 TOLERANCE_SWEEP = (0.5, 0.2, 0.1, 0.05, 0.02, 0.01, 1e-3, 1e-4, 1e-5)
+DISTANCE_SAMPLE_N = 2_000_000    # cap on pairs used for the TSS distance module
 # -------------------------------------------------------------------------
 
 STATUSES = ('PASS', 'WARN', 'FAIL', 'INFO')
@@ -50,6 +51,19 @@ class QCModule:
     table_html: str = ""     # pre-rendered <table>...</table>, or ""
     figure_b64: str = ""     # base64 PNG payload, or ""
     figure_alt: str = ""     # alt text for the figure
+
+
+def get_missing_inputs_msg(*missing_inputs):
+    """Generate the exact not-evaluated string for missing dependencies."""
+    missing = [x for x in missing_inputs if x]
+    if not missing:
+        return ""
+    if len(missing) == 1:
+        return f"Not evaluated: {missing[0]} not supplied."
+    elif len(missing) == 2:
+        return f"Not evaluated: {missing[0]} and {missing[1]} not supplied."
+    else:
+        return f"Not evaluated: {', '.join(missing[:-1])} and {missing[-1]} not supplied."
 
 
 def fig_to_base64(fig, dpi=110) -> str:
@@ -184,7 +198,7 @@ def render_html(dataset: str, meta: dict, modules: list) -> str:
     return html_doc
 
 
-def build_run_provenance_module(report: dict, df=None) -> QCModule:
+def build_run_provenance_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
     purpose = (
         "Records the inputs the rest of this report is computed from, so that any "
         "figure or table here can be traced back to a specific run. Every other "
@@ -234,7 +248,7 @@ def build_run_provenance_module(report: dict, df=None) -> QCModule:
     )
 
 
-def build_region_composition_module(report: dict, df=None) -> QCModule:
+def build_region_composition_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
     purpose = (
         "Confirms the cis-window enrichment produced the near-gene coverage the "
         "per-region calibration needs, and that the two distal strata are balanced. "
@@ -340,7 +354,7 @@ def build_region_composition_module(report: dict, df=None) -> QCModule:
     )
 
 
-def build_bulk_calibration_module(report: dict, df=None) -> QCModule:
+def build_bulk_calibration_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
     purpose = (
         "Compares the permutation p-value against the analytic p-value across the "
         "mostly-null bulk band, where the two should agree if the parametric null "
@@ -429,7 +443,7 @@ def build_bulk_calibration_module(report: dict, df=None) -> QCModule:
     )
 
 
-def build_calibration_direction_module(report: dict, df=None) -> QCModule:
+def build_calibration_direction_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
     purpose = (
         "Reports the direction and magnitude of disagreement between the permutation "
         "and analytic p-values across the null bulk. The bulk calibration module shows "
@@ -598,7 +612,7 @@ def build_calibration_direction_module(report: dict, df=None) -> QCModule:
     )
 
 
-def build_verdict_robustness_module(report: dict, df=None) -> QCModule:
+def build_verdict_robustness_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
     purpose = (
         "Asks how far the applied tolerance would have to move before the "
         "stratification verdict changed. A verdict that holds across several orders of "
@@ -724,7 +738,7 @@ def build_verdict_robustness_module(report: dict, df=None) -> QCModule:
     )
 
 
-def build_permutation_resolution_module(report: dict, df=None) -> QCModule:
+def build_permutation_resolution_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
     purpose = (
         "Establishes the smallest p-value the permutation null in this run is capable "
         "of resolving, and how much of the significant tail is sitting at that limit. "
@@ -866,7 +880,7 @@ def build_permutation_resolution_module(report: dict, df=None) -> QCModule:
     )
 
 
-def build_tail_behaviour_module(report: dict, df=None) -> QCModule:
+def build_tail_behaviour_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
     purpose = (
         "Reports how the permutation and analytic p-values diverge in the significant "
         "tail, which is the regime where a permutation null is expected to add the "
@@ -982,7 +996,7 @@ def build_tail_behaviour_module(report: dict, df=None) -> QCModule:
     )
 
 
-def build_stratification_module(report: dict, df=None) -> QCModule:
+def build_stratification_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
     purpose = (
         "Asks whether each region's null bulk behaves like the trans reference. If "
         "the near-gene regions calibrate the same way trans does, a single global "
@@ -1101,6 +1115,8 @@ def main():
     parser.add_argument('--df', type=int, help="Degrees of freedom (optional)")
     parser.add_argument('--dataset', required=True, help="Dataset name for the report title")
     parser.add_argument('--out', required=True, help="Path to output HTML file")
+    parser.add_argument('--gene-annotation', help="Path to gene BED6/GFF annotation")
+    parser.add_argument('--meth-annotation', help="Path to methylation BED6 annotation")
 
     args = parser.parse_args()
 
@@ -1134,11 +1150,30 @@ def main():
         build_verdict_robustness_module,
         build_permutation_resolution_module,
         build_tail_behaviour_module,
+        build_analytic_p_precision_module,
+        build_cis_pair_density_module,
+        build_gene_span_distribution_module,
+        build_tss_distance_module,
     ]
+
+    import assignRegionToEcpg_parquet as A
+    gene_annot = None
+    if getattr(args, 'gene_annotation', None):
+        try:
+            gene_annot = A.readAnnotationFileToDict(args.gene_annotation)
+        except Exception as e:
+            logger.warning(f"Failed to load gene annotation from {args.gene_annotation}: {e}")
+
+    meth_annot = None
+    if getattr(args, 'meth_annotation', None):
+        try:
+            meth_annot = A.readAnnotationFileToDict(args.meth_annotation)
+        except Exception as e:
+            logger.warning(f"Failed to load meth annotation from {args.meth_annotation}: {e}")
 
     for build_func in builders:
         try:
-            mod = build_func(report_data, df)
+            mod = build_func(report_data, df, gene_annot, meth_annot)
             modules.append(mod)
 
         except Exception as e:
@@ -1169,9 +1204,487 @@ def main():
         sys.exit(1)
 
 
-if __name__ == "__main__":
+def build_analytic_p_precision_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
+    purpose = (
+        "Checks that the stored analytic p-value is a faithful representation of the "
+        "test statistic it was computed from, and that its distribution is continuous "
+        "where it should be. Every claim about the significant tail rests on these "
+        "values, so a storage or precision limit in them would propagate to the tail "
+        "comparison without being visible there."
+    )
+    interpretation = (
+        "The stored p-value is compared against a p-value recomputed in double "
+        "precision from the stored t-statistic and the reported degrees of freedom. A "
+        "large maximum ratio between the two means precision is being lost somewhere "
+        "between computation and storage, which matters most for the smallest "
+        "p-values, which are exactly the ones the tail analysis depends on. The decade "
+        "counts are reported because a p-value distribution with real signal should "
+        "thin out smoothly as it deepens: an empty decade sitting above a populated "
+        "one is not a shape any continuous distribution produces, and indicates a "
+        "storage floor, a clipping step, or a filter applied somewhere upstream. This "
+        "module reports the observation and deliberately does not diagnose the cause; "
+        "the smallest representable positive value in a 32-bit float is far below the "
+        "range where such a gap would ordinarily appear, so a gap here should be "
+        "traced rather than assumed to be a representation limit."
+    )
+
+    missing = []
+    if df is None or 'mt_p' not in df.columns or 'mt_t' not in df.columns:
+        missing.append('--perm-output')
+
+    if missing:
+        msg = get_missing_inputs_msg(*missing)
+        return QCModule(
+            anchor="analytic-p-precision", title="Analytic P Precision", status="INFO",
+            purpose=purpose, interpretation=msg
+        )
+
+    if not report.get('metadata', {}).get('df'):
+        return QCModule(
+            anchor="analytic-p-precision", title="Analytic P Precision", status="INFO",
+            purpose=purpose, interpretation="Not evaluated: report missing degrees of freedom."
+        )
+
+    import scipy.stats
+    import numpy as np
+
+    metadata_df = report['metadata']['df']
+    p_stored = df['mt_p'].dropna()
+    p_recomputed = 2 * scipy.stats.t.sf(abs(df['mt_t'].astype('float64')), metadata_df)
+
+    smallest_pos = p_stored[p_stored > 0].min() if (p_stored > 0).any() else None
+    smallest_pos_count = (p_stored == smallest_pos).sum() if smallest_pos is not None else 0
+    smallest_pos_pct = (smallest_pos_count / len(p_stored)) * 100 if len(p_stored) > 0 else 0
+    exact_zeros = (p_stored == 0).sum()
+
+    mask = (p_stored > 0) & (p_recomputed > 0)
+    excluded_rows = len(p_stored) - mask.sum()
+
+    max_abs_log_ratio = 0.0
+    if mask.any():
+        with np.errstate(divide='ignore', invalid='ignore'):
+            log_ratio = np.abs(np.log10(p_stored[mask] / p_recomputed[mask]))
+        log_ratio = log_ratio[np.isfinite(log_ratio)]
+        if len(log_ratio) > 0:
+            max_abs_log_ratio = log_ratio.max()
+
+    log_p = -np.log10(p_stored[p_stored > 0])
+    decades = log_p.astype(int)
+    decade_counts = [(decades == k).sum() for k in range(31)]
+
+    shallowest_gap = None
+    first_populated = -1
+    for k in range(31):
+        if decade_counts[k] > 0 and first_populated == -1:
+            first_populated = k
+
+    if first_populated != -1:
+        for k in range(first_populated + 1, 31):
+            if decade_counts[k] == 0:
+                if any(decade_counts[j] > 0 for j in range(k + 1, 31)):
+                    shallowest_gap = k
+                    break
+
+    status = 'PASS'
+    if shallowest_gap is not None or max_abs_log_ratio >= 0.1:
+        status = 'WARN'
+
+    table_rows = [
+        ["Smallest non-zero stored p", f"{smallest_pos:.2e}" if smallest_pos is not None else "None"],
+        ["Rows at smallest non-zero p", f"{smallest_pos_count:,} ({smallest_pos_pct:.4f}%)"],
+        ["Exact zeros in stored p", f"{exact_zeros:,}"],
+        ["Rows excluded from ratio (zeros)", f"{excluded_rows:,}"],
+        ["Max |log10(stored / recomputed)|", f"{max_abs_log_ratio:.4f}"],
+        ["Shallowest empty decade (with tail)", str(shallowest_gap) if shallowest_gap is not None else "None"],
+        ["Total rows compared", f"{len(p_stored):,}"]
+    ]
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+    log_p_recomp = -np.log10(p_recomputed[p_recomputed > 0])
+    bins = np.arange(32)
+
+    ax.hist(log_p, bins=bins, histtype='step', log=True, label='Stored', alpha=0.7)
+    ax.hist(log_p_recomp, bins=bins, histtype='step', log=True, label='Recomputed', alpha=0.7)
+    if shallowest_gap is not None:
+        ax.axvline(shallowest_gap, color='r', linestyle='--', label=f'Gap at {shallowest_gap}')
+
+    ax.set_xlim(0, 30)
+    ax.set_xlabel("-log10(p)")
+    ax.set_ylabel("Count")
+    ax.legend(loc='upper right')
+
+    return QCModule(
+        anchor="analytic-p-precision",
+        title="Analytic P Precision",
+        status=status,
+        purpose=purpose,
+        interpretation=interpretation,
+        table_html=render_table(["Metric", "Value"], table_rows),
+        figure_b64=fig_to_base64(fig),
+        figure_alt="Histograms of -log10(p) for stored vs recomputed values."
+    )
+
+
+def build_cis_pair_density_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
+    purpose = (
+        "Reports how many methylation pairs each gene actually contributed within the "
+        "mapped window. A window predicate that silently collapses, or that fails for "
+        "one strand, shows up here as a per-gene count far below what the requested "
+        "window size implies, long before it shows up in any calibration statistic."
+    )
+    interpretation = (
+        "Compare the median near-gene pairs per gene against what the window size and "
+        "array density would predict. A median below one means most genes contributed "
+        "no near-gene pair at all, which for any realistic window is not a biological "
+        "result but a mapping defect - a collapsed window, a coordinate mismatch, or a "
+        "strand handling error. A defect of this kind has occurred in this pipeline "
+        "before and produced roughly one pair per gene from a window that should have "
+        "produced thousands, so this check is deliberately blunt and cheap. A long "
+        "right tail is expected and is not a concern: gene-dense regions legitimately "
+        "produce many more pairs per gene than gene deserts."
+    )
+
+    missing = []
+    if df is None or 'gt_id' not in df.columns or 'region' not in df.columns:
+        missing.append('--perm-output')
+
+    if missing:
+        msg = get_missing_inputs_msg(*missing)
+        return QCModule(
+            anchor="cis-pair-density", title="Cis Pair Density", status="INFO",
+            purpose=purpose, interpretation=msg
+        )
+
+    import numpy as np
+
+    all_pairs_per_gene = df.groupby('gt_id').size()
+    near_gene_df = df[df['region'].isin(NEAR_GENE_REGIONS)]
+    near_gene_pairs_per_gene = near_gene_df.groupby('gt_id').size()
+
+    all_genes = set(all_pairs_per_gene.index)
+    near_genes = set(near_gene_pairs_per_gene.index)
+    zero_near_genes_count = len(all_genes - near_genes)
+
+    near_gene_pairs_per_gene = near_gene_pairs_per_gene.reindex(list(all_genes), fill_value=0)
+
+    def get_quantiles(series):
+        if len(series) == 0:
+            return [0, 0, 0, 0, 0, 0]
+        return [
+            series.min(),
+            series.quantile(0.25),
+            series.median(),
+            series.quantile(0.75),
+            series.quantile(0.90),
+            series.max()
+        ]
+
+    q_all = get_quantiles(all_pairs_per_gene)
+    q_near = get_quantiles(near_gene_pairs_per_gene)
+
+    median_near = q_near[2]
+    status = 'WARN' if median_near < 1 else 'PASS'
+
+    def fmt(q):
+        return [f"{int(x):,}" for x in q]
+
+    table_rows = [
+        ["<b>All Pairs</b>", ""],
+        ["Distinct genes with pairs", f"{len(all_pairs_per_gene):,}"],
+        ["Pairs per gene (min, 25, 50, 75, 90, max)", ", ".join(fmt(q_all))],
+        ["<b>Near-Gene Pairs</b>", ""],
+        ["Genes with zero near-gene pairs", f"{zero_near_genes_count:,}"],
+        ["Near-gene pairs per gene (min, 25, 50, 75, 90, max)", ", ".join(fmt(q_near))]
+    ]
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+
+    max_val = max(q_near[5], 1)
+    bins = np.logspace(0, np.log10(max_val + 1), 50)
+    positive_near = near_gene_pairs_per_gene[near_gene_pairs_per_gene > 0]
+    ax.hist(positive_near, bins=bins, color='steelblue', edgecolor='black')
+    ax.set_xscale('log')
+    ax.axvline(median_near, color='r', linestyle='--', label=f'Median: {median_near}')
+    ax.set_xlabel("Near-gene pairs per gene")
+    ax.set_ylabel("Count of genes")
+    ax.legend()
+
+    return QCModule(
+        anchor="cis-pair-density",
+        title="Cis Pair Density",
+        status=status,
+        purpose=purpose,
+        interpretation=interpretation,
+        table_html=render_table(["Metric", "Value"], table_rows),
+        figure_b64=fig_to_base64(fig),
+        figure_alt="Histogram of near-gene pairs per gene."
+    )
+
+
+def build_gene_span_distribution_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
+    purpose = (
+        "Reports the distribution of annotated gene spans, because the region taxonomy "
+        "can only assign a pair to the gene body when the annotated gene is long "
+        "enough for a gene-body interval to exist at all. This module establishes "
+        "whether the GENEBODY label is reachable for most genes in this cohort."
+    )
+    interpretation = (
+        "The gene-body branch of the region assignment requires a methylation position "
+        "strictly inside the annotated gene and beyond the promoter window, so an "
+        "annotated span at or below the promoter distance leaves no interval for that "
+        "branch to match and the pair is assigned to a neighbouring region instead. "
+        "Where a large fraction of entries fall below the threshold, a low GENEBODY "
+        "count in the region composition module is a property of the annotation rather "
+        "than of the biology, and pairs that a transcript-span annotation would have "
+        "labelled GENEBODY are being labelled PROMOTER or 3-prime cis instead. This "
+        "affects how the catalog should be described and does not affect the "
+        "calibration verdict: the receiving regions are themselves calibrated, and "
+        "moving pairs between calibrated strata cannot create divergence. Treat a "
+        "warning here as a question about the annotation source, not about the "
+        "permutation null."
+    )
+
+    if gene_annot is None:
+        msg = get_missing_inputs_msg("--gene-annotation")
+        return QCModule(
+            anchor="gene-span-distribution", title="Gene Span Distribution", status="INFO",
+            purpose=purpose, interpretation=msg
+        )
+
+    import sys
+    import numpy as np
+
+    spans = []
+    for g, data in gene_annot.items():
+        # span = chromEnd - chromStart
+        spans.append(data['chromEnd'] - data['chromStart'])
+
+    spans = pd.Series(spans)
+
+    if len(spans) == 0:
+        return QCModule(
+            anchor="gene-span-distribution", title="Gene Span Distribution", status="WARN",
+            purpose=purpose, interpretation="No genes found in annotation.",
+            table_html=render_table(["Metric", "Value"], [["Count", "0"]])
+        )
+
+    # Must be read dynamically here so monkeypatching works
+    import assignRegionToEcpg_parquet as A
+    PROMOTER_DOWNSTREAM_DISTANCE = getattr(A, 'PROMOTER_DOWNSTREAM_DISTANCE', 2500)
+
+    q = [
+        spans.min(),
+        spans.quantile(0.25),
+        spans.median(),
+        spans.quantile(0.75),
+        spans.quantile(0.90),
+        spans.max()
+    ]
+
+    short_spans = (spans <= PROMOTER_DOWNSTREAM_DISTANCE).sum()
+    short_spans_pct = (short_spans / len(spans)) * 100
+
+    status = 'WARN' if short_spans_pct > 50 else 'PASS'
+
+    def fmt(q):
+        return [f"{int(x):,}" for x in q]
+
+    table_rows = [
+        ["Total annotated genes", f"{len(spans):,}"],
+        ["Gene span (min, 25, 50, 75, 90, max)", ", ".join(fmt(q))],
+        [f"Genes with span ≤ {PROMOTER_DOWNSTREAM_DISTANCE:,}", f"{short_spans:,} ({short_spans_pct:.2f}%)"]
+    ]
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+
+    bins = np.logspace(0, np.log10(max(q[5], 1) + 1), 50)
+    ax.hist(spans, bins=bins, color='seagreen', edgecolor='black')
+    ax.set_xscale('log')
+    ax.axvline(PROMOTER_DOWNSTREAM_DISTANCE, color='r', linestyle='--',
+               label=f'Promoter downstream ({PROMOTER_DOWNSTREAM_DISTANCE})')
+    ax.set_xlabel("Gene span (bases)")
+    ax.set_ylabel("Count of genes")
+    ax.legend()
+
+    return QCModule(
+        anchor="gene-span-distribution",
+        title="Gene Span Distribution",
+        status=status,
+        purpose=purpose,
+        interpretation=interpretation,
+        table_html=render_table(["Metric", "Value"], table_rows),
+        figure_b64=fig_to_base64(fig),
+        figure_alt="Histogram of gene spans."
+    )
+
+
+def build_tss_distance_module(report: dict, df=None, gene_annot=None, meth_annot=None) -> QCModule:
+    purpose = (
+        "Verifies that pairs carrying a given region label actually sit where the "
+        "region taxonomy says they should, by measuring the strand-oriented distance "
+        "from each pair's methylation position to its gene's transcription start site "
+        "and comparing that against the label."
+    )
+    interpretation = (
+        "The three 5-prime regions have boundaries fixed relative to the transcription "
+        "start site and are therefore checkable directly: pairs falling outside their "
+        "band indicate a coordinate convention mismatch, a strand handling error, or "
+        "an annotation build that differs from the one used at assignment time. The "
+        "gene body and the two 3-prime regions are bounded by the gene end rather than "
+        "the start, so their distance from the start site varies with gene length and "
+        "no band check is applied to them; their distributions are shown for "
+        "inspection only. This module measures distances and reads the stored region "
+        "labels, and it does not re-derive them - region assignment has exactly one "
+        "implementation, and a second one here would be able to agree with a shared "
+        "error rather than detect it. A clean result here confirms the labels are "
+        "placed consistently with the coordinates; it does not confirm that the "
+        "annotation itself is the right one."
+    )
+
+    missing = []
+    if df is None or 'mt_id' not in df.columns or 'gt_id' not in df.columns or 'region' not in df.columns:
+        missing.append('--perm-output')
+    if gene_annot is None:
+        missing.append('--gene-annotation')
+    if meth_annot is None:
+        missing.append('--meth-annotation')
+
+    if missing:
+        msg = get_missing_inputs_msg(*missing)
+        return QCModule(
+            anchor="tss-distance-by-region", title="TSS Distance by Region", status="INFO",
+            purpose=purpose, interpretation=msg
+        )
+
+    import sys
+    import assignRegionToEcpg_parquet as A
+    import numpy as np
+
+    mod = sys.modules[__name__]
+    DISTANCE_SAMPLE_N = getattr(mod, 'DISTANCE_SAMPLE_N', 2_000_000)
+
+    PROMOTER_DOWNSTREAM_DISTANCE = getattr(A, 'PROMOTER_DOWNSTREAM_DISTANCE', 2500)
+    CIS_UPSTREAM_DISTANCE = getattr(A, 'CIS_UPSTREAM_DISTANCE', 50000)
+    DISTAL_OFFSET = getattr(A, 'DISTAL_OFFSET', 50000)
+
+    sampled_df = df
+    if len(df) > DISTANCE_SAMPLE_N:
+        sampled_df = df.sample(n=DISTANCE_SAMPLE_N, random_state=42)
+
+    distances = []
+    regions = []
+
+    for row in sampled_df.itertuples(index=False):
+        gt = row.gt_id
+        mt = row.mt_id
+        r = row.region
+
+        if r == 'TRANS':
+            continue
+
+        g_info = gene_annot.get(gt)
+        m_info = meth_annot.get(mt)
+
+        if not g_info or not m_info:
+            continue
+
+        if g_info['chrom'] != m_info['chrom']:
+            continue
+
+        strand = g_info['strand']
+        tss = g_info['chromStart'] if strand == '+' else g_info['chromEnd']
+        sign = 1 if strand == '+' else -1
+        mt_start = m_info['chromStart']
+
+        d = (mt_start - tss) * sign
+        distances.append(d)
+        regions.append(r)
+
+    d_df = pd.DataFrame({'d': distances, 'region': regions})
+
+    cis_regions = [r for r in CANONICAL_REGIONS if r != 'TRANS']
+
+    table_rows = []
+    any_warn = False
+    region_d_arrays = []
+
+    for r in cis_regions:
+        r_df = d_df[d_df['region'] == r]
+        d_vals = r_df['d']
+        count = len(d_vals)
+
+        if count == 0:
+            table_rows.append([r, "0", "N/A", "N/A", "N/A", "N/A"])
+            region_d_arrays.append([])
+            continue
+
+        median_d = d_vals.median()
+        p5 = d_vals.quantile(0.05)
+        p95 = d_vals.quantile(0.95)
+
+        region_d_arrays.append(d_vals.values)
+
+        out_of_band = 0
+        is_checkable = False
+        if r == 'PROMOTER':
+            is_checkable = True
+            out_of_band = (d_vals.abs() > PROMOTER_DOWNSTREAM_DISTANCE).sum()
+        elif r == 'CIS5':
+            is_checkable = True
+            out_of_band = ((d_vals < -CIS_UPSTREAM_DISTANCE) | (d_vals >= -PROMOTER_DOWNSTREAM_DISTANCE)).sum()
+        elif r == 'DISTAL5':
+            is_checkable = True
+            out_of_band = (d_vals >= -DISTAL_OFFSET).sum()
+
+        if is_checkable:
+            pct_out = (out_of_band / count) * 100
+            band_str = f"{out_of_band:,} ({pct_out:.2f}%)"
+            if pct_out > 1.0:
+                any_warn = True
+        else:
+            band_str = "—"
+
+        table_rows.append([
+            r, f"{count:,}", f"{median_d:.0f}", f"{p5:.0f}", f"{p95:.0f}", band_str
+        ])
+
+    status = 'WARN' if any_warn else 'PASS'
+
+    fig, ax = plt.subplots(figsize=(10, 6))
+    valid_data = [arr for arr in region_d_arrays if len(arr) > 0]
+    valid_labels = [r for r, arr in zip(cis_regions, region_d_arrays) if len(arr) > 0]
+
+    if valid_data:
+        ax.violinplot(valid_data, showmedians=True)
+        ax.set_xticks(np.arange(1, len(valid_labels) + 1))
+        ax.set_xticklabels(valid_labels)
+
+        ax.axhline(PROMOTER_DOWNSTREAM_DISTANCE, color='g', linestyle=':', alpha=0.5)
+        ax.axhline(-PROMOTER_DOWNSTREAM_DISTANCE, color='g', linestyle=':', alpha=0.5)
+        ax.axhline(-DISTAL_OFFSET, color='r', linestyle=':', alpha=0.5)
+        ax.axhline(DISTAL_OFFSET, color='r', linestyle=':', alpha=0.5)
+
+        ax.set_ylim(-200_000, 200_000)
+        ax.set_ylabel("Distance from TSS (bp)")
+
+    return QCModule(
+        anchor="tss-distance-by-region",
+        title="TSS Distance by Region",
+        status=status,
+        purpose=purpose,
+        interpretation=interpretation,
+        table_html=render_table(
+            ["Region", "Pairs Sampled", "Median d", "5th pctl", "95th pctl", "Out of Band"],
+            table_rows
+        ),
+        figure_b64=fig_to_base64(fig),
+        figure_alt="Violin plots of distance to TSS per region."
+    )
+
+
+if __name__ == '__main__':
     try:
         main()
     except Exception as e:
-        logger.error(f"Unhandled exception in permute_qc_report: {e}")
+        logger.error(f'Unhandled exception in permute_qc_report: {e}')
         sys.exit(1)


### PR DESCRIPTION
## Structural verification (synthetic fixture — NOT cohort data)
Using synthetic report JSON, parquet files, and G/M annotation files in temporary testing blocks simulating JSON-only run, parquet run, and full run:

- All twelve sections present, in registry order, permutation-resolution before tail-behaviour.
- **JSON-only run:** All 4 new modules show `INFO`. Message lists `Not evaluated: --perm-output, --gene-annotation and --meth-annotation not supplied.` for TSS Distance, `Not evaluated: --perm-output not supplied.` for Analytic P Precision and Cis Pair Density, and `Not evaluated: --gene-annotation not supplied.` for Gene Span Distribution.
- **Parquet run:** `INFO` modules decrease correctly; Gene Span Distribution and TSS Distance remain `INFO` due to lacking annotations.
- **Full run:** No `INFO` panels for missing dependencies in new modules.
- The report generates and is self-contained in all three runs (no external references/scripts, no crashes).
- Tests explicitly exercise both PASS and WARN paths for each new module:
  - Gap and precision ratios test WARN/PASS.
  - Per-gene median values < 1 or >= 1.
  - Sub/Supra PROMOTER distance bounds violation test WARN/PASS.
  - Span thresholding tests WARN/PASS.
  - Tested negative strand window logic directly (positive strand uses chromStart, negative strand uses chromEnd, computed appropriately).

## Real-artifact verification: PENDING — requires klabdev
Because the generated Parquet and Annotation files rely on GPU runs on `klabdev` and aren't shareable due to 17.5M rows of data, reporting of empirical values from real outputs remains **pending**. Real rendering should be executed post-merge.

## Schema conformance independent oracle test update
Proved it still detects wrong key:

```
    def test_schema_conformance_independent_oracle():
...
        # INJECT A FAKE KEY
        requested_keys.add("fake_injected_key_for_test")

        for key in requested_keys:
            if "assignRegionToEcpg_parquet" in key or "tools.assignRegionToEcpg_parquet" in key:
                continue
>           assert key in known_valid_keys, f"Reader asks for missing/wrong key: {key}"
E           AssertionError: Reader asks for missing/wrong key: fake_injected_key_for_test
```

---
*PR created automatically by Jules for task [13057299383863076593](https://jules.google.com/task/13057299383863076593) started by @kordk*