### PR TITLE
Add FDR-column comparison oracle and licensing-mask guard

### DIFF
--- a/pipelinePermute.sh
+++ b/pipelinePermute.sh
@@ -581,6 +581,7 @@ if [ $EXECUTE -eq 1 ]; then
                 --df "$DF" \
                 --p-column p_permute \
                 --fdr-column fdr_permute \
+                --compare-fdr-column fdr_est \
                 --calculate-fdr \
                 --output-fdr-file "$FINAL_OUT"
 

--- a/tests/test_annotate_permute_p.py
+++ b/tests/test_annotate_permute_p.py
@@ -279,3 +279,56 @@ def test_empty_input_fails_closed(tmp_path, input_parquet_path, eval_report_path
     assert "input contains no rows" in res.stderr
     assert not out.exists()
     assert not (tmp_path / "out.parquet.tmp").exists()
+
+def test_unlicensed_region_populated_fails_closed(tmp_path, input_parquet_path, eval_report_path, monkeypatch, capsys):
+    import tools.annotate_permute_p as app
+    import pandas as pd
+    import sys
+
+    original_isin = pd.Series.isin
+    def patched_isin(self, values):
+        res = original_isin(self, values)
+        if hasattr(self, 'name') and self.name == 'region':
+            genebody_mask = (self == 'GENEBODY')
+            res = res | genebody_mask
+        return res
+
+    monkeypatch.setattr(pd.Series, 'isin', patched_isin)
+
+    sys.argv = [
+        "annotate_permute_p.py",
+        "--input", str(input_parquet_path),
+        "--output", str(tmp_path / "out.parquet"),
+        "--eval-report", str(eval_report_path)
+    ]
+
+    with pytest.raises(SystemExit) as e:
+        app.main()
+
+    assert e.value.code == 1
+
+    captured = capsys.readouterr()
+    assert "Fail-closed: unlicensed region(s) carry populated p-values:" in captured.err
+    assert "GENEBODY" in captured.err
+
+def test_absent_region_rows_never_populated(tmp_path, input_parquet_path, eval_report_path, capsys):
+    out = tmp_path / "out.parquet"
+    res = run_tool(tmp_path, input_parquet_path, eval_report_path, out)
+    assert res.returncode == 0
+
+    import re
+    match = re.search(r"\(absent\)\s+-\s+no\s+(\d+)\s+(\d+)", res.stdout)
+    assert match is not None, "Could not find (absent) row in stdout"
+    n_rows = int(match.group(1))
+    n_populated = int(match.group(2))
+
+    assert n_rows > 0
+    assert n_populated == 0
+
+def test_provenance_line_names_source_and_target(tmp_path, input_parquet_path, eval_report_path):
+    out = tmp_path / "out.parquet"
+    res = run_tool(tmp_path, input_parquet_path, eval_report_path, out,
+                   ["--p-source", "precise_mt_p", "--p-column", "p_permute"])
+    assert res.returncode == 0
+
+    assert "Provenance: wrote 'p_permute' as a copy of 'precise_mt_p'" in res.stdout

--- a/tests/test_summarize_fdr_columns.py
+++ b/tests/test_summarize_fdr_columns.py
@@ -219,3 +219,177 @@ def test_bh_matches_hand_computed_reference(tmp_path, base_fixture):
     df_valid.iloc[sorted_idx, df_valid.columns.get_loc('hand_fdr')] = fdr_est
 
     pd.testing.assert_series_equal(df_valid['fdr_est'], df_valid['hand_fdr'], check_names=False)
+
+def run_fdr_tool(tmp_path, df_in, fdr_col, compare_col=None, total_tests=10):
+    main_file = tmp_path / "main.parquet"
+    res_file = tmp_path / "res.csv"
+    out_file = tmp_path / f"out_{fdr_col}.parquet"
+
+    df_in.to_parquet(main_file)
+    pd.DataFrame(columns=['mt_id', 'gt_id', 'mt_t', 'p_value']).to_csv(res_file, index=False)
+
+    cmd = [
+        "--main-file", str(main_file),
+        "--reservoir-file", str(res_file),
+        "--total-tests", str(total_tests),
+        "--df", "10",
+        "--calculate-fdr",
+        "--p-column", "p_source" if "p_source" in df_in.columns else "precise_mt_p",
+        "--fdr-column", fdr_col,
+        "--output-fdr-file", str(out_file)
+    ]
+    if compare_col:
+        cmd.extend(["--compare-fdr-column", compare_col])
+
+    return run_tool(cmd), out_file
+
+def test_compare_fdr_identical_pools_reports_equal(tmp_path):
+    df = pd.DataFrame({'mt_id': [1, 2, 3], 'gt_id': [1, 2, 3], 'precise_mt_p': [0.01, 0.05, 0.1]})
+    res1, out1 = run_fdr_tool(tmp_path, df, "fdr_est")
+    df2 = pd.read_parquet(out1)
+    df2["p_permute"] = df2["precise_mt_p"]
+    main_file2 = tmp_path / "main2.parquet"
+    res_file2 = tmp_path / "res2.csv"
+    out_file2 = tmp_path / "out2.parquet"
+    df2.to_parquet(main_file2)
+    pd.DataFrame(columns=['mt_id', 'gt_id', 'mt_t', 'p_value']).to_csv(res_file2, index=False)
+    res2 = run_tool([
+        "--main-file", str(main_file2), "--reservoir-file", str(res_file2), "--total-tests", "10",
+        "--df", "10", "--calculate-fdr", "--p-column", "p_permute", "--fdr-column", "fdr_permute",
+        "--compare-fdr-column", "fdr_est", "--output-fdr-file", str(out_file2)
+    ])
+    assert res2.returncode == 0
+    assert "VERDICT: EQUAL (identical pools and denominator)" in res2.stdout
+    assert "max|diff|            : 0.000000e+00" in res2.stdout
+
+def test_compare_fdr_subset_pool_reports_directional(tmp_path):
+    df = pd.DataFrame({'mt_id': [1, 2, 3, 4, 5], 'gt_id': [1, 2, 3, 4, 5], 'precise_mt_p': [0.001, 0.002, 0.003, 0.004, 0.005]})
+    res1, out1 = run_fdr_tool(tmp_path, df, "fdr_est")
+    df2 = pd.read_parquet(out1)
+    df2["p_permute"] = df2["precise_mt_p"]
+    df2.loc[1:2, "p_permute"] = np.nan
+    main_file2 = tmp_path / "main2.parquet"
+    res_file2 = tmp_path / "res2.csv"
+    out_file2 = tmp_path / "out2.parquet"
+    df2.to_parquet(main_file2)
+    pd.DataFrame(columns=['mt_id', 'gt_id', 'mt_t', 'p_value']).to_csv(res_file2, index=False)
+    res2 = run_tool([
+        "--main-file", str(main_file2), "--reservoir-file", str(res_file2), "--total-tests", "10",
+        "--df", "10", "--calculate-fdr", "--p-column", "p_permute", "--fdr-column", "fdr_permute",
+        "--compare-fdr-column", "fdr_est", "--output-fdr-file", str(out_file2)
+    ])
+    assert res2.returncode == 0
+    assert "VERDICT: DIRECTIONAL-OK" in res2.stdout
+    assert "rows left the pool   : 2" in res2.stdout
+    import re
+    match = re.search(r"min diff \(signed\)\s*:\s*([^\s]+)", res2.stdout)
+    assert match is not None
+    assert float(match.group(1)) >= 0.0
+
+def test_compare_fdr_smaller_denominator_is_violation(tmp_path):
+    df = pd.DataFrame({'mt_id': [1, 2, 3], 'gt_id': [1, 2, 3], 'precise_mt_p': [0.01, 0.05, 0.1]})
+    res1, out1 = run_fdr_tool(tmp_path, df, "fdr_est", total_tests=9)
+    df2 = pd.read_parquet(out1)
+    df2["p_permute"] = df2["precise_mt_p"]
+    main_file2 = tmp_path / "main2.parquet"
+    res_file2 = tmp_path / "res2.csv"
+    out_file2 = tmp_path / "out2.parquet"
+    df2.to_parquet(main_file2)
+    pd.DataFrame(columns=['mt_id', 'gt_id', 'mt_t', 'p_value']).to_csv(res_file2, index=False)
+    res2 = run_tool([
+        "--main-file", str(main_file2), "--reservoir-file", str(res_file2), "--total-tests", "3",
+        "--df", "10", "--calculate-fdr", "--p-column", "p_permute", "--fdr-column", "fdr_permute",
+        "--compare-fdr-column", "fdr_est", "--output-fdr-file", str(out_file2)
+    ])
+    assert res2.returncode == 1
+    assert "VERDICT: VIOLATION" in res2.stdout
+
+def test_compare_fdr_column_absent_prints_notice_and_skips(tmp_path, base_fixture):
+    main_file, res_file = base_fixture
+    out_file = tmp_path / "out.parquet"
+    res = run_tool([
+        "--main-file", str(main_file), "--reservoir-file", str(res_file), "--total-tests", "10",
+        "--df", "10", "--calculate-fdr", "--fdr-column", "fdr_est", "--compare-fdr-column", "missing_fdr",
+        "--output-fdr-file", str(out_file)
+    ])
+    assert res.returncode == 0
+    assert "Notice: --compare-fdr-column 'missing_fdr' not found in schema. Skipping comparison." in res.stdout
+    assert "FDR comparison:" not in res.stdout
+    assert out_file.exists()
+
+def test_compare_fdr_not_requested_prints_no_verdict_block(tmp_path, base_fixture):
+    main_file, res_file = base_fixture
+    out_file = tmp_path / "out.parquet"
+    res = run_tool([
+        "--main-file", str(main_file), "--reservoir-file", str(res_file), "--total-tests", "10",
+        "--df", "10", "--calculate-fdr", "--fdr-column", "fdr_est", "--output-fdr-file", str(out_file)
+    ])
+    assert res.returncode == 0
+    assert "FDR comparison:" not in res.stdout
+    assert out_file.exists()
+
+def test_compare_fdr_disjoint_nulls_excluded_from_comparable(tmp_path):
+    df = pd.DataFrame({'mt_id': [1, 2, 3, 4], 'gt_id': [1, 2, 3, 4], 'precise_mt_p': [0.01, 0.05, np.nan, 0.1]})
+    res1, out1 = run_fdr_tool(tmp_path, df, "fdr_est")
+    df2 = pd.read_parquet(out1)
+    df2["p_permute"] = [0.01, np.nan, 0.08, 0.1]
+    main_file2 = tmp_path / "main2.parquet"
+    res_file2 = tmp_path / "res2.csv"
+    out_file2 = tmp_path / "out2.parquet"
+    df2.to_parquet(main_file2)
+    pd.DataFrame(columns=['mt_id', 'gt_id', 'mt_t', 'p_value']).to_csv(res_file2, index=False)
+    res2 = run_tool([
+        "--main-file", str(main_file2), "--reservoir-file", str(res_file2), "--total-tests", "10",
+        "--df", "10", "--calculate-fdr", "--p-column", "p_permute", "--fdr-column", "fdr_permute",
+        "--compare-fdr-column", "fdr_est", "--output-fdr-file", str(out_file2)
+    ])
+    assert res2.returncode == 0
+    assert "comparable rows      : 2" in res2.stdout
+    assert "rows left the pool   : 1" in res2.stdout
+    assert "rows entered the pool: 1" in res2.stdout
+
+def test_compare_fdr_subtolerance_positive_diff_is_not_equal(tmp_path):
+    df = pd.DataFrame({'mt_id': [1, 2, 3], 'gt_id': [1, 2, 3], 'precise_mt_p': [0.01, 0.05, 0.1]})
+    res1, out1 = run_fdr_tool(tmp_path, df, "fdr_est")
+    df2 = pd.read_parquet(out1)
+    df2["p_permute"] = df2["precise_mt_p"]
+    df2.loc[0, "fdr_est"] -= 5e-13
+    main_file2 = tmp_path / "main2.parquet"
+    res_file2 = tmp_path / "res2.csv"
+    out_file2 = tmp_path / "out2.parquet"
+    df2.to_parquet(main_file2)
+    pd.DataFrame(columns=['mt_id', 'gt_id', 'mt_t', 'p_value']).to_csv(res_file2, index=False)
+    res2 = run_tool([
+        "--main-file", str(main_file2), "--reservoir-file", str(res_file2), "--total-tests", "10",
+        "--df", "10", "--calculate-fdr", "--p-column", "p_permute", "--fdr-column", "fdr_permute",
+        "--compare-fdr-column", "fdr_est", "--output-fdr-file", str(out_file2)
+    ])
+    assert res2.returncode == 0
+    assert "VERDICT: DIRECTIONAL-OK" in res2.stdout
+    import re
+    match = re.search(r"max\|diff\|\s*:\s*([^\s]+)", res2.stdout)
+    assert match is not None
+    max_diff = float(match.group(1))
+    assert np.isclose(max_diff, 5e-13, atol=1e-15, rtol=0)
+    match2 = re.search(r"min diff \(signed\)\s*:\s*([^\s]+)", res2.stdout)
+    assert match2 is not None
+    assert float(match2.group(1)) >= 0.0
+
+def test_compare_fdr_subtolerance_negative_diff_is_violation(tmp_path):
+    df = pd.DataFrame({'mt_id': [1, 2, 3], 'gt_id': [1, 2, 3], 'precise_mt_p': [0.01, 0.05, 0.1]})
+    res1, out1 = run_fdr_tool(tmp_path, df, "fdr_est")
+    df2 = pd.read_parquet(out1)
+    df2["p_permute"] = df2["precise_mt_p"]
+    df2.loc[0, "fdr_est"] += 5e-13
+    main_file2 = tmp_path / "main2.parquet"
+    res_file2 = tmp_path / "res2.csv"
+    out_file2 = tmp_path / "out2.parquet"
+    df2.to_parquet(main_file2)
+    pd.DataFrame(columns=['mt_id', 'gt_id', 'mt_t', 'p_value']).to_csv(res_file2, index=False)
+    res2 = run_tool([
+        "--main-file", str(main_file2), "--reservoir-file", str(res_file2), "--total-tests", "10",
+        "--df", "10", "--calculate-fdr", "--p-column", "p_permute", "--fdr-column", "fdr_permute",
+        "--compare-fdr-column", "fdr_est", "--output-fdr-file", str(out_file2)
+    ])
+    assert res2.returncode == 1
+    assert "VERDICT: VIOLATION" in res2.stdout

--- a/tools/annotate_permute_p.py
+++ b/tools/annotate_permute_p.py
@@ -135,6 +135,7 @@ def main():
                 if '(absent)' not in region_counts:
                     region_counts['(absent)'] = {'n_rows': 0, 'n_populated': 0}
                 region_counts['(absent)']['n_rows'] += null_mask.sum()
+                region_counts['(absent)']['n_populated'] += (~np.isnan(p_new[null_mask.values])).sum()
 
             # Fix coordinate columns as in summarizeOutput_parquet
             if 'mt_chromStart' in df_chunk.columns:
@@ -179,6 +180,8 @@ def main():
     os.replace(args.output + '.tmp', args.output)
 
     # 5. Output summary
+    print(f"Provenance: wrote '{args.p_column}' as a copy of '{args.p_source}' "
+          f"for licensed strata; unlicensed and null-region rows left null.")
     print(f"{'region':<11} {'status':<17} {'licensed':<10} {'n_rows':<11} {'n_populated'}")
 
     # We want to print all regions that are present (n_rows > 0)
@@ -198,6 +201,22 @@ def main():
         print(f"{'(absent)':<11} {'-':<17} {'no':<10} {stats['n_rows']:<11} {stats['n_populated']}")
 
     print(f"\nTotals: {total_rows} rows, {total_populated} populated. Recommendation: {recommendation}")
+
+    # Licensing-mask guard. A region that did not license must carry no populated
+    # p-values. A populated unlicensed region means the mask inverted or leaked --
+    # which would license precisely the strata the verdict excluded.
+    leaks = []
+    for r, stats in region_counts.items():
+        if r == '(absent)':
+            if stats['n_populated'] > 0:
+                leaks.append((r, stats['n_populated']))
+        elif r not in licensed and stats['n_populated'] > 0:
+            leaks.append((r, stats['n_populated']))
+    if leaks:
+        print("Fail-closed: unlicensed region(s) carry populated p-values:", file=sys.stderr)
+        for r, n in leaks:
+            print(f"  {r}: {n} populated rows", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/tools/summarizeOutput_parquet.py
+++ b/tools/summarizeOutput_parquet.py
@@ -146,6 +146,12 @@ Outputs and Metrics Calculated:
 
     parser.add_argument("--p-column", default=DEFAULT_P_COLUMN, help=f"Name of the p-value column to rank and correct. Default: {DEFAULT_P_COLUMN}.")
     parser.add_argument("--fdr-column", default=DEFAULT_FDR_COLUMN, help=f"Name of the FDR column to write. Default: {DEFAULT_FDR_COLUMN}. Must not name an existing column.")
+    parser.add_argument("--compare-fdr-column", default=None,
+                        help="Name of an EXISTING FDR column to compare the newly written --fdr-column "
+                             "against. Optional; off by default. When the two columns share a BH pool and "
+                             "denominator they must agree exactly; when the new pool is a strict subset the "
+                             "new values must be greater than or equal, never smaller. A smaller value is "
+                             "reported as a VIOLATION and exits non-zero.")
 
     fdr_group = parser.add_mutually_exclusive_group()
     fdr_group.add_argument("--calculate-fdr", action="store_true", help="Calculate and append an estimated FDR column (see --fdr-column).")
@@ -558,6 +564,18 @@ Outputs and Metrics Calculated:
     # Write FDR Output
     if args.output_fdr_file:
         print(f"\nWriting output FDR Parquet file to: {args.output_fdr_file}")
+
+        do_compare = args.compare_fdr_column is not None
+        if do_compare and args.compare_fdr_column not in schema_cols:
+            print(f"Notice: --compare-fdr-column '{args.compare_fdr_column}' not found in schema. Skipping comparison.")
+            do_compare = False
+
+        cmp_n_comparable = 0
+        cmp_max_abs_diff = 0.0
+        cmp_min_diff = np.inf
+        cmp_n_new_null_ref_present = 0
+        cmp_n_new_present_ref_null = 0
+
         writer = None
         try:
             for i, batch in enumerate(parquet_file.iter_batches(batch_size=args.chunk_size)):
@@ -593,6 +611,31 @@ Outputs and Metrics Calculated:
                     mapped[~source_is_null] = mapped[~source_is_null].fillna(1.0)
                     df_chunk[args.fdr_column] = mapped.values
 
+                if do_compare:
+                    new_vals = df_chunk[args.fdr_column].astype(np.float64).values
+                    ref_vals = df_chunk[args.compare_fdr_column].astype(np.float64).values
+
+                    new_is_na = np.isnan(new_vals)
+                    ref_is_na = np.isnan(ref_vals)
+
+                    cmp_n_new_null_ref_present += (new_is_na & ~ref_is_na).sum()
+                    cmp_n_new_present_ref_null += (~new_is_na & ref_is_na).sum()
+
+                    comparable_mask = ~new_is_na & ~ref_is_na
+                    if comparable_mask.any():
+                        c_new = new_vals[comparable_mask]
+                        c_ref = ref_vals[comparable_mask]
+                        diff = c_new - c_ref
+
+                        cmp_n_comparable += len(diff)
+                        chunk_max_abs = np.max(np.abs(diff))
+                        chunk_min = np.min(diff)
+
+                        if chunk_max_abs > cmp_max_abs_diff:
+                            cmp_max_abs_diff = chunk_max_abs
+                        if chunk_min < cmp_min_diff:
+                            cmp_min_diff = chunk_min
+
                 # Ensure coordinate columns are consistently typed as nullable Int64
                 # This prevents pyarrow from deducing int64 for chunks without nulls and float64 for chunks with nulls.
                 if 'mt_chromStart' in df_chunk.columns:
@@ -621,6 +664,36 @@ Outputs and Metrics Calculated:
         finally:
             if writer is not None:
                 writer.close()
+
+        if do_compare:
+            if cmp_n_comparable == 0:
+                verdict = "INFO (no comparable rows)"
+                cmp_min_diff_fmt = 0.0
+            elif cmp_min_diff < 0.0:
+                verdict = "VIOLATION (new FDR smaller than reference; check the BH denominator)"
+                cmp_min_diff_fmt = cmp_min_diff
+            elif cmp_max_abs_diff == 0.0:
+                verdict = "EQUAL (identical pools and denominator)"
+                cmp_min_diff_fmt = cmp_min_diff
+            else:
+                verdict = "DIRECTIONAL-OK (new pool is a subset; values moved upward only)"
+                cmp_min_diff_fmt = cmp_min_diff
+
+            if cmp_n_comparable == 0 and cmp_min_diff == np.inf:
+                cmp_min_diff_fmt = 0.0
+
+            print("-" * 60)
+            print(f"FDR comparison: {args.fdr_column} vs {args.compare_fdr_column}")
+            print(f"  comparable rows      : {cmp_n_comparable}")
+            print(f"  max|diff|            : {cmp_max_abs_diff:.6e}")
+            print(f"  min diff (signed)    : {cmp_min_diff_fmt:.6e}")
+            print(f"  rows left the pool   : {cmp_n_new_null_ref_present}")
+            print(f"  rows entered the pool: {cmp_n_new_present_ref_null}")
+            print(f"  VERDICT: {verdict}")
+            print("-" * 60)
+
+            if verdict.startswith("VIOLATION"):
+                sys.exit(1)
 
     # Histogram
     try:


### PR DESCRIPTION
This submission introduces a self-validating FDR comparison oracle and a licensing-mask guard.

- Added `--compare-fdr-column` to `summarizeOutput_parquet.py` to compare a newly written FDR column against an existing reference.
- Enhanced `annotate_permute_p.py` to track populated rows for absent regions and added a fail-closed guard if an unlicensed region carries populated p-values.
- Enabled the oracle in `pipelinePermute.sh` by passing `--compare-fdr-column fdr_est` to `summarizeOutput_parquet.py`.
- Wrote extensive tests for the new behaviors and verified sub-tolerance conditions.

---
*PR created automatically by Jules for task [6235088928751408727](https://jules.google.com/task/6235088928751408727) started by @kordk*