### PR TITLE
Refactor benchmark_kennedy.py for C1

### DIFF
--- a/tests/test_benchmark_kennedy.py
+++ b/tests/test_benchmark_kennedy.py
@@ -1,0 +1,246 @@
+import pytest
+import pandas as pd
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import os
+import sys
+
+from tools.benchmark_kennedy import (
+    resolve_kennedy_columns,
+    resolve_tecpg_pvalue_column,
+    load_kennedy,
+    load_catalog,
+    compute_eligibility,
+    compute_overlap_rates,
+    export_pair_lists,
+    main
+)
+
+# O1. resolver_consistency
+def test_resolver_consistency():
+    columns = ['CpG.probe', 'exp.Probe', 'p.val', 'annot.gene']
+    resolved = resolve_kennedy_columns(columns)
+    # The requirement: The column used for the gene diagnostic and the merge key read from the SAME returned dict.
+    assert resolved['probe'] == 'exp.Probe'
+    assert resolved['gene'] == 'annot.gene'
+
+# O2. column_order_independence
+def test_column_order_independence():
+    gtp_cols = ['exp.Probe', 'CpG.probe', 'exp.probe.chrm', 'exp.probe.start', 'exp.probe.stop', 'exp.probe.strand', 'annot.gene', 'in_dist', 'distance', 'status', 'other_gene', 'distance.other.gene', 'p.val', 'T.stat', 'beta', 'beta.sd']
+    mesa_cols = ['CpG.probe', 'exp.Probe'] + gtp_cols[2:]
+
+    res_gtp = resolve_kennedy_columns(gtp_cols)
+    res_mesa = resolve_kennedy_columns(mesa_cols)
+    assert res_gtp == res_mesa
+
+# O3. hard_fail_missing_required
+def test_hard_fail_missing_required():
+    columns = ['CpG.probe', 'p.val', 'other_col']
+    with pytest.raises(ValueError) as excinfo:
+        resolve_kennedy_columns(columns)
+    msg = str(excinfo.value)
+    assert 'exp.Probe' in msg
+    assert 'CpG.probe' in msg
+    assert 'other_col' in msg
+
+# O4. hard_fail_missing_precise
+def test_hard_fail_missing_precise():
+    columns = ['mt_id', 'gt_id', 'mt_p']
+    with pytest.raises(ValueError) as excinfo:
+        resolve_tecpg_pvalue_column(columns)
+    msg = str(excinfo.value)
+    assert 'precise_mt_p' in msg
+    assert 'mt_p' in msg
+
+# O5. na_preservation
+def test_na_preservation(tmp_path):
+    df = pd.DataFrame({
+        'CpG.probe': ['cg1', 'cg2'],
+        'exp.Probe': ['pr1', 'pr2'],
+        'status': ['TRANS', 'IN'],
+        'distance': [pd.NA, 100],
+        'in_dist': [False, pd.NA],
+        'p.val': [0.01, 0.05]
+    })
+    path = tmp_path / "test.tsv"
+    df.to_csv(path, sep='\t', index=False)
+
+    loaded = load_kennedy(path, sep='\t')
+    assert len(loaded) == 2
+
+# O6. eligibility_classification
+def test_eligibility_classification(tmp_path):
+    catalog_df = pd.DataFrame({
+        'mt_id': ['cg1', 'cg3', 'cg5'],
+        'gt_id': ['pr1', 'pr3', 'pr5'],
+        'precise_mt_p': [1e-6, 1e-2, 1e-6],
+        'mt_est': [1.0, 1.0, 1.0],
+        'mt_t': [1.0, 1.0, 1.0],
+        'region': ['cis', 'trans', 'cis'],
+        'fdr_est': [0.01, 0.5, 0.01]
+    })
+    kennedy_df = pd.DataFrame({
+        'CpG.probe': ['cg1', 'cg2', 'cg3', 'cg1'],
+        'exp.Probe': ['pr1', 'pr1', 'pr4', 'pr3'],
+        'p.val': [1e-6, 1e-6, 1e-6, 1e-6],
+        'status': ['IN', 'IN', 'IN', 'IN'],
+        'distance': [10, 10, 10, 10]
+    })
+
+    cols = resolve_kennedy_columns(kennedy_df.columns)
+    kennedy_df = compute_eligibility(catalog_df, kennedy_df, cols)
+
+    diag_results = compute_overlap_rates(catalog_df, kennedy_df, cols, 1e-5, 1e-5, 'precise_mt_p')
+
+    export_pair_lists(tmp_path, catalog_df, kennedy_df, cols, diag_results, 'precise_mt_p')
+
+    df_k_only = pd.read_csv(tmp_path / "pairs_kennedy_only.tsv", sep='\t')
+
+    assert len(df_k_only) == 3
+    # Check reasons
+    reasons = df_k_only.set_index(['mt_id', 'gt_id'])['non_overlap_reason'].to_dict()
+    assert reasons[('cg2', 'pr1')] == 'ineligible_cpg'
+    assert reasons[('cg3', 'pr4')] == 'ineligible_probe'
+    assert reasons[('cg1', 'pr3')] == 'tested_and_missed'
+
+# O7. recovery_confirmation_arithmetic
+def test_recovery_confirmation_arithmetic(tmp_path):
+    catalog_df = pd.DataFrame({
+        'mt_id': ['c1', 'c2', 'c3', 'c4'],
+        'gt_id': ['p1', 'p2', 'p3', 'p4'],
+        'precise_mt_p': [1e-10, 1e-10, 1e-4, 1e-4],
+        'mt_est': [1.0]*4, 'mt_t': [1.0]*4, 'region': ['cis']*4, 'fdr_est': [0.1]*4
+    })
+    kennedy_df = pd.DataFrame({
+        'CpG.probe': ['c1', 'c3', 'cx', 'c2'],
+        'exp.Probe': ['p1', 'p3', 'px', 'p2'],
+        'p.val': [1e-10, 1e-10, 1e-10, 1e-4],
+        'status': ['IN']*4, 'distance': [10]*4
+    })
+    cols = resolve_kennedy_columns(kennedy_df.columns)
+    kennedy_df = compute_eligibility(catalog_df, kennedy_df, cols)
+    res = compute_overlap_rates(catalog_df, kennedy_df, cols, 1e-5, 1e-5, 'precise_mt_p')
+
+    assert res['recovery'] == 0.5
+    assert res['confirmation_raw'] == 0.5
+    assert res['confirmation_kennedy_testable'] == 0.5
+
+    # Check caveats in summary
+    from tools.benchmark_kennedy import build_summary_text
+    import argparse
+    args = argparse.Namespace(tecpg='cat.parquet', kennedy='ken.tsv', kennedy_thresh=1e-5, tecpg_thresh=1e-5, upset=False)
+    grid = {(1e-5, 1e-5): res}
+    summary = build_summary_text(args, 2, 0, 0, 0, 'beta', 0, 0, 0, 'T.stat', grid, res, [1e-5], cols, kennedy_df)
+    assert "Confirmation denominators are LOWER BOUNDS (except kennedy_testable)" in summary
+    assert "The Kennedy file is not a full universe, so we cannot know how many of our" in summary
+
+# O8. threshold_dtype
+def test_threshold_dtype():
+    # np.float32(1e-5) is 9.999999747378752e-06
+    # python float(1e-5) is 1.000000000000000e-05
+    catalog_df = pd.DataFrame({
+        'mt_id': ['cg1'],
+        'gt_id': ['pr1'],
+        'precise_mt_p': [9.99e-6]
+    })
+    kennedy_df = pd.DataFrame({
+        'CpG.probe': ['cg1'],
+        'exp.Probe': ['pr1'],
+        'p.val': [9.99e-6]
+    })
+    cols = resolve_kennedy_columns(kennedy_df.columns)
+    kennedy_df = compute_eligibility(catalog_df, kennedy_df, cols)
+
+    res = compute_overlap_rates(catalog_df, kennedy_df, cols, float(1e-5), float(1e-5), 'precise_mt_p')
+    assert len(res['T_tt']) == 1 # float(1e-5) > 9.99e-6
+    assert len(res['K_tk']) == 1
+
+# O9. export_schema
+def test_export_schema(tmp_path):
+    catalog_df = pd.DataFrame({
+        'mt_id': ['c1', 'c2'],
+        'gt_id': ['p1', 'p2'],
+        'precise_mt_p': [1e-10, 1e-10],
+        'mt_est': [1.0, 1.0], 'mt_t': [1.0, 1.0], 'region': ['cis', 'trans'], 'fdr_est': [0.1, 0.1]
+    })
+    kennedy_df = pd.DataFrame({
+        'CpG.probe': ['c1', 'c3'],
+        'exp.Probe': ['p1', 'p3'],
+        'p.val': [1e-10, 1e-10],
+        'status': ['IN', 'IN'],
+        'distance': [10, 10]
+    })
+
+    cols = resolve_kennedy_columns(kennedy_df.columns)
+    kennedy_df = compute_eligibility(catalog_df, kennedy_df, cols)
+    res = compute_overlap_rates(catalog_df, kennedy_df, cols, 1e-5, 1e-5, 'precise_mt_p')
+
+    export_pair_lists(tmp_path, catalog_df, kennedy_df, cols, res, 'precise_mt_p')
+
+    conc = pd.read_csv(tmp_path / 'pairs_concordant.tsv', sep='\t')
+    t_only = pd.read_csv(tmp_path / 'pairs_tecpg_only.tsv', sep='\t')
+    k_only = pd.read_csv(tmp_path / 'pairs_kennedy_only.tsv', sep='\t')
+
+    expected_cols = {'mt_id', 'gt_id', 'precise_mt_p', 'mt_est', 'mt_t', 'region', 'fdr_est', 'p.val', 'status', 'distance', 'non_overlap_reason'}
+    expected_cols = expected_cols | {'eligible_cpg', 'eligible_probe'}
+    assert set(conc.columns) == expected_cols
+    assert set(t_only.columns) == expected_cols
+    assert set(k_only.columns) == expected_cols
+
+    assert len(conc) + len(t_only) == len(res['T_tt'])
+    assert len(conc) + len(k_only) == len(res['K_tk'])
+
+# O10. threshold_arg_precedence
+def test_threshold_arg_precedence(monkeypatch, caplog):
+    import logging
+    monkeypatch.setattr(sys, 'argv', ['benchmark_kennedy.py', 'cat.parquet', 'ken.tsv', '--p-thresh', '1e-6'])
+    with caplog.at_level(logging.WARNING):
+        try:
+            main()
+        except FileNotFoundError:
+            pass
+    assert "DeprecationWarning: --p-thresh is deprecated" in caplog.text
+
+    monkeypatch.setattr(sys, 'argv', ['benchmark_kennedy.py', 'cat.parquet', 'ken.tsv', '--p-thresh', '1e-6', '--kennedy-thresh', '1e-5'])
+    with pytest.raises(ValueError, match="Cannot provide both"):
+        main()
+
+# R1. Kennedy real data parse
+@pytest.mark.skipif(not os.environ.get("TECPG_KENNEDY_GTP"), reason="Requires real Kennedy data")
+def test_real_kennedy():
+    df = pd.read_csv(os.environ.get("TECPG_KENNEDY_GTP"), sep='\t')
+    assert len(df) == 67606
+    assert len(df[['exp.Probe', 'CpG.probe']].drop_duplicates()) == 67606
+    assert df.columns[0] == "exp.Probe"
+    sig = df[df['p.val'] < 1e-11]
+    assert len(sig) == 2466
+    assert len(sig[sig['status'] == 'TRANS']) == 958
+
+# R2. Catalog real data parse
+@pytest.mark.skipif(not os.environ.get("TECPG_CATALOG_GTP"), reason="Requires real catalog data")
+def test_real_catalog():
+    df = pq.read_table(os.environ.get("TECPG_CATALOG_GTP"), columns=['precise_mt_p']).to_pandas()
+    assert len(df) == 17142039
+    assert 'precise_mt_p' in df.columns
+    assert df['precise_mt_p'].max() < 1.2e-3
+
+# Test that confirmation_testable is upward biased on a fixture where it differs
+def test_confirmation_testable_upward_biased():
+    catalog_df = pd.DataFrame({
+        'mt_id': ['c1', 'c2'],
+        'gt_id': ['p1', 'p2'],
+        'precise_mt_p': [1e-10, 1e-10]
+    })
+    kennedy_df = pd.DataFrame({
+        'CpG.probe': ['c1'],
+        'exp.Probe': ['p1'],
+        'p.val': [1e-10]
+    })
+    cols = resolve_kennedy_columns(kennedy_df.columns)
+    kennedy_df = compute_eligibility(catalog_df, kennedy_df, cols)
+    res = compute_overlap_rates(catalog_df, kennedy_df, cols, 1e-5, 1e-5, 'precise_mt_p')
+
+    assert res['confirmation_raw'] == 0.5 # 1 / 2
+    assert res['confirmation_kennedy_testable'] == 1.0 # 1 / 1
+    assert res['confirmation_raw'] <= res['confirmation_kennedy_testable']

--- a/tools/benchmark_kennedy.py
+++ b/tools/benchmark_kennedy.py
@@ -1,79 +1,385 @@
+#!/usr/bin/env python3
 import argparse
 import os
 import sys
-import numpy as np
+import logging
 import pandas as pd
-import matplotlib.pyplot as plt
-import scipy.stats as stats
 import pyarrow.parquet as pq
+import matplotlib.pyplot as plt
 from matplotlib_venn import venn2
 import upsetplot
-import logging
+from scipy import stats
 
-logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s: %(message)s")
+
+def resolve_kennedy_columns(columns):
+    required = {'cpg': 'CpG.probe', 'probe': 'exp.Probe', 'pval': 'p.val'}
+    missing = [name for name in required.values() if name not in columns]
+    if missing:
+        raise ValueError(f"Missing required Kennedy columns: {missing}. Observed columns: {list(columns)}")
+
+    resolved = {
+        'cpg': 'CpG.probe',
+        'probe': 'exp.Probe',
+        'pval': 'p.val',
+        'status': 'status' if 'status' in columns else None,
+        'distance': 'distance' if 'distance' in columns else None,
+        'in_dist': 'in_dist' if 'in_dist' in columns else None,
+        'tstat': 'T.stat' if 'T.stat' in columns else None,
+        'beta': 'beta' if 'beta' in columns else None,
+        'beta_sd': 'beta.sd' if 'beta.sd' in columns else None,
+        'gene': 'annot.gene' if 'annot.gene' in columns else None,
+        'probe_chrom': 'exp.probe.chrm' if 'exp.probe.chrm' in columns else None,
+        'probe_start': 'exp.probe.start' if 'exp.probe.start' in columns else None,
+        'probe_stop': 'exp.probe.stop' if 'exp.probe.stop' in columns else None,
+        'probe_strand': 'exp.probe.strand' if 'exp.probe.strand' in columns else None,
+        'other_gene': 'other_gene' if 'other_gene' in columns else None,
+        'other_gene_distance': 'distance.other.gene' if 'distance.other.gene' in columns else None
+    }
+    return resolved
+
+
+def resolve_tecpg_pvalue_column(columns):
+    if 'precise_mt_p' not in columns:
+        raise ValueError(f"Missing precise_mt_p in tecpg catalog. Observed columns: {list(columns)}")
+    return 'precise_mt_p'
+
+
+
+def load_kennedy(path, sep):
+    df = pd.read_csv(path, sep=sep)
+    # We must dropna on key columns, but we don't know the resolved column names here yet!
+    # Wait, the old code didn't dropna on load_kennedy. It did it during merge or set operations.
+    return df
+
+
+def load_catalog(path, columns_to_read=None):
+    schema = pq.ParquetFile(path).schema_arrow.names
+    desired_cols = [
+        'mt_id', 'gt_id', 'precise_mt_p', 'mt_est', 'mt_t',
+        'region', 'fdr_est', 'mt_chrom', 'gt_chrom'
+    ]
+    if columns_to_read:
+        desired_cols.append(columns_to_read)
+
+    cols_to_load = [c for c in set(desired_cols) if c in schema]
+    df = pq.read_table(path, columns=cols_to_load).to_pandas()
+    if df.index.names != [None]:
+        df = df.reset_index()
+    return df
+
+
+def compute_eligibility(catalog_df, kennedy_df, cols):
+    catalog_cpgs = set(catalog_df['mt_id'].dropna())
+    catalog_probes = set(catalog_df['gt_id'].dropna())
+
+    df = kennedy_df.copy()
+    df['eligible_cpg'] = df[cols['cpg']].isin(catalog_cpgs)
+    df['eligible_probe'] = df[cols['probe']].isin(catalog_probes)
+    df['eligible'] = df['eligible_cpg'] & df['eligible_probe']
+
+    return df
+
+
+def compute_overlap_rates(catalog_df, kennedy_df, cols, kennedy_thresh, tecpg_thresh, tecpg_p_col):
+    K_tk_mask = kennedy_df[cols['pval']] < kennedy_thresh
+    K_tk_df = kennedy_df[K_tk_mask]
+    K_tk = set(zip(K_tk_df[cols['cpg']], K_tk_df[cols['probe']]))
+
+    K_tk_E_df = kennedy_df[K_tk_mask & kennedy_df['eligible']]
+    K_tk_E = set(zip(K_tk_E_df[cols['cpg']], K_tk_E_df[cols['probe']]))
+
+    T_tt_df = catalog_df[catalog_df[tecpg_p_col] < tecpg_thresh]
+    T_tt = set(zip(T_tt_df['mt_id'], T_tt_df['gt_id']))
+
+    recovery_num = len(K_tk_E.intersection(T_tt))
+    recovery_denom = len(K_tk_E)
+    recovery = recovery_num / recovery_denom if recovery_denom > 0 else 0.0
+
+    confirmation_num = len(T_tt.intersection(K_tk))
+    confirmation_denom = len(T_tt)
+    confirmation_raw = confirmation_num / confirmation_denom if confirmation_denom > 0 else 0.0
+
+    kennedy_cpgs = set(kennedy_df[cols['cpg']].dropna())
+    kennedy_probes = set(kennedy_df[cols['probe']].dropna())
+
+    T_tt_kennedy_testable = {(c, p) for c, p in T_tt if c in kennedy_cpgs and p in kennedy_probes}
+    confirmation_testable_num = len(T_tt_kennedy_testable.intersection(K_tk))
+    confirmation_testable_denom = len(T_tt_kennedy_testable)
+    testable_val = confirmation_testable_num / confirmation_testable_denom if confirmation_testable_denom > 0 else 0.0
+    confirmation_kennedy_testable = testable_val
+
+    union = K_tk.union(T_tt)
+    jaccard = len(T_tt.intersection(K_tk)) / len(union) if len(union) > 0 else 0.0
+
+    return {
+        'recovery': recovery,
+        'confirmation_raw': confirmation_raw,
+        'confirmation_kennedy_testable': confirmation_kennedy_testable,
+        'jaccard': jaccard,
+        'T_tt': T_tt,
+        'K_tk': K_tk,
+        'K_tk_E': K_tk_E,
+        'K_tk_E_df': K_tk_E_df,
+        'T_tt_df': T_tt_df,
+        'kennedy_cpgs': kennedy_cpgs,
+        'kennedy_probes': kennedy_probes
+    }
+
+
+def export_pair_lists(outdir, catalog_df, kennedy_df, cols, diag_results, tecpg_p_col):
+    T_tt = diag_results['T_tt']
+    K_tk = diag_results['K_tk']
+    kennedy_cpgs = diag_results['kennedy_cpgs']
+    kennedy_probes = diag_results['kennedy_probes']
+
+    overlap = T_tt.intersection(K_tk)
+    tecpg_only = T_tt - K_tk
+    kennedy_only = K_tk - T_tt
+
+    conc_mt, conc_gt = zip(*overlap) if overlap else ([], [])
+    df_conc = pd.DataFrame({'mt_id': conc_mt, 'gt_id': conc_gt})
+
+    t_only_mt, t_only_gt = zip(*tecpg_only) if tecpg_only else ([], [])
+    df_t_only = pd.DataFrame({'mt_id': t_only_mt, 'gt_id': t_only_gt})
+
+    k_only_mt, k_only_gt = zip(*kennedy_only) if kennedy_only else ([], [])
+    df_k_only = pd.DataFrame({'mt_id': k_only_mt, 'gt_id': k_only_gt})
+
+    def annotate_reasons(df, reason='concordant'):
+        if len(df) == 0:
+            df['non_overlap_reason'] = []
+            df['eligible_cpg'] = []
+            df['eligible_probe'] = []
+            return df
+
+        cpg_in_k = df['mt_id'].isin(kennedy_cpgs)
+        probe_in_k = df['gt_id'].isin(kennedy_probes)
+        df['eligible_cpg'] = cpg_in_k
+        df['eligible_probe'] = probe_in_k
+
+        if reason == 'tecpg_only':
+            reasons = []
+            for c, p in zip(cpg_in_k, probe_in_k):
+                if c and p:
+                    reasons.append('kennedy_tested_and_missed')
+                else:
+                    reasons.append('kennedy_universe_unknown')
+            df['non_overlap_reason'] = reasons
+        else:
+            df['non_overlap_reason'] = reason
+
+        return df
+
+    df_conc = annotate_reasons(df_conc, 'concordant')
+    df_t_only = annotate_reasons(df_t_only, 'tecpg_only')
+
+    if len(df_k_only) > 0:
+        k_merge = pd.merge(
+            df_k_only, kennedy_df, left_on=['mt_id', 'gt_id'],
+            right_on=[cols['cpg'], cols['probe']], how='left'
+        )
+        catalog_pairs = set(zip(catalog_df['mt_id'], catalog_df['gt_id']))
+        in_catalog = [p in catalog_pairs for p in zip(k_merge['mt_id'], k_merge['gt_id'])]
+
+        reasons = []
+        for i, row in k_merge.iterrows():
+            if in_catalog[i]:
+                reasons.append('tested_and_missed')
+            elif not row['eligible_cpg']:
+                reasons.append('ineligible_cpg')
+            elif not row['eligible_probe']:
+                reasons.append('ineligible_probe')
+            else:
+                reasons.append('tested_and_missed')
+        k_merge['non_overlap_reason'] = reasons
+        df_k_only = k_merge[['mt_id', 'gt_id', 'non_overlap_reason', 'eligible_cpg', 'eligible_probe']]
+    else:
+        df_k_only['non_overlap_reason'] = []
+        df_k_only['eligible_cpg'] = []
+        df_k_only['eligible_probe'] = []
+
+    tecpg_cols = ['mt_id', 'gt_id', tecpg_p_col, 'mt_est', 'mt_t', 'region', 'fdr_est']
+    tecpg_cols_to_merge = [c for c in tecpg_cols if c in catalog_df.columns]
+
+    k_cols_base = [
+        cols['pval'], cols['tstat'], cols['beta'],
+        cols['beta_sd'], cols['status'], cols['distance']
+    ]
+    k_cols_valid = [c for c in k_cols_base if c and c in kennedy_df.columns]
+
+    def merge_all(df):
+        if len(df) == 0:
+            for c in tecpg_cols_to_merge[2:] + k_cols_valid:
+                df[c] = []
+            return df
+        df = pd.merge(df, catalog_df[tecpg_cols_to_merge], on=['mt_id', 'gt_id'], how='left')
+        df = pd.merge(
+            df, kennedy_df[[cols['cpg'], cols['probe']] + k_cols_valid],
+            left_on=['mt_id', 'gt_id'], right_on=[cols['cpg'], cols['probe']], how='left'
+        )
+        if cols['cpg'] in df.columns and cols['cpg'] != 'mt_id':
+            df = df.drop(columns=[cols['cpg']])
+        if cols['probe'] in df.columns and cols['probe'] != 'gt_id':
+            df = df.drop(columns=[cols['probe']])
+        return df
+
+    df_conc = merge_all(df_conc)
+    df_t_only = merge_all(df_t_only)
+    df_k_only = merge_all(df_k_only)
+
+    df_conc.to_csv(os.path.join(outdir, 'pairs_concordant.tsv'), sep='\t', index=False)
+    df_t_only.to_csv(os.path.join(outdir, 'pairs_tecpg_only.tsv'), sep='\t', index=False)
+    df_k_only.to_csv(os.path.join(outdir, 'pairs_kennedy_only.tsv'), sep='\t', index=False)
+
+
+def build_summary_text(
+    args, num_merged, pearson_r_beta, spearman_r_beta, r2_beta, beta_col,
+    pearson_r_t, spearman_r_t, r2_t, tstat_col,
+    grid_results, diag_results, thresholds, cols, kennedy_df
+):
+
+    summary = f"""Benchmark Summary
+=================
+Input tecpg file: {args.tecpg}
+Input Kennedy file: {args.kennedy}
+Kennedy p-value threshold: {args.kennedy_thresh}
+tecpg p-value threshold: {args.tecpg_thresh}
+
+Mapping & Merging
+-----------------
+Overlapping Pairs Mapped: {num_merged}
+"""
+    if 'status' in cols and cols['status']:
+        statuses = kennedy_df[cols['status']].unique()
+        summary += "\nEligibility by Status:\n"
+        for s in statuses:
+            sub = kennedy_df[kennedy_df[cols['status']] == s]
+            el = sub['eligible'].sum()
+            summary += f"  {s}: {el} / {len(sub)} eligible\n"
+    else:
+        summary += f"\nOverall Eligibility: {kennedy_df['eligible'].sum()} / {len(kennedy_df)}\n"
+
+    summary += f"""
+Comparison A: Statistical Concordance
+-------------------------------------
+Effect Size (mt_est vs {beta_col}):
+  Pearson r:  {pearson_r_beta:.4f}
+  Spearman rho: {spearman_r_beta:.4f}
+  R^2:        {r2_beta:.4f}
+
+Test Statistic (mt_t vs {tstat_col}):
+  Pearson r:  {pearson_r_t:.4f}
+  Spearman rho: {spearman_r_t:.4f}
+  R^2:        {r2_t:.4f}
+
+Comparison B: Hit Overlap (Directional Rates)
+---------------------------------------------
+Note: Confirmation denominators are LOWER BOUNDS (except kennedy_testable).
+The Kennedy file is not a full universe, so we cannot know how many of our
+hits they actually tested and found insignificant vs never tested.
+
+--- Recovery Matrix (tecpg_thresh \\ kennedy_thresh) ---
+"""
+    header = "          " + "".join([f"{t:10.1e}" for t in thresholds])
+    summary += header + "\n"
+    for tt in thresholds:
+        row_str = f"{tt:10.1e}"
+        for tk in thresholds:
+            res = grid_results[(tk, tt)]
+            row_str += f"{res['recovery']:10.3f}"
+        summary += row_str + "\n"
+
+    summary += "\n--- Confirmation (Raw Lower Bound) Matrix ---\n"
+    summary += header + "\n"
+    for tt in thresholds:
+        row_str = f"{tt:10.1e}"
+        for tk in thresholds:
+            res = grid_results[(tk, tt)]
+            row_str += f"{res['confirmation_raw']:10.3f}"
+        summary += row_str + "\n"
+
+    summary += f"""
+--- Diagonal (Like-for-like at {args.tecpg_thresh}) ---
+  Recovery:                      {diag_results['recovery']:.4f}
+  Confirmation (Raw Lower Bound): {diag_results['confirmation_raw']:.4f}
+  Confirmation (Kennedy Testable):{diag_results['confirmation_kennedy_testable']:.4f}
+  Jaccard Index:                 {diag_results['jaccard']:.4f}
+
+Outputs
+-------
+Summary saved to: benchmark_summary.txt
+Plots saved to: concordance_scatter.png, overlap_venn_diagonal.png
+Pair lists saved to: pairs_*.tsv
+"""
+    if args.upset:
+        summary += "UpSet plot saved to: overlap_upset_diagonal.png\n"
+
+    return summary
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Benchmark tecpg output against Kennedy 2018 baseline.")
-    parser.add_argument('-t', '--tecpg', required=True, help="Path to tecpg Parquet output file")
-    parser.add_argument('-k', '--kennedy', required=True, help="Path to Kennedy 2018 txt file")
-    parser.add_argument('--p-thresh', type=float, default=1e-6, help="P-value threshold for Kennedy hits (default: 1e-6)")
-    parser.add_argument('-o', '--outdir', default='.', help="Directory to save output files (default: current directory)")
+    parser = argparse.ArgumentParser(description="Benchmark tecpg output against Kennedy eQTL summary statistics.")
+    parser.add_argument('tecpg', help="Path to tecpg output parquet file")
+    parser.add_argument('kennedy', help="Path to Kennedy supplementary CSV/TSV file")
+    parser.add_argument('--outdir', default='.', help="Directory to save output plots and summary")
+
+    parser.add_argument('--tecpg-thresh', type=float, default=1e-5, help="p-value threshold for tecpg hits")
+    parser.add_argument('--kennedy-thresh', type=float, default=1e-5, help="p-value threshold for Kennedy hits")
+    parser.add_argument('--p-thresh', type=float, default=None, help="Deprecated. Use --kennedy-thresh")
+
+    parser.add_argument('--kennedy-sep', default='\t', help="Separator for Kennedy file")
+    parser.add_argument('--tecpg-p-col', default=None, help="Override for tecpg precise_mt_p column")
+    parser.add_argument('--upset', action='store_true', help="Generate UpSet plot")
 
     args = parser.parse_args()
 
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+    if args.p_thresh is not None:
+        if '--p-thresh' in sys.argv and '--kennedy-thresh' in sys.argv:
+            raise ValueError("Cannot provide both --p-thresh and --kennedy-thresh.")
+        logging.warning("DeprecationWarning: --p-thresh is deprecated. Please use --kennedy-thresh instead.")
+        args.kennedy_thresh = float(args.p_thresh)
+
+    args.kennedy_thresh = float(args.kennedy_thresh)
+    args.tecpg_thresh = float(args.tecpg_thresh)
+
     os.makedirs(args.outdir, exist_ok=True)
 
-    logging.info(f"Loading tecpg data from {args.tecpg}...")
-    try:
-        df_tecpg = pq.read_table(args.tecpg).to_pandas()
-        if df_tecpg.index.names != [None]:
-            df_tecpg = df_tecpg.reset_index()
-        logging.info(f"tecpg data loaded. Shape: {df_tecpg.shape}")
-        logging.info(f"tecpg columns: {list(df_tecpg.columns)}")
-        logging.info(f"tecpg distinct genes (gt_id): {df_tecpg.get('gt_id', pd.Series()).nunique()}")
-        logging.info(f"tecpg distinct CpG loci (mt_id): {df_tecpg.get('mt_id', pd.Series()).nunique()}")
-    except Exception as e:
-        logging.error(f"Failed to read tecpg file: {e}")
-        sys.exit(1)
+    logging.info(f"Loading Kennedy file: {args.kennedy}")
+    df_kennedy = load_kennedy(args.kennedy, args.kennedy_sep)
+    cols = resolve_kennedy_columns(df_kennedy.columns)
 
-    logging.info(f"Loading Kennedy data from {args.kennedy}...")
-    try:
-        # Kennedy format is likely tab or space separated
-        df_kennedy = pd.read_csv(args.kennedy, sep=None, engine='python')
-        logging.info(f"Kennedy data loaded. Shape: {df_kennedy.shape}")
-        logging.info(f"Kennedy columns: {list(df_kennedy.columns)}")
-        # Check potential cpg and gene columns
-        cpg_col_initial = 'CpG.probe' if 'CpG.probe' in df_kennedy.columns else df_kennedy.columns[0]
-        gene_col_initial = 'annot.gene' if 'annot.gene' in df_kennedy.columns else ('exp.Probe' if 'exp.Probe' in df_kennedy.columns else df_kennedy.columns[1])
-        logging.info(f"Kennedy distinct genes ({gene_col_initial}): {df_kennedy.get(gene_col_initial, pd.Series()).nunique()}")
-        logging.info(f"Kennedy distinct CpG loci ({cpg_col_initial}): {df_kennedy.get(cpg_col_initial, pd.Series()).nunique()}")
-    except Exception as e:
-        logging.error(f"Failed to read Kennedy file: {e}")
-        sys.exit(1)
+    cpg_col = cols['cpg']
+    query_col = cols['probe']
 
-    logging.info("Preprocessing and mapping IDs...")
+    df_kennedy = df_kennedy.dropna(subset=[cpg_col, query_col])
 
-    # Standardize column names for merge
-    # Kennedy CpG usually 'CpG.probe', tecpg 'mt_id'
-    cpg_col = 'CpG.probe' if 'CpG.probe' in df_kennedy.columns else df_kennedy.columns[0]
-    query_col = 'exp.Probe' if 'exp.Probe' in df_kennedy.columns else ('annot.gene' if 'annot.gene' in df_kennedy.columns else df_kennedy.columns[1])
+    if cols['gene']:
+        logging.info(f"Using column '{cols['gene']}' for Gene cardinality diagnostic.")
+        genes = len(df_kennedy[cols['gene']].dropna().unique())
+        logging.info(f"Kennedy unique genes: {genes}")
 
-    _kennedy_before = len(df_kennedy)
-    df_kennedy = df_kennedy.dropna(subset=[query_col, cpg_col])
-    logging.info(
-        f"Drop site benchmark_kennedy.dropna_keys[{query_col},{cpg_col}]: dropped "
-        f"Kennedy rows with missing key columns: {_kennedy_before} -> "
-        f"{len(df_kennedy)} ({_kennedy_before - len(df_kennedy)} dropped)"
-    )
+    logging.info(f"Loading tecpg catalog: {args.tecpg}")
+    schema = pq.ParquetFile(args.tecpg).schema_arrow.names
+    tecpg_p_col = args.tecpg_p_col if args.tecpg_p_col else resolve_tecpg_pvalue_column(schema)
 
-    # Log a sample of the key columns before merging
-    if 'mt_id' in df_tecpg.columns and 'gt_id' in df_tecpg.columns:
-        logging.info(f"Sample of tecpg key columns (first 5 rows):\n{df_tecpg[['mt_id', 'gt_id']].head().to_string()}")
+    df_tecpg = load_catalog(args.tecpg, tecpg_p_col)
 
-    if cpg_col in df_kennedy.columns and query_col in df_kennedy.columns:
-        logging.info(f"Sample of Kennedy key columns before merge (first 5 rows):\n{df_kennedy[[cpg_col, query_col]].head().to_string()}")
+    if 'mt_chrom' in df_tecpg.columns and 'gt_chrom' in df_tecpg.columns:
+        mt_chroms = df_tecpg['mt_chrom'].dropna().unique()
+        gt_chroms = df_tecpg['gt_chrom'].dropna().unique()
+        expected_combos = len(mt_chroms) * len(gt_chroms)
+        actual_combos = len(df_tecpg[['mt_chrom', 'gt_chrom']].drop_duplicates())
+        if actual_combos < expected_combos:
+            logging.warning(
+                f"STRUCTURAL WARNING: Catalog does not span all chromosome pairings "
+                f"({actual_combos} observed vs {expected_combos} expected). "
+                f"Eligibility may not factorize; recovery is an upper bound."
+            )
 
-    # Calculate overlaps before merging
+    df_kennedy = compute_eligibility(df_tecpg, df_kennedy, cols)
+
     if 'mt_id' in df_tecpg.columns and cpg_col in df_kennedy.columns:
         loci_overlap = len(set(df_tecpg['mt_id'].dropna()).intersection(set(df_kennedy[cpg_col].dropna())))
         logging.info(f"Overlapping distinct CpG loci: {loci_overlap}")
@@ -82,8 +388,7 @@ def main():
         genes_overlap = len(set(df_tecpg['gt_id'].dropna()).intersection(set(df_kennedy[query_col].dropna())))
         logging.info(f"Overlapping distinct genes: {genes_overlap}")
 
-    logging.info("Merging datasets...")
-    # Inner join on CpG and Gene
+    logging.info("Merging datasets (inner join)...")
     df_merged = pd.merge(
         df_tecpg,
         df_kennedy,
@@ -100,205 +405,121 @@ def main():
         logging.error("No overlapping pairs found between datasets. Please check the ID mapping.")
         sys.exit(1)
 
-    # Variables for plotting
-    # Effect Size: tecpg mt_est vs Kennedy beta
-    # Test Statistic: tecpg mt_t vs Kennedy T.stat
-
-    beta_col = 'beta' if 'beta' in df_kennedy.columns else 'estimate' if 'estimate' in df_kennedy.columns else None
-    tstat_col = 'T.stat' if 'T.stat' in df_kennedy.columns else 't.stat' if 't.stat' in df_kennedy.columns else None
-    pval_col = 'p.val' if 'p.val' in df_kennedy.columns else 'p.value' if 'p.value' in df_kennedy.columns else None
+    beta_col = cols['beta']
+    tstat_col = cols['tstat']
 
     if beta_col is None or tstat_col is None:
-        # Try to infer
         logging.warning("Could not automatically identify beta or T.stat columns in Kennedy data. Will try to infer.")
-        beta_col = df_kennedy.columns[2] if len(df_kennedy.columns) > 2 else df_kennedy.columns[-2]
-        tstat_col = df_kennedy.columns[3] if len(df_kennedy.columns) > 3 else df_kennedy.columns[-1]
 
-    # --- Comparison A: Statistical Concordance ---
-    logging.info("Calculating concordance metrics...")
+    pearson_r_beta = spearman_r_beta = r2_beta = 0.0
+    pearson_r_t = spearman_r_t = r2_t = 0.0
 
-    # Filter out NaNs if any
-    valid_beta = df_merged[['mt_est', beta_col]].dropna()
-    logging.info(
-        f"Drop site benchmark_kennedy.valid_beta[mt_est,{beta_col}]: dropped "
-        f"merged pairs with missing effect-size values: {len(df_merged)} -> "
-        f"{len(valid_beta)} ({len(df_merged) - len(valid_beta)} dropped)"
+    if beta_col and 'mt_est' in df_merged.columns:
+        valid_beta = df_merged[['mt_est', beta_col]].dropna()
+        dropped = len(df_merged) - len(valid_beta)
+        logging.info(
+            f"Drop site benchmark_kennedy.valid_beta[mt_est,{beta_col}]: "
+            f"dropped merged pairs with missing effect-size values: {len(df_merged)} -> "
+            f"{len(valid_beta)} ({dropped} dropped)"
+        )
+        if len(valid_beta) > 1:
+            pearson_r_beta, _ = stats.pearsonr(valid_beta['mt_est'], valid_beta[beta_col])
+            spearman_r_beta, _ = stats.spearmanr(valid_beta['mt_est'], valid_beta[beta_col])
+            r2_beta = pearson_r_beta**2
+
+            logging.info("Generating scatter plots...")
+            fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+            ax1 = axes[0]
+            ax1.hexbin(valid_beta['mt_est'], valid_beta[beta_col], gridsize=50, cmap='Blues', mincnt=1)
+            min_val_b = min(valid_beta['mt_est'].min(), valid_beta[beta_col].min())
+            max_val_b = max(valid_beta['mt_est'].max(), valid_beta[beta_col].max())
+            ax1.plot([min_val_b, max_val_b], [min_val_b, max_val_b], 'r--', lw=2, label='y=x')
+            ax1.set_xlabel('tecpg Effect Size (mt_est)')
+            ax1.set_ylabel(f'Kennedy Effect Size ({beta_col})')
+            ax1.set_title('Effect Size Concordance')
+            text_b = f"Pearson r: {pearson_r_beta:.3f}\nSpearman $\\rho$: {spearman_r_beta:.3f}\n$R^2$: {r2_beta:.3f}"
+            ax1.text(0.05, 0.95, text_b, transform=ax1.transAxes, fontsize=12, verticalalignment='top',
+                     bbox=dict(boxstyle='round', facecolor='white', alpha=0.8))
+
+    if tstat_col and 'mt_t' in df_merged.columns:
+        valid_t = df_merged[['mt_t', tstat_col]].dropna()
+        dropped = len(df_merged) - len(valid_t)
+        logging.info(
+            f"Drop site benchmark_kennedy.valid_t[mt_t,{tstat_col}]: "
+            f"dropped merged pairs with missing test-statistic values: {len(df_merged)} -> "
+            f"{len(valid_t)} ({dropped} dropped)"
+        )
+        if len(valid_t) > 1:
+            pearson_r_t, _ = stats.pearsonr(valid_t['mt_t'], valid_t[tstat_col])
+            spearman_r_t, _ = stats.spearmanr(valid_t['mt_t'], valid_t[tstat_col])
+            r2_t = pearson_r_t**2
+
+            if 'ax1' in locals():
+                ax2 = axes[1]
+                ax2.hexbin(valid_t['mt_t'], valid_t[tstat_col], gridsize=50, cmap='Blues', mincnt=1)
+                min_val_t = min(valid_t['mt_t'].min(), valid_t[tstat_col].min())
+                max_val_t = max(valid_t['mt_t'].max(), valid_t[tstat_col].max())
+                ax2.plot([min_val_t, max_val_t], [min_val_t, max_val_t], 'r--', lw=2, label='y=x')
+                ax2.set_xlabel('tecpg Test Statistic (mt_t)')
+                ax2.set_ylabel(f'Kennedy Test Statistic ({tstat_col})')
+                ax2.set_title('Test Statistic Concordance')
+                text_t = f"Pearson r: {pearson_r_t:.3f}\nSpearman $\\rho$: {spearman_r_t:.3f}\n$R^2$: {r2_t:.3f}"
+                ax2.text(0.05, 0.95, text_t, transform=ax2.transAxes, fontsize=12, verticalalignment='top',
+                         bbox=dict(boxstyle='round', facecolor='white', alpha=0.8))
+
+                plt.tight_layout()
+                plt.savefig(os.path.join(args.outdir, 'concordance_scatter.png'), dpi=300)
+                plt.close()
+
+    logging.info("Calculating directional overlap rates (sweep)...")
+    thresholds = [1e-5, 1e-6, 1e-7, 1e-8, 1e-9, 1e-10, 1e-11]
+
+    grid_results = {}
+    for tt in thresholds:
+        for tk in thresholds:
+            grid_results[(tk, tt)] = compute_overlap_rates(df_tecpg, df_kennedy, cols, tk, tt, tecpg_p_col)
+
+    logging.info("Calculating directional overlap rates (diagonal)...")
+    diag_results = compute_overlap_rates(
+        df_tecpg, df_kennedy, cols, args.kennedy_thresh, args.tecpg_thresh, tecpg_p_col
     )
-    valid_t = df_merged[['mt_t', tstat_col]].dropna()
-    logging.info(
-        f"Drop site benchmark_kennedy.valid_t[mt_t,{tstat_col}]: dropped "
-        f"merged pairs with missing test-statistic values: {len(df_merged)} -> "
-        f"{len(valid_t)} ({len(df_merged) - len(valid_t)} dropped)"
-    )
 
-    pearson_r_beta, _ = stats.pearsonr(valid_beta['mt_est'], valid_beta[beta_col])
-    spearman_r_beta, _ = stats.spearmanr(valid_beta['mt_est'], valid_beta[beta_col])
-    r2_beta = pearson_r_beta**2
+    logging.info("Exporting pair lists...")
+    export_pair_lists(args.outdir, df_tecpg, df_kennedy, cols, diag_results, tecpg_p_col)
 
-    pearson_r_t, _ = stats.pearsonr(valid_t['mt_t'], valid_t[tstat_col])
-    spearman_r_t, _ = stats.spearmanr(valid_t['mt_t'], valid_t[tstat_col])
-    r2_t = pearson_r_t**2
+    T_tt = diag_results['T_tt']
+    K_tk_E = diag_results['K_tk_E']
 
-    # Plotting
-    logging.info("Generating scatter plots...")
-    fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+    ineligible_count = len(diag_results['K_tk']) - len(K_tk_E)
 
-    # Panel 1: Beta vs mt_est
-    ax1 = axes[0]
-    ax1.hexbin(valid_beta['mt_est'], valid_beta[beta_col], gridsize=50, cmap='Blues', mincnt=1)
-    # Overlay identity line
-    min_val_b = min(valid_beta['mt_est'].min(), valid_beta[beta_col].min())
-    max_val_b = max(valid_beta['mt_est'].max(), valid_beta[beta_col].max())
-    ax1.plot([min_val_b, max_val_b], [min_val_b, max_val_b], 'r--', lw=2, label='y=x')
-    ax1.set_xlabel('tecpg Effect Size (mt_est)')
-    ax1.set_ylabel('Kennedy Effect Size (beta)')
-    ax1.set_title('Effect Size Concordance')
-    # Text box
-    text_b = f"Pearson r: {pearson_r_beta:.3f}\nSpearman $\\rho$: {spearman_r_beta:.3f}\n$R^2$: {r2_beta:.3f}"
-    ax1.text(0.05, 0.95, text_b, transform=ax1.transAxes, fontsize=12,
-             verticalalignment='top', bbox=dict(boxstyle='round', facecolor='white', alpha=0.8))
-
-    # Panel 2: T.stat vs mt_t
-    ax2 = axes[1]
-    ax2.hexbin(valid_t['mt_t'], valid_t[tstat_col], gridsize=50, cmap='Blues', mincnt=1)
-    min_val_t = min(valid_t['mt_t'].min(), valid_t[tstat_col].min())
-    max_val_t = max(valid_t['mt_t'].max(), valid_t[tstat_col].max())
-    ax2.plot([min_val_t, max_val_t], [min_val_t, max_val_t], 'r--', lw=2, label='y=x')
-    ax2.set_xlabel('tecpg Test Statistic (mt_t)')
-    ax2.set_ylabel('Kennedy Test Statistic (T.stat)')
-    ax2.set_title('Test Statistic Concordance')
-    text_t = f"Pearson r: {pearson_r_t:.3f}\nSpearman $\\rho$: {spearman_r_t:.3f}\n$R^2$: {r2_t:.3f}"
-    ax2.text(0.05, 0.95, text_t, transform=ax2.transAxes, fontsize=12,
-             verticalalignment='top', bbox=dict(boxstyle='round', facecolor='white', alpha=0.8))
-
-    plt.tight_layout()
-    scatter_path = os.path.join(args.outdir, 'concordance_scatter.png')
-    plt.savefig(scatter_path, dpi=300)
+    plt.figure(figsize=(8, 6))
+    v = venn2([T_tt, K_tk_E], set_labels=('tecpg hits', 'Kennedy hits (Eligible)'))
+    plt.title(f'Diagonal Overlap\n({ineligible_count} ineligible Kennedy hits omitted)')
+    plt.savefig(os.path.join(args.outdir, 'overlap_venn_diagonal.png'), dpi=300)
     plt.close()
 
-    # --- Comparison B: Hit Overlap and FDR Sensitivity ---
-    logging.info("Calculating overlap sets...")
-
-    # Calculate Sets for ALL
-    tecpg_all_mappings = set(zip(df_tecpg['mt_id'], df_tecpg['gt_id']))
-    tecpg_all_genes = set(df_tecpg['gt_id'].dropna())
-    tecpg_all_loci = set(df_tecpg['mt_id'].dropna())
-
-    kennedy_all_mappings = set(zip(df_kennedy[cpg_col], df_kennedy[query_col]))
-    kennedy_all_genes = set(df_kennedy[query_col].dropna())
-    kennedy_all_loci = set(df_kennedy[cpg_col].dropna())
-
-    # Calculate Sets for SIGNIFICANT
-    tecpg_fdr_col = 'fdr_est' if 'fdr_est' in df_tecpg.columns else 'fdr_bh' if 'fdr_bh' in df_tecpg.columns else 'mt_p' if 'mt_p' in df_tecpg.columns else None
-
-    if pval_col is None:
-        pval_col = [c for c in df_kennedy.columns if 'p' in c.lower()][-1]
-
-    kennedy_sig_df = df_kennedy[df_kennedy[pval_col] < args.p_thresh]
-    kennedy_sig_mappings = set(zip(kennedy_sig_df[cpg_col], kennedy_sig_df[query_col]))
-    kennedy_sig_genes = set(kennedy_sig_df[query_col].dropna())
-    kennedy_sig_loci = set(kennedy_sig_df[cpg_col].dropna())
-
-    if tecpg_fdr_col:
-        # if using FDR, < 0.05
-        tecpg_thresh = 0.05 if 'fdr' in tecpg_fdr_col.lower() else args.p_thresh
-        tecpg_sig_df = df_tecpg[df_tecpg[tecpg_fdr_col] < tecpg_thresh]
-    else:
-        logging.warning("Could not find FDR or p-value column in tecpg data. Using all merged pairs as tecpg hits.")
-        tecpg_sig_df = df_tecpg
-
-    tecpg_sig_mappings = set(zip(tecpg_sig_df['mt_id'], tecpg_sig_df['gt_id']))
-    tecpg_sig_genes = set(tecpg_sig_df['gt_id'].dropna())
-    tecpg_sig_loci = set(tecpg_sig_df['mt_id'].dropna())
-
-    def create_plots(tecpg_set, kennedy_set, title_prefix, filename_prefix):
-        overlap = kennedy_set.intersection(tecpg_set)
-        union = kennedy_set.union(tecpg_set)
-        jaccard = len(overlap) / len(union) if len(union) > 0 else 0
-
-        # Venn diagram
+    if args.upset and (len(T_tt) > 0 or len(K_tk_E) > 0):
+        upset_data = upsetplot.from_contents({
+            'tecpg': T_tt,
+            'Kennedy (Eligible)': K_tk_E
+        })
         plt.figure(figsize=(8, 6))
-        venn2([tecpg_set, kennedy_set], set_labels=('tecpg', 'Kennedy'))
-        plt.title(f'{title_prefix} Overlap')
-        venn_path = os.path.join(args.outdir, f'overlap_venn_{filename_prefix}.png')
-        plt.savefig(venn_path, dpi=300)
+        upsetplot.plot(upset_data)
+        plt.title('UpSet Plot (Eligible)')
+        plt.savefig(os.path.join(args.outdir, 'overlap_upset_diagonal.png'), dpi=300)
         plt.close()
 
-        # UpSet plot
-        if len(tecpg_set) > 0 or len(kennedy_set) > 0:
-            upset_data = upsetplot.from_contents({
-                'tecpg': tecpg_set,
-                'Kennedy': kennedy_set
-            })
-            plt.figure(figsize=(8, 6))
-            upsetplot.plot(upset_data)
-            plt.title(f'UpSet Plot of {title_prefix}')
-            upset_path = os.path.join(args.outdir, f'overlap_upset_{filename_prefix}.png')
-            plt.savefig(upset_path, dpi=300)
-            plt.close()
+    logging.info("Building summary...")
+    summary = build_summary_text(
+        args, num_merged, pearson_r_beta, spearman_r_beta, r2_beta, beta_col,
+        pearson_r_t, spearman_r_t, r2_t, tstat_col,
+        grid_results, diag_results, thresholds, cols, df_kennedy
+    )
 
-        only_tecpg = len(tecpg_set - kennedy_set)
-        only_kennedy = len(kennedy_set - tecpg_set)
-        return len(tecpg_set), len(kennedy_set), len(overlap), only_tecpg, only_kennedy, jaccard
-
-    logging.info("Generating overlap visualizations...")
-
-    comparisons = [
-        (tecpg_all_mappings, kennedy_all_mappings, 'All Mappings', 'all_mappings'),
-        (tecpg_all_genes, kennedy_all_genes, 'All Genes', 'all_genes'),
-        (tecpg_all_loci, kennedy_all_loci, 'All Loci', 'all_loci'),
-        (tecpg_sig_mappings, kennedy_sig_mappings, 'Significant Mappings', 'sig_mappings'),
-        (tecpg_sig_genes, kennedy_sig_genes, 'Significant Genes', 'sig_genes'),
-        (tecpg_sig_loci, kennedy_sig_loci, 'Significant Loci', 'sig_loci'),
-    ]
-
-    results = {}
-    for t_set, k_set, title, fname in comparisons:
-        results[title] = create_plots(t_set, k_set, title, fname)
-
-    # Summary Output
-    def format_overlap_stats(title, stats_tuple):
-        t_len, k_len, o_len, only_t, only_k, jaccard = stats_tuple
-        return f"{title}:\n  tecpg Count:   {t_len}\n  Kennedy Count: {k_len}\n  Overlap:       {o_len}\n  Only in tecpg: {only_t}\n  Only in Kennedy: {only_k}\n  Jaccard Index: {jaccard:.4f}\n"
-
-    summary = f"""Benchmark Summary
-=================
-Input tecpg file: {args.tecpg}
-Input Kennedy file: {args.kennedy}
-Kennedy p-value threshold: {args.p_thresh}
-
-Mapping & Merging
------------------
-Overlapping Pairs Mapped: {num_merged}
-
-Comparison A: Statistical Concordance
--------------------------------------
-Effect Size (mt_est vs {beta_col}):
-  Pearson r:  {pearson_r_beta:.4f}
-  Spearman rho: {spearman_r_beta:.4f}
-  R^2:        {r2_beta:.4f}
-
-Test Statistic (mt_t vs {tstat_col}):
-  Pearson r:  {pearson_r_t:.4f}
-  Spearman rho: {spearman_r_t:.4f}
-  R^2:        {r2_t:.4f}
-
-Comparison B: Hit Overlap
--------------------------
-"""
-    for title, fname in [comp[2:4] for comp in comparisons]:
-        summary += format_overlap_stats(title, results[title])
-
-    summary += f"""
-Outputs
--------
-Summary saved to: benchmark_summary.txt
-Plots saved to: concordance_scatter.png, overlap_venn_*.png, overlap_upset_*.png
-"""
     print(summary)
-    summary_path = os.path.join(args.outdir, 'benchmark_summary.txt')
-    with open(summary_path, 'w') as f:
+    with open(os.path.join(args.outdir, 'benchmark_summary.txt'), 'w') as f:
         f.write(summary)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Addressed the benchmark_kennedy.py C1 requirements by ensuring exact column resolution, preventing silent fallbacks, refining subset math, restructuring as pure functions for testability, handling threshold warnings, maintaining identical structure across export files, and testing the edge cases with pytest.

---
*PR created automatically by Jules for task [13098058967267119301](https://jules.google.com/task/13098058967267119301) started by @kordk*