### PR TITLE
feat: pipelinePermute.sh golden path -- derive, log loudly, validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,14 @@ stages. Each stage name (in `code`) matches the value accepted by
 `--start-stage`, so any individual step can be re-run in isolation.
 
 1. **`map` — eQTM mapping** *(stage `[3/9]`)*. Runs `tecpg ... run
-   mlr --mlr-method qr --<mapping> --compute-ig`, with chunk sizes
-   auto-selected by the CLI's `_auto_chunk_sizes` (overridable by
-   exporting `TECPG_M_CHUNK` / `TECPG_G_CHUNK`). Logs are tee'd to
-   `mlr_run_<dataset>.log` and `TOTAL_TESTS` is extracted from that
-   log for downstream FDR.
+   mlr --mlr-method qr --<mapping> -p "$MAP_P_THRESH" --compute-ig`,
+   with chunk sizes auto-selected by the CLI's `_auto_chunk_sizes`
+   (overridable by exporting `TECPG_M_CHUNK` / `TECPG_G_CHUNK`).
+   `MAP_P_THRESH` (default `0.001`, matching the CLI's own `-p`
+   default) is the catalog's inclusion gate: pairs above it are never
+   written. It is set explicitly in `pipeline.sh` so it appears in the
+   run log. Logs are tee'd to `mlr_run_<dataset>.log` and
+   `TOTAL_TESTS` is extracted from that log for downstream FDR.
 2. **`merge` — Merge chunked output** *(stage `[4/9]`)*.
    `tools/mergeOutputs.py` combines per-chunk files into a single
    `output_<dataset>/merged.parquet`; intermediate chunk files are
@@ -542,9 +545,10 @@ HT-12 mapping pipeline (Re-Annotator → GEO → UCSC WG-6, with NA
 fallback and provenance tracking) and correctly handles unmapped
 probes, alternate/unplaced contigs, and pseudoautosomal labels. The
 defaults follow Kennedy et al. *BMC Genomics* (2018) **19:476**:
-`PVALCUTOFF = 1e-6` (exploratory), `CIS < 50 kb` upstream of TSS,
-`DISTAL > 50 kb` from TSS, and `PROMOTER ± 2.5 kb` of TSS. Override
-these in the script's defaults block if you need different cutoffs.
+`CIS < 50 kb` upstream of TSS, `DISTAL > 50 kb` from TSS, and
+`PROMOTER ± 2.5 kb` of TSS. Override these in the script's defaults
+block if you need different cutoffs. The script annotates every row it
+is given; it applies no p-value filter of its own.
 
 > **Legacy CSV path:** the original per-chunk CSV classifier
 > `tools/assignRegionToEcpg.py` is retained for backwards

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -31,6 +31,18 @@ START_STAGE="all"
 MLR_IG_COVARIATES="all"
 BOOTSTRAP_IG_COVARIATES="all"
 
+# Mapper p-value threshold. This is the FIRST filter in the pipeline and the
+# rule that decides which pairs enter the catalog at all: the mapper keeps a
+# pair only if its p-value is <= this value. tecpg's own `-p` default for
+# `run mlr` is 0.001; it is set explicitly here so the value appears in the run
+# log and can be cited in methods instead of being an implicit CLI default.
+# The threshold is applied to the float32 `mt_p` column inside the mapper,
+# before Stage 6 recomputes `precise_mt_p` in float64. float32 is sound AT this
+# cutoff (|t| ~ 3.3, far above the ~5.96e-08 cancellation floor), but the
+# ranking within the retained set is not -- that is what Stage 6 repairs.
+# Changing this value changes the catalog and therefore every downstream count.
+MAP_P_THRESH="0.001"
+
 # Chunk sizes for `tecpg run mlr` are intentionally NOT set here. As of
 # tecpg 1.21.0-dev the CLI's anchored auto-sizer (`_auto_chunk_sizes` in
 # tecpg/cli.py) picks `--gene-loci-per-chunk` and `--meth-loci-per-chunk`
@@ -216,6 +228,7 @@ if [ "${#MLR_CHUNK_ARGS[@]}" -gt 0 ]; then
 else
     log "Chunk sizes auto-selected by tecpg CLI from host budget. Input: $DATA_DIR, Annotations: $ANNOT_DIR, Output: $OUT_DIR"
 fi
+log "Mapper p-value threshold: -p $MAP_P_THRESH (catalog inclusion gate, applied to float32 mt_p)"
 
 # Ensure pipefail is set so pipeline errors (like in mlr) are not masked by tee
 set -o pipefail
@@ -225,7 +238,7 @@ if [ "$MLR_IG_COVARIATES" = "all" ]; then
 elif [ -n "$MLR_IG_COVARIATES" ] && [ "$MLR_IG_COVARIATES" != "none" ]; then
     MLR_IG_ARGS+=(--ig-covariates-list "$MLR_IG_COVARIATES")
 fi
-python3 -m tecpg -i "$DATA_DIR" -a "$ANNOT_DIR" -o "$OUT_DIR" run mlr --mlr-method qr --$MAPPING "${MLR_CHUNK_ARGS[@]}" --compute-ig "${MLR_IG_ARGS[@]}" 2>&1 | tee "mlr_run_${DATASET}.log"
+python3 -m tecpg -i "$DATA_DIR" -a "$ANNOT_DIR" -o "$OUT_DIR" run mlr --mlr-method qr --$MAPPING -p "$MAP_P_THRESH" "${MLR_CHUNK_ARGS[@]}" --compute-ig "${MLR_IG_ARGS[@]}" 2>&1 | tee "mlr_run_${DATASET}.log"
 set +o pipefail
 fi
 

--- a/pipelinePermute.sh
+++ b/pipelinePermute.sh
@@ -19,6 +19,7 @@ CIS_ENRICH=0
 CIS_WINDOW=1000000
 TOTAL_TESTS=""
 ANNOTATE_MAINLINE=1
+N_NULL_PAIRS=""
 
 PERMUTE_ARGS=()
 
@@ -36,16 +37,16 @@ while [[ "$#" -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  -h, --help                     Show this help message and exit"
-            echo "      --master-parquet PATH      REQUIRED (if no --reservoir). Existing mapping output parquet."
+            echo "      --master-parquet PATH      Overrides --cis-enrich. Existing mapping output parquet."
             echo "                                 Also accepts the reservoir directly: a *.csv PATH (e.g."
             echo "                                 sample_reservoir.csv) is converted to reservoir_master.parquet,"
             echo "                                 and a not-yet-built reservoir_master.parquet is built from its"
             echo "                                 sibling sample_reservoir.csv."
-            echo "      --reservoir                REQUIRED (if no --master-parquet). Convert and use sample_reservoir.csv"
+            echo "      --reservoir                Overrides --cis-enrich. Convert and use sample_reservoir.csv"
             echo "                                 whose (mt_id, gt_id) universe is scored. Must have been"
             echo "                                 mapped from the SAME data_<ds> (same covariate design);"
             echo "                                 qr_permute fail-closes at runtime if the design mismatches."
-            echo "      --cis-enrich               REQUIRED (if no --master-parquet/--reservoir). Cis-window enrichment"
+            echo "      --cis-enrich               [DEFAULT] Instead of a flat reservoir, build a unified master from"
             echo "                                 analysis: runs a cis write-all map, assembles the near-gene pairs"
             echo "                                 with the reservoir's trans/distal pairs (build_gene_anchored_master.py),"
             echo "                                 and scores the assembled master. Needs output_<ds>/sample_reservoir.csv"
@@ -58,6 +59,8 @@ while [[ "$#" -gt 0 ]]; do
             echo "                                 same TOTAL_TESTS pipeline.sh uses for fdr_est -- NOT the"
             echo "                                 permute run's tecpg_perm_n_reported. Cross-checked against"
             echo "                                 mlr_run_<ds>.log when that log is present."
+            echo "      --n-null-pairs N           Fallback for permutation parquets written before tecpg_perm_n_null_pairs"
+            echo "                                 was stamped. Passed directly to eval_permute."
             echo "      --no-annotate-mainline     Skip stage [5/5] (mainline p_permute/fdr_permute annotation)."
             echo "  -d, --dataset DATASET          Specify the dataset to use. Options: dummy (default), gtpsub, gtp, mesa"
             echo "  -m, --mapping MAPPING          Region flag passed to qr_permute. Options: all (default)."
@@ -105,6 +108,10 @@ while [[ "$#" -gt 0 ]]; do
             TOTAL_TESTS="$2"
             shift 2
             ;;
+        --n-null-pairs)
+            N_NULL_PAIRS="$2"
+            shift 2
+            ;;
         --no-annotate-mainline)
             ANNOTATE_MAINLINE=0
             shift
@@ -140,6 +147,20 @@ done
 # qr_permute is a post-mapping consumer: it requires an observed statistic master.
 # Exactly one master source: an existing --master-parquet, the --reservoir, or
 # --cis-enrich (which BUILDS the master from a cis map + the reservoir).
+
+# Default master source. Applied only when no source was given explicitly,
+# so the mutual-exclusion guard below still sees exactly one source and
+# stays argument-order-independent. Do NOT move this into the parse cases:
+# MODE_COUNT is computed after the parse loop, so clearing CIS_ENRICH there
+# makes `--cis-enrich --master-parquet X` and `--master-parquet X
+# --cis-enrich` behave differently.
+if [ -z "$MASTER_PARQUET" ] && [ $USE_RESERVOIR -eq 0 ] && [ $CIS_ENRICH -eq 0 ]; then
+    CIS_ENRICH=1
+    CIS_ENRICH_DEFAULTED=1
+else
+    CIS_ENRICH_DEFAULTED=0
+fi
+
 MODE_COUNT=0
 [ -n "$MASTER_PARQUET" ] && MODE_COUNT=$((MODE_COUNT + 1))
 [ $USE_RESERVOIR -eq 1 ] && MODE_COUNT=$((MODE_COUNT + 1))
@@ -440,12 +461,27 @@ if [ $EXECUTE -eq 1 ]; then
     log "[3/5] Running eval..."
     [ -s "$PERM_OUTPUT" ] || { log "Error: $PERM_OUTPUT missing or empty. Run with --start-stage permute first."; exit 1; }
 
-    python3 -u tools/eval_permute.py \
-        --perm-output "$PERM_OUTPUT" \
-        --m-annot "$ANNOT_DIR/M.bed6" \
-        --g-annot "$ANNOT_DIR/G.bed6" \
-        --df "$DF" \
+    if [ -s "$OUT_DIR/eval_permute_report.json" ]; then
+        BACKUP_PATH="${OUT_DIR}/eval_permute_report.$(date +%Y%m%d-%H%M%S).json"
+        if [ ! -f "$BACKUP_PATH" ]; then
+            cp "$OUT_DIR/eval_permute_report.json" "$BACKUP_PATH" || { log "Error: Failed to backup eval report to $BACKUP_PATH"; exit 1; }
+            log "Backed up existing eval report to $BACKUP_PATH"
+        fi
+    fi
+
+    EVAL_ARGS=(
+        --perm-output "$PERM_OUTPUT"
+        --m-annot "$ANNOT_DIR/M.bed6"
+        --g-annot "$ANNOT_DIR/G.bed6"
+        --df "$DF"
         --out-dir "$OUT_DIR"
+    )
+
+    if [ -n "$N_NULL_PAIRS" ]; then
+        EVAL_ARGS+=( --n-null-pairs "$N_NULL_PAIRS" )
+    fi
+
+    python3 -u tools/eval_permute.py "${EVAL_ARGS[@]}"
 
     log "Finished eval_permute. Report at $OUT_DIR/eval_permute_report.json"
 fi
@@ -492,6 +528,64 @@ if [ $EXECUTE -eq 1 ]; then
     else
         mkdir -p "$PERMUTE_PLOTS_DIR"
 
+        # Resolve TOTAL_TESTS for fdr_permute
+        MLR_LOG="mlr_run_${DATASET}.log"
+        TOTAL_TESTS_SOURCE=""
+        if [ -n "$TOTAL_TESTS" ]; then
+            if [ -f "$MLR_LOG" ]; then
+                LOG_TOTAL=$(grep -o 'TOTAL_TESTS=[0-9]*' "$MLR_LOG" | tail -n 1 | cut -d= -f2 || true)
+                if [ -n "$LOG_TOTAL" ] && [ "$LOG_TOTAL" != "$TOTAL_TESTS" ]; then
+                    log "Error: --total-tests ($TOTAL_TESTS) disagrees with TOTAL_TESTS=$LOG_TOTAL in $MLR_LOG."
+                    log "  fdr_permute must share fdr_est's denominator. Refusing to proceed."
+                    exit 1
+                fi
+                TOTAL_TESTS_SOURCE="--total-tests (cross-checked against mlr_run_${DATASET}.log)"
+            else
+                TOTAL_TESTS_SOURCE="--total-tests (no mapping log present)"
+            fi
+        else
+            if [ -f "$MLR_LOG" ]; then
+                LOG_TOTAL=$(grep -o 'TOTAL_TESTS=[0-9]*' "$MLR_LOG" | tail -n 1 | cut -d= -f2 || true)
+                if [ -n "$LOG_TOTAL" ]; then
+                    TOTAL_TESTS="$LOG_TOTAL"
+                    TOTAL_TESTS_SOURCE="derived from mlr_run_${DATASET}.log"
+                else
+                    log "Error: Could not resolve TOTAL_TESTS. --total-tests was absent, and $MLR_LOG yielded no value."
+                    log "  --total-tests may be supplied explicitly."
+                    exit 1
+                fi
+            else
+                log "Error: Could not resolve TOTAL_TESTS. --total-tests was absent, and $MLR_LOG is missing."
+                log "  --total-tests may be supplied explicitly."
+                exit 1
+            fi
+        fi
+
+        # Extract GENES_EVAL and LOCI_EVAL
+        if [ -f "$MLR_LOG" ]; then
+            GENES_EVAL=$(grep -o 'Genes evaluated: [0-9]*' "$MLR_LOG" | tail -n 1 | grep -o '[0-9]*' || true)
+            LOCI_EVAL=$(grep -o 'Methylation loci evaluated: [0-9]*' "$MLR_LOG" | tail -n 1 | grep -o '[0-9]*' || true)
+            LOG_MTIME=$(date -r "$MLR_LOG" || echo "n/a")
+        else
+            GENES_EVAL=""
+            LOCI_EVAL=""
+            LOG_MTIME="n/a"
+        fi
+
+        if [ -z "$GENES_EVAL" ] || [ -z "$LOCI_EVAL" ]; then
+            GRID_DIMS="unavailable"
+            log "      (Dimension validation will be skipped; GENES_EVAL or LOCI_EVAL could not be extracted)"
+        else
+            GRID_DIMS="${GENES_EVAL} genes x ${LOCI_EVAL} loci"
+        fi
+
+        log "[5/5] BH denominator resolution:"
+        log "        TOTAL_TESTS = $TOTAL_TESTS"
+        log "        source      = $TOTAL_TESTS_SOURCE"
+        log "        log mtime   = $LOG_MTIME"
+        log "        grid dims   = $GRID_DIMS"
+        log "        cis default = $CIS_ENRICH_DEFAULTED"
+
         for TARGET in "${OUT_DIR}/summarized.parquet" "${OUT_DIR}/bootstrap_merged.parquet"; do
             TARGET_NAME="$(basename "$TARGET")"
 
@@ -518,24 +612,11 @@ if [ $EXECUTE -eq 1 ]; then
                 exit 1
             fi
 
-            if [ -z "$TOTAL_TESTS" ]; then
-                log "Error: --total-tests is required to annotate $TARGET_NAME."
-                log "  It is the BH denominator and must be the MAPPING GRID size -- the same"
-                log "  TOTAL_TESTS pipeline.sh used at stage 7 of 9 for fdr_est. It is NOT the permute"
-                log "  run's tecpg_perm_n_reported."
-                exit 1
-            fi
-
-            # Cross-check against the mapping log when present (mirrors pipeline.sh).
-            MLR_LOG="mlr_run_${DATASET}.log"
-            if [ -f "$MLR_LOG" ]; then
-                LOG_TOTAL=$(grep -o 'TOTAL_TESTS=[0-9]*' "$MLR_LOG" | tail -n 1 | cut -d= -f2 || true)
-                if [ -n "$LOG_TOTAL" ] && [ "$LOG_TOTAL" != "$TOTAL_TESTS" ]; then
-                    log "Error: --total-tests ($TOTAL_TESTS) disagrees with TOTAL_TESTS=$LOG_TOTAL in $MLR_LOG."
-                    log "  fdr_permute must share fdr_est's denominator. Refusing to proceed."
-                    exit 1
-                fi
-            fi
+            # Check catalog grid (validation)
+            GRID_ARGS=(--catalog "$TARGET")
+            if [ -n "$GENES_EVAL" ]; then GRID_ARGS+=(--max-genes "$GENES_EVAL"); fi
+            if [ -n "$LOCI_EVAL" ]; then GRID_ARGS+=(--max-loci "$LOCI_EVAL"); fi
+            python3 tools/check_catalog_grid.py "${GRID_ARGS[@]}"
 
             ANNOT_TMP="${TARGET%.parquet}.p_permute.tmp.parquet"
             FINAL_OUT="${TARGET%.parquet}.permute.parquet"

--- a/pipelinePost.sh
+++ b/pipelinePost.sh
@@ -21,6 +21,8 @@ NETWORK_DIR="${OUT_DIR}/network"
 ENRICHMENT_DIR="${OUT_DIR}/enrichment"
 PARQUET_FILE="${OUT_DIR}/bootstrap_merged.parquet"
 SUMMARIZED_PARQUET="${OUT_DIR}/summarized.parquet"
+CONCORDANCE_PARQUET="${OUT_DIR}/bootstrap_concordance.parquet"
+CONCORDANCE_SUMMARY="${OUT_DIR}/bootstrap_concordance_summary.json"
 
 # Network export filtering defaults
 NETWORK_TOP_K=5000
@@ -40,7 +42,7 @@ fi
 mkdir -p "$PLOTS_DIR" "$NETWORK_DIR" "$ENRICHMENT_DIR"
 
 # Stage 1: Obtain cytoBand.txt if missing
-log "[1/7] Checking for cytoBand.txt..."
+log "[1/8] Checking for cytoBand.txt..."
 if [ ! -f "cytoBand.txt" ]; then
     log "cytoBand.txt not found. Downloading from UCSC..."
     curl -O http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/cytoBand.txt.gz
@@ -51,15 +53,15 @@ else
 fi
 
 # Stage 2: Run plotCircos.py
-log "[2/7] Running plotCircos.py..."
+log "[2/8] Running plotCircos.py..."
 python3 -u tools/plotCircos.py -i "$PARQUET_FILE" --cytoband cytoBand.txt --out-dir "$PLOTS_DIR"
 
 # Stage 3: Run visualizeFindings.py
-log "[3/7] Running visualizeFindings.py..."
+log "[3/8] Running visualizeFindings.py..."
 python3 -u tools/visualizeFindings.py --all -m "$DATA_DIR/M.csv" -g "$DATA_DIR/G.csv" -c "$DATA_DIR/C.csv" "$PARQUET_FILE" --out-dir "$PLOTS_DIR"
 
 # Stage 4: Run exportBipartiteNetwork.py to generate cytoscape nodes/edges
-log "[4/7] Generating Cytoscape network files..."
+log "[4/8] Generating Cytoscape network files..."
 python3 -u tools/exportBipartiteNetwork.py \
     -i "$PARQUET_FILE" \
     -o cytoscape \
@@ -68,17 +70,27 @@ python3 -u tools/exportBipartiteNetwork.py \
     --max-boot-p "$NETWORK_MAX_BOOT_P"
 
 # Stage 5: Run visualizeBipartiteNetwork.py
-log "[5/7] Running visualizeBipartiteNetwork.py..."
+log "[5/8] Running visualizeBipartiteNetwork.py..."
 python3 -u tools/visualizeBipartiteNetwork.py --edges "$NETWORK_DIR/cytoscape_edges.csv" --nodes "$NETWORK_DIR/cytoscape_nodes.csv" --out-dir "$NETWORK_DIR"
 # Stage 6: Run evaluateSaliency.py
-log "[6/7] Running evaluateSaliency.py..."
+log "[6/8] Running evaluateSaliency.py..."
 python3 -u tools/evaluateSaliency.py -i "$PARQUET_FILE" -o "$PLOTS_DIR"
 
-# Stage 7: Run runEnrichment.py for functional (and optional ENCODE) enrichment.
+# Stage 7: Score bootstrap/analytic concordance. This annotates raw scores and
+# reports their observed distribution; it sets no thresholds and filters nothing.
+# The output is a separate parquet, so bootstrap_merged.parquet is unchanged and
+# every existing consumer is unaffected.
+log "[7/8] Scoring bootstrap/analytic concordance..."
+python3 -u tools/annotate_bootstrap_concordance.py \
+    -i "$PARQUET_FILE" \
+    -o "$CONCORDANCE_PARQUET" \
+    -s "$CONCORDANCE_SUMMARY"
+
+# Stage 8: Run runEnrichment.py for functional (and optional ENCODE) enrichment.
 # This analysis was previously bundled into tools/summarizeOutput_parquet.py and is
 # now a standalone tool. It draws significant genes from the FDR summary
 # (summarized.parquet) and from the bootstrap IG ranking (bootstrap_merged.parquet).
-log "[7/7] Running functional enrichment analysis..."
+log "[8/8] Running functional enrichment analysis..."
 python3 -u tools/runEnrichment.py \
     --fdr-input "$SUMMARIZED_PARQUET" \
     --ig-input "$PARQUET_FILE" \

--- a/tecpg/__init__.py
+++ b/tecpg/__init__.py
@@ -1,1 +1,1 @@
-__version__ = '2.0.0b2.dev57'
+__version__ = '2.0.0b2.dev58'

--- a/tests/test_bootstrap_concordance_scores.py
+++ b/tests/test_bootstrap_concordance_scores.py
@@ -1,0 +1,209 @@
+"""Guards for tools/annotate_bootstrap_concordance.py.
+
+The tool adds four raw bootstrap-vs-analytic scores and summarizes their
+distributions. It sets no thresholds, raises no flags, and removes no rows;
+these tests pin that scope as much as they pin the arithmetic.
+"""
+import json
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from scipy import stats
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TOOL = os.path.join(REPO_ROOT, "tools", "annotate_bootstrap_concordance.py")
+
+SCORE_COLUMNS = [
+    "boot_se_ratio",
+    "boot_bias_ratio",
+    "boot_ci_skew",
+    "boot_p_floor_gap",
+]
+
+N_ROWS = 60
+N_BOOTSTRAPPED = 40
+
+# Row indices carrying deliberate edge cases, and the score each one nulls.
+EDGE_CASES = {
+    1: "boot_se_ratio",      # mt_err == 0
+    2: "boot_bias_ratio",    # mt_est_boot_std == 0
+    3: "boot_ci_skew",       # zero-width CI
+    4: "boot_p_floor_gap",   # p_boot == 0
+}
+
+
+def _write_fixture(path):
+    rng = np.random.default_rng(3)
+    n = N_ROWS
+
+    mt_est = rng.normal(0.3, 0.1, n)
+    mt_err = np.abs(rng.normal(0.05, 0.01, n))
+    mt_t = mt_est / mt_err
+    regions = rng.choice(["TRANS", "CIS5", "PROMOTER", "GENEBODY"], n)
+
+    b_std = mt_err * rng.normal(1.0, 0.06, n)
+    b_std[5] = mt_err[5] * 1.9                       # inflated bootstrap SE
+    b_mean = mt_est + b_std * rng.normal(0, 0.02, n)
+    ci_low = mt_est - 1.96 * b_std
+    ci_high = mt_est + 1.96 * b_std
+    ci_high[7] += 3 * b_std[7]                       # skewed CI
+    p_boot = np.maximum(2 * stats.norm.sf(np.abs(mt_t)), 1e-3)
+    p_boot[9] = 0.02                                 # off the floor
+
+    for arr in (b_std, b_mean, ci_low, ci_high, p_boot):
+        arr[N_BOOTSTRAPPED:] = np.nan                # not bootstrapped
+
+    mt_err[1] = 0.0
+    b_std[2] = 0.0
+    ci_low[3] = ci_high[3] = mt_est[3]
+    p_boot[4] = 0.0
+    mt_t[6] = 60.0                                   # 2*sf(|t|) underflows
+
+    df = pd.DataFrame({
+        "mt_id": [f"cg{i:04d}" for i in range(n)],
+        "gt_id": [f"G{i % 7}" for i in range(n)],
+        "region": regions,
+        "mt_est": mt_est, "mt_err": mt_err, "mt_t": mt_t,
+        "precise_mt_p": 2 * stats.t.sf(np.abs(mt_t), 321),
+        "mt_est_boot_mean": b_mean, "mt_est_boot_std": b_std,
+        "ci_low": ci_low, "ci_high": ci_high, "p_boot": p_boot,
+        "degenerate_resamples": np.where(np.isnan(b_std), np.nan, 0.0),
+    })
+    pq.write_table(pa.Table.from_pandas(df), path)
+    return df
+
+
+def _run(inp, out, summary=None, extra=None, expect_ok=True):
+    cmd = [sys.executable, TOOL, "-i", str(inp), "-o", str(out), "--chunk-size", "25"]
+    if summary:
+        cmd += ["-s", str(summary)]
+    if extra:
+        cmd += extra
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if expect_ok:
+        assert proc.returncode == 0, f"tool failed:\n{proc.stdout}\n{proc.stderr}"
+    return proc
+
+
+@pytest.fixture
+def scored(tmp_path):
+    inp = tmp_path / "boot.parquet"
+    out = tmp_path / "scored.parquet"
+    summary = tmp_path / "summary.json"
+    src = _write_fixture(inp)
+    proc = _run(inp, out, summary)
+    return src, pq.read_table(out).to_pandas(), json.loads(summary.read_text()), proc.stdout
+
+
+def test_scores_are_additive_and_no_rows_lost(scored):
+    """Load-bearing scope guard: annotate only. Every input row and column survives."""
+    src, out, _, _ = scored
+    assert len(out) == len(src) == N_ROWS
+    for col in src.columns:
+        assert col in out.columns, f"input column {col} was dropped"
+    for col in SCORE_COLUMNS:
+        assert col in out.columns
+    assert list(out["mt_id"]) == list(src["mt_id"])
+
+
+def test_se_ratio_matches_hand_computation(scored):
+    """boot_se_ratio == mt_est_boot_std / mt_err on a row with no edge case."""
+    src, out, _, _ = scored
+    i = 10
+    expected = src["mt_est_boot_std"][i] / src["mt_err"][i]
+    assert out["boot_se_ratio"][i] == pytest.approx(expected, rel=1e-12)
+
+
+def test_ci_skew_matches_hand_computation(scored):
+    """boot_ci_skew is the normalized asymmetry of the bootstrap CI about mt_est."""
+    src, out, _, _ = scored
+    i = 7
+    hi, lo, est = src["ci_high"][i], src["ci_low"][i], src["mt_est"][i]
+    expected = ((hi - est) - (est - lo)) / (hi - lo)
+    assert out["boot_ci_skew"][i] == pytest.approx(expected, rel=1e-12)
+    assert out["boot_ci_skew"][i] > 0.4          # the injected skew is visible
+
+
+def test_scores_null_where_bootstrap_did_not_run(scored):
+    """Coverage must match p_boot's: null outside the bootstrapped block."""
+    _, out, _, _ = scored
+    for col in SCORE_COLUMNS:
+        assert out[col][N_BOOTSTRAPPED:].isna().all(), f"{col} populated without a bootstrap"
+
+
+def test_edge_cases_yield_null_not_inf(scored):
+    """Zero denominators and non-positive p_boot must produce NaN, never inf."""
+    _, out, _, _ = scored
+    for row, col in EDGE_CASES.items():
+        v = out[col][row]
+        assert not np.isfinite(v), f"{col} row {row} should be null, got {v}"
+    for col in SCORE_COLUMNS:
+        vals = out[col].to_numpy(dtype=np.float64)
+        assert not np.isinf(vals).any(), f"{col} contains inf"
+
+
+def test_large_t_does_not_underflow(scored):
+    """boot_p_floor_gap uses logsf, so |t|=60 stays finite where 2*sf would be 0."""
+    _, out, _, _ = scored
+    assert np.isfinite(out["boot_p_floor_gap"][6])
+    assert 2 * stats.norm.sf(60.0) == 0.0        # the naive form really does underflow
+
+
+def test_summary_reports_raw_distribution_not_cutpoints(scored):
+    """The summary must carry observed percentiles and no threshold vocabulary."""
+    _, _, summary, stdout = scored
+    assert summary["total_rows"] == N_ROWS
+    assert summary["n_bootstrapped"] == N_BOOTSTRAPPED
+    for col in SCORE_COLUMNS:
+        s = summary["scores"][col]
+        assert s is not None and s["n_finite"] > 0
+        for p in ("1", "5", "25", "50", "75", "95", "99"):
+            assert p in s["percentiles"]
+    # Structural scope guard: the summary may *say* it applies no thresholds, but
+    # it must not carry a field that encodes one. Check keys, not prose values.
+    def _keys(obj):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                yield k
+                yield from _keys(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                yield from _keys(v)
+
+    banned = ("threshold", "flag", "cutoff", "cut_point", "status", "badge",
+              "verdict", "outlier", "problematic")
+    for key in _keys(summary):
+        low = key.lower()
+        for word in banned:
+            assert word not in low, f"summary carries a decision field: {key!r}"
+
+
+def test_existing_score_column_fails_closed(tmp_path):
+    """Additive-writes-only: refuse to overwrite a score column that already exists."""
+    inp = tmp_path / "boot.parquet"
+    _write_fixture(inp)
+    df = pq.read_table(inp).to_pandas()
+    df["boot_se_ratio"] = 1.0
+    pq.write_table(pa.Table.from_pandas(df), inp)
+    proc = _run(inp, tmp_path / "out.parquet", expect_ok=False)
+    assert proc.returncode == 1
+    assert "additive" in proc.stderr.lower()
+    assert not (tmp_path / "out.parquet").exists()
+
+
+def test_missing_required_column_fails_closed(tmp_path):
+    """A missing bootstrap input must abort, not silently produce all-null scores."""
+    inp = tmp_path / "boot.parquet"
+    _write_fixture(inp)
+    df = pq.read_table(inp).to_pandas().drop(columns=["mt_err"])
+    pq.write_table(pa.Table.from_pandas(df), inp)
+    proc = _run(inp, tmp_path / "out.parquet", expect_ok=False)
+    assert proc.returncode == 1
+    assert "mt_err" in proc.stderr
+    assert not (tmp_path / "out.parquet").exists()

--- a/tests/test_check_catalog_grid.py
+++ b/tests/test_check_catalog_grid.py
@@ -1,0 +1,82 @@
+import pytest
+import subprocess
+import os
+
+# Local helper, isolated import
+def _write_mock_catalog(path, data_dict):
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+    table = pa.table(data_dict)
+    pq.write_table(table, path)
+
+@pytest.fixture
+def catalog_path(tmp_path):
+    path = str(tmp_path / "mock_catalog.parquet")
+    _write_mock_catalog(path, {
+        "gt_id": ["g1", "g2", "g1", "g3"],  # 3 distinct
+        "mt_id": ["m1", "m2", "m3", "m4"]   # 4 distinct
+    })
+    return path
+
+@pytest.fixture
+def custom_catalog_path(tmp_path):
+    path = str(tmp_path / "custom_catalog.parquet")
+    _write_mock_catalog(path, {
+        "custom_g": ["g1", "g2", "g3", "g4", "g5"],  # 5 distinct
+        "custom_m": ["m1", "m1", "m2", "m2", "m3"]   # 3 distinct
+    })
+    return path
+
+def _run_tool(*args):
+    cmd = ["python3", "tools/check_catalog_grid.py"] + list(args)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result
+
+def test_within_bounds_exits_zero(catalog_path):
+    res = _run_tool("--catalog", catalog_path, "--max-genes", "10", "--max-loci", "10")
+    assert res.returncode == 0
+    assert "catalog grid: 4 rows, 3 distinct gt_id, 4 distinct mt_id" in res.stdout
+
+def test_genes_exceed_bound_fails_closed(catalog_path):
+    res = _run_tool("--catalog", catalog_path, "--max-genes", "2", "--max-loci", "10")
+    assert res.returncode == 1
+    assert "gt_id" in res.stderr
+    assert "(3)" in res.stderr
+    assert "(2)" in res.stderr
+
+def test_loci_exceed_bound_fails_closed(catalog_path):
+    res = _run_tool("--catalog", catalog_path, "--max-genes", "10", "--max-loci", "2")
+    assert res.returncode == 1
+    assert "mt_id" in res.stderr
+    assert "(4)" in res.stderr
+    assert "(2)" in res.stderr
+
+def test_counts_equal_to_bound_pass(catalog_path):
+    res = _run_tool("--catalog", catalog_path, "--max-genes", "3", "--max-loci", "4")
+    assert res.returncode == 0
+
+def test_omitted_bounds_skip_validation(catalog_path):
+    res = _run_tool("--catalog", catalog_path)
+    assert res.returncode == 0
+
+def test_only_gene_bound_given_checks_only_genes(catalog_path):
+    res = _run_tool("--catalog", catalog_path, "--max-genes", "5")
+    assert res.returncode == 0
+
+def test_missing_column_fails_closed(catalog_path):
+    res = _run_tool("--catalog", catalog_path, "--gene-column", "missing_gene")
+    assert res.returncode == 1
+    assert "missing_gene" in res.stderr
+    assert "gt_id" in res.stderr
+    assert "mt_id" in res.stderr
+
+def test_custom_column_names_are_honoured(custom_catalog_path):
+    res = _run_tool("--catalog", custom_catalog_path, "--gene-column", "custom_g", "--locus-column", "custom_m", "--max-genes", "10", "--max-loci", "10")
+    assert res.returncode == 0
+    assert "5 distinct custom_g" in res.stdout
+    assert "3 distinct custom_m" in res.stdout
+
+def test_summary_line_reports_actual_counts(catalog_path):
+    res = _run_tool("--catalog", catalog_path)
+    assert res.returncode == 0
+    assert "catalog grid: 4 rows, 3 distinct gt_id, 4 distinct mt_id" in res.stdout

--- a/tests/test_map_p_threshold_explicit.py
+++ b/tests/test_map_p_threshold_explicit.py
@@ -1,0 +1,106 @@
+"""Guards for D2: the mapper p-threshold is explicit in pipeline.sh.
+
+`tecpg run mlr` gates the catalog at `-p` (default 0.001) before anything else
+runs. pipeline.sh previously relied on that CLI default implicitly, so the
+catalog's inclusion rule never appeared in the run log and could shift silently
+if the CLI default changed. These tests pin the value, its wiring into the Stage
+3 invocation, and its agreement with the CLI default.
+"""
+import ast
+import os
+import re
+import subprocess
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PIPELINE_SH = os.path.join(REPO_ROOT, "pipeline.sh")
+CLI_PY = os.path.join(REPO_ROOT, "tecpg", "cli.py")
+
+
+def _pipeline_text():
+    with open(PIPELINE_SH, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _shell_var(name, text):
+    """Return the value of a top-level `NAME="value"` assignment."""
+    m = re.search(rf'^{name}="([^"]*)"\s*$', text, re.MULTILINE)
+    assert m, f"{name} is not assigned in pipeline.sh"
+    return m.group(1)
+
+
+def _cli_mlr_p_default():
+    """The -p/--p-thresh default on `run mlr`, read from source without importing torch.
+
+    tecpg/cli.py declares -p twice: once on `mlr` and once on `mlr-single`
+    (a different default). Walking to the FunctionDef named `mlr` disambiguates.
+    """
+    tree = ast.parse(open(CLI_PY, encoding="utf-8").read())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != "mlr":
+            continue
+        for dec in node.decorator_list:
+            if not (isinstance(dec, ast.Call)
+                    and getattr(dec.func, "attr", None) == "option"):
+                continue
+            flags = [a.value for a in dec.args if isinstance(a, ast.Constant)]
+            if "-p" not in flags and "--p-thresh" not in flags:
+                continue
+            for kw in dec.keywords:
+                if kw.arg == "default":
+                    return ast.literal_eval(kw.value)
+    raise AssertionError("could not locate the -p default on the `run mlr` command")
+
+
+def test_map_p_thresh_is_defined():
+    """pipeline.sh must define the threshold as a named variable."""
+    assert _shell_var("MAP_P_THRESH", _pipeline_text()) == "0.001"
+
+
+def test_map_p_thresh_matches_cli_default():
+    """Load-bearing guard: making the gate explicit must not change the gate.
+
+    If the CLI default and the pipeline value ever diverge, the catalog silently
+    changes size. This forces the divergence to be a deliberate, reviewed edit.
+    """
+    shell_value = float(_shell_var("MAP_P_THRESH", _pipeline_text()))
+    assert shell_value == _cli_mlr_p_default(), (
+        "pipeline.sh MAP_P_THRESH and the `run mlr` -p default disagree. "
+        "Making the mapper gate explicit was meant to be behaviour-preserving; "
+        "changing either value changes the catalog and every downstream count."
+    )
+
+
+def test_stage3_invocation_passes_the_threshold():
+    """The qr mapping call must actually receive -p, not merely define it."""
+    text = _pipeline_text()
+    m = re.search(r"^.*run mlr --mlr-method qr .*$", text, re.MULTILINE)
+    assert m, "could not find the Stage 3 `run mlr --mlr-method qr` invocation"
+    invocation = m.group(0)
+    assert '-p "$MAP_P_THRESH"' in invocation, (
+        f"Stage 3 does not pass -p; invocation was:\n{invocation}"
+    )
+
+
+def test_threshold_is_logged():
+    """The value must reach the run log so it is citable in methods."""
+    text = _pipeline_text()
+    log_lines = [ln for ln in text.splitlines()
+                 if ln.strip().startswith("log ") and "MAP_P_THRESH" in ln]
+    assert log_lines, "no log line emits MAP_P_THRESH"
+
+
+def test_bootstrap_invocation_does_not_pass_the_threshold():
+    """qr_bootstrap ignores p_thresh; passing it there would imply otherwise."""
+    text = _pipeline_text()
+    m = re.search(r"^.*run mlr --mlr-method qr_bootstrap .*$", text, re.MULTILINE)
+    assert m, "could not find the Stage 9 `run mlr --mlr-method qr_bootstrap` invocation"
+    assert "MAP_P_THRESH" not in m.group(0)
+
+
+def test_pipeline_sh_is_valid_bash():
+    """Quoting errors in the edited invocation must not reach a production run."""
+    proc = subprocess.run(["bash", "-n", PIPELINE_SH],
+                          capture_output=True, text=True)
+    assert proc.returncode == 0, f"bash -n failed:\n{proc.stderr}"

--- a/tests/test_region_annotation_no_pvalue_filter.py
+++ b/tests/test_region_annotation_no_pvalue_filter.py
@@ -1,0 +1,98 @@
+"""Guards for D1: assignRegionToEcpg_parquet.py annotates, it never filters on p.
+
+The module formerly carried `PVALCUTOFF = np.float32(1e-6)` and logged it as
+"Using default p-value cutoff", but no code path ever compared against it. These
+tests pin the real behaviour (every input row is emitted) and prevent the dead
+constant and its misleading log line from returning.
+"""
+import os
+import subprocess
+import sys
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TOOL = os.path.join(REPO_ROOT, "tools", "assignRegionToEcpg_parquet.py")
+
+# Straddles the former 1e-6 cutoff: one row below, two rows above.
+FIXTURE_PVALUES = {
+    "cgSTRONG": 2.29e-14,   # below 1e-6 -> would have survived a live filter
+    "cgWEAK": 7.87e-05,     # above 1e-6 -> would have been dropped
+    "cgNULLISH": 4.63e-02,  # above 1e-6 -> would have been dropped
+}
+
+
+@pytest.fixture
+def annotated_run(tmp_path):
+    """Run the annotator on a 3-row fixture and return (stdout+stderr, output df)."""
+    gene_bed = tmp_path / "G.bed6"
+    gene_bed.write_text("chr1\t100000\t120000\tGENE1\t0\t+\n")
+
+    meth_bed = tmp_path / "M.bed6"
+    meth_bed.write_text(
+        "chr1\t110000\t110001\tcgSTRONG\t0\t+\n"
+        "chr1\t110500\t110501\tcgWEAK\t0\t+\n"
+        "chr1\t111000\t111001\tcgNULLISH\t0\t+\n"
+    )
+
+    in_parquet = tmp_path / "in.parquet"
+    df = pd.DataFrame(
+        {
+            "mt_id": list(FIXTURE_PVALUES),
+            "gt_id": ["GENE1"] * 3,
+            "mt_est": [0.5, 0.3, 0.1],
+            "mt_t": [8.0, 4.0, 2.0],
+            "mt_p": [1e-14, 7.9e-5, 4.6e-2],
+            "precise_mt_p": list(FIXTURE_PVALUES.values()),
+        }
+    )
+    pq.write_table(pa.Table.from_pandas(df), in_parquet)
+
+    out_parquet = tmp_path / "out.parquet"
+    proc = subprocess.run(
+        [sys.executable, TOOL,
+         "-d", str(in_parquet), "-g", str(gene_bed),
+         "-m", str(meth_bed), "-o", str(out_parquet)],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, f"annotator failed:\n{proc.stdout}\n{proc.stderr}"
+    return proc.stdout + proc.stderr, pq.read_table(out_parquet).to_pandas()
+
+
+def test_all_rows_survive_regardless_of_pvalue(annotated_run):
+    """Load-bearing guard: the annotator emits every row it is given.
+
+    Reinstating the p-value filter the deleted constant implied drops the two
+    rows above 1e-6 and turns this red.
+    """
+    _, out = annotated_run
+    assert len(out) == 3
+    assert set(out["mt_id"]) == set(FIXTURE_PVALUES)
+    # the two rows above the former cutoff are present and annotated
+    above = out[out["precise_mt_p"] > 1e-6]
+    assert len(above) == 2
+    assert above["region"].notna().all()
+
+
+def test_no_pvalue_exclusions_reported(annotated_run):
+    """The exclusion summary must report zero p-value exclusions."""
+    log, _ = annotated_run
+    assert "p-value filter: 0" in log
+
+
+def test_module_exposes_no_pvalcutoff_symbol():
+    """The dead constant must not return."""
+    import tools.assignRegionToEcpg_parquet as A
+    assert not hasattr(A, "PVALCUTOFF"), (
+        "PVALCUTOFF is back. The annotator does not filter on p; a constant "
+        "implying otherwise is misleading (see docs/ecpg-filtering-prioritization.md D1)."
+    )
+
+
+def test_no_cutoff_log_line(annotated_run):
+    """The misleading 'Using default p-value cutoff' line must not return."""
+    log, _ = annotated_run
+    assert "p-value cutoff" not in log

--- a/tools/annotate_bootstrap_concordance.py
+++ b/tools/annotate_bootstrap_concordance.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Adds raw bootstrap-vs-analytic concordance scores to a bootstrapped catalog.
+
+Every score is a deterministic function of columns already present on
+bootstrap_merged.parquet. No thresholds, flags, or filters are applied and no
+row is removed: this tool scores and summarizes so that a threshold decision can
+be made later from measured distributions rather than assumed ones.
+
+Scores are null wherever the bootstrap did not run, matching p_boot's coverage.
+"""
+import argparse
+import json
+import os
+import sys
+import traceback
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from scipy import stats
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import eval_permute as E  # noqa: E402
+
+SCORE_COLUMNS = [
+    'boot_se_ratio',
+    'boot_bias_ratio',
+    'boot_ci_skew',
+    'boot_p_floor_gap',
+]
+
+REQUIRED_INPUTS = [
+    'mt_est', 'mt_err', 'mt_t',
+    'mt_est_boot_mean', 'mt_est_boot_std',
+    'ci_low', 'ci_high', 'p_boot',
+]
+
+PERCENTILES = [1, 5, 25, 50, 75, 95, 99]
+
+LOG10 = np.log(10.0)
+
+
+def _safe_divide(num, den):
+    """Element-wise division yielding NaN (never inf) on a zero or non-finite denominator."""
+    num = np.asarray(num, dtype=np.float64)
+    den = np.asarray(den, dtype=np.float64)
+    out = np.full(num.shape, np.nan, dtype=np.float64)
+    ok = np.isfinite(num) & np.isfinite(den) & (den != 0)
+    out[ok] = num[ok] / den[ok]
+    return out
+
+
+def compute_scores(df):
+    """Return a dict of the four raw score arrays for one chunk."""
+    mt_est = df['mt_est'].to_numpy(dtype=np.float64)
+    mt_err = df['mt_err'].to_numpy(dtype=np.float64)
+    mt_t = df['mt_t'].to_numpy(dtype=np.float64)
+    b_mean = df['mt_est_boot_mean'].to_numpy(dtype=np.float64)
+    b_std = df['mt_est_boot_std'].to_numpy(dtype=np.float64)
+    ci_low = df['ci_low'].to_numpy(dtype=np.float64)
+    ci_high = df['ci_high'].to_numpy(dtype=np.float64)
+    p_boot = df['p_boot'].to_numpy(dtype=np.float64)
+
+    se_ratio = _safe_divide(b_std, mt_err)
+    bias_ratio = _safe_divide(b_mean - mt_est, b_std)
+
+    width = ci_high - ci_low
+    skew = _safe_divide((ci_high - mt_est) - (mt_est - ci_low), width)
+
+    # log10 of the normal-implied two-sided sign-instability probability,
+    # via logsf so it stays finite for large |t| where 2*sf underflows.
+    with np.errstate(invalid='ignore'):
+        implied_log10 = (np.log(2.0) + stats.norm.logsf(np.abs(mt_t))) / LOG10
+    observed_log10 = np.full(p_boot.shape, np.nan, dtype=np.float64)
+    ok = np.isfinite(p_boot) & (p_boot > 0)
+    observed_log10[ok] = np.log10(p_boot[ok])
+    floor_gap = observed_log10 - implied_log10
+    floor_gap[~np.isfinite(floor_gap)] = np.nan
+
+    return {
+        'boot_se_ratio': se_ratio,
+        'boot_bias_ratio': bias_ratio,
+        'boot_ci_skew': skew,
+        'boot_p_floor_gap': floor_gap,
+    }
+
+
+class Accumulator:
+    """Collects finite score values so raw percentiles can be reported."""
+
+    def __init__(self, reservoir_cap):
+        self.cap = reservoir_cap
+        self.values = {c: [] for c in SCORE_COLUMNS}
+        self.n_finite = {c: 0 for c in SCORE_COLUMNS}
+        self.n_kept = {c: 0 for c in SCORE_COLUMNS}
+        self.rng = np.random.default_rng(0)
+
+    def add(self, col, arr):
+        finite = arr[np.isfinite(arr)]
+        self.n_finite[col] += finite.size
+        if finite.size == 0:
+            return
+        room = self.cap - self.n_kept[col]
+        if room <= 0:
+            return
+        take = finite if finite.size <= room else self.rng.choice(finite, room, replace=False)
+        self.values[col].append(np.asarray(take, dtype=np.float64))
+        self.n_kept[col] += take.size
+
+    def summary(self, col):
+        if not self.values[col]:
+            return None
+        v = np.concatenate(self.values[col])
+        pct = np.percentile(v, PERCENTILES)
+        med = float(np.median(v))
+        mad = float(np.median(np.abs(v - med)))
+        return {
+            'n_finite': int(self.n_finite[col]),
+            'n_used_for_percentiles': int(v.size),
+            'truncated': bool(self.n_finite[col] > self.n_kept[col]),
+            'min': float(v.min()),
+            'max': float(v.max()),
+            'median': med,
+            'mad': mad,
+            'percentiles': {str(p): float(q) for p, q in zip(PERCENTILES, pct)},
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Adds raw bootstrap-vs-analytic concordance scores. No thresholds are applied."
+    )
+    parser.add_argument('-i', '--input', required=True, help="Bootstrapped catalog parquet")
+    parser.add_argument('-o', '--output', required=True, help="Output parquet path")
+    parser.add_argument('-s', '--summary-json', default=None,
+                        help="Optional path for the machine-readable distribution summary")
+    parser.add_argument('--chunk-size', type=int, default=100000, help="Rows per batch (default: 100000)")
+    parser.add_argument('--percentile-reservoir', type=int, default=2000000,
+                        help="Max finite values retained per score for percentiles (default: 2000000)")
+    args = parser.parse_args()
+
+    parquet_file = pq.ParquetFile(args.input)
+    col_names = parquet_file.schema.names
+
+    missing = [c for c in REQUIRED_INPUTS if c not in col_names]
+    if missing:
+        print(f"Fail-closed: required column(s) absent from input: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
+
+    collisions = [c for c in SCORE_COLUMNS if c in col_names]
+    if collisions:
+        print(f"Fail-closed: score column(s) already present in input: {', '.join(collisions)}. "
+              "Writes must be additive.", file=sys.stderr)
+        sys.exit(1)
+
+    has_region = 'region' in col_names
+
+    writer = None
+    explicit_schema = None
+    acc = Accumulator(args.percentile_reservoir)
+    region_acc = {}
+    total_rows = 0
+    n_bootstrapped = 0
+
+    try:
+        for batch in parquet_file.iter_batches(batch_size=args.chunk_size):
+            df_chunk = batch.to_pandas()
+            if df_chunk.index.names != [None]:
+                df_chunk = df_chunk.reset_index()
+
+            scores = compute_scores(df_chunk)
+            for c in SCORE_COLUMNS:
+                df_chunk[c] = scores[c]
+                acc.add(c, scores[c])
+
+            total_rows += len(df_chunk)
+            n_bootstrapped += int(np.isfinite(
+                df_chunk['mt_est_boot_std'].to_numpy(dtype=np.float64)).sum())
+
+            if has_region:
+                region_series = df_chunk['region']
+                for r in region_series.dropna().unique():
+                    if r not in E.CANONICAL_REGIONS:
+                        continue
+                    m = (region_series == r).to_numpy()
+                    d = region_acc.setdefault(r, {'n_rows': 0, 'n_scored': 0})
+                    d['n_rows'] += int(m.sum())
+                    d['n_scored'] += int(np.isfinite(scores['boot_se_ratio'][m]).sum())
+
+            for c in ('mt_chromStart', 'gt_chromStart', 'mt_chromEnd', 'gt_chromEnd'):
+                if c in df_chunk.columns:
+                    df_chunk[c] = pd.to_numeric(df_chunk[c], errors='coerce').astype('Int64')
+
+            table = pa.Table.from_pandas(df_chunk, preserve_index=False)
+            if writer is None:
+                explicit_schema = table.schema
+                writer = pq.ParquetWriter(args.output + '.tmp', explicit_schema)
+            else:
+                table = table.cast(explicit_schema)
+            writer.write_table(table)
+
+    except Exception as e:
+        print(f"Error processing parquet: {e}", file=sys.stderr)
+        traceback.print_exc(file=sys.stderr)
+        if writer is not None:
+            writer.close()
+            writer = None
+        if os.path.exists(args.output + '.tmp'):
+            try:
+                os.remove(args.output + '.tmp')
+            except OSError:
+                pass
+        sys.exit(1)
+    finally:
+        if writer is not None:
+            writer.close()
+
+    if total_rows == 0:
+        if os.path.exists(args.output + '.tmp'):
+            os.remove(args.output + '.tmp')
+        print("Fail-closed: input contains no rows.", file=sys.stderr)
+        sys.exit(1)
+
+    os.replace(args.output + '.tmp', args.output)
+
+    summary = {
+        'input': os.path.abspath(args.input),
+        'output': os.path.abspath(args.output),
+        'total_rows': int(total_rows),
+        'n_bootstrapped': int(n_bootstrapped),
+        'coverage_fraction': (float(n_bootstrapped) / total_rows) if total_rows else 0.0,
+        'scores': {c: acc.summary(c) for c in SCORE_COLUMNS},
+        'by_region': region_acc if has_region else None,
+        'note': ('Raw scores only. No thresholds, flags, or filters are applied; '
+                 'no rows are removed. Percentiles describe the observed distribution '
+                 'and are not cut points.'),
+    }
+
+    print("Provenance: wrote %s as raw scores; null where the bootstrap did not run. "
+          "No thresholds applied, no rows removed." % ', '.join(SCORE_COLUMNS))
+    print(f"Rows: {total_rows}  bootstrapped: {n_bootstrapped} "
+          f"({100.0 * summary['coverage_fraction']:.4f}%)")
+    print()
+    hdr = f"{'score':<19}{'n_finite':>12}{'median':>12}{'MAD':>12}"
+    hdr += ''.join(f"{'p' + str(p):>12}" for p in PERCENTILES)
+    print(hdr)
+    for c in SCORE_COLUMNS:
+        s = summary['scores'][c]
+        if s is None:
+            print(f"{c:<19}{0:>12}{'-':>12}{'-':>12}" + ''.join(f"{'-':>12}" for _ in PERCENTILES))
+            continue
+        row = f"{c:<19}{s['n_finite']:>12}{s['median']:>12.5g}{s['mad']:>12.5g}"
+        row += ''.join(f"{s['percentiles'][str(p)]:>12.5g}" for p in PERCENTILES)
+        print(row)
+
+    if has_region and region_acc:
+        print()
+        print(f"{'region':<11}{'n_rows':>12}{'n_scored':>12}")
+        for r in E.CANONICAL_REGIONS:
+            if r in region_acc:
+                d = region_acc[r]
+                print(f"{r:<11}{d['n_rows']:>12}{d['n_scored']:>12}")
+
+    if args.summary_json:
+        with open(args.summary_json, 'w') as f:
+            json.dump(summary, f, indent=2)
+        print(f"\nSummary written to {args.summary_json}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/assignRegionToEcpg_parquet.py
+++ b/tools/assignRegionToEcpg_parquet.py
@@ -14,10 +14,6 @@ import pandas as pd
 
 ## DEFAULTS - Kennedy et al. BMC Genomics (2018) 19:476
 
-#PVALCUTOFF=0.00001                   ## 10-5 is "suggestive" in Kennedy 2018
-#PVALCUTOFF=0.00000000001             ## 10-11 is "significant" in Kennedy 2018
-PVALCUTOFF = np.float32(0.000001)     ## 10-6 is our "exploratory" cutoff
-
 ## DISTAL >50Kb TSS
 DISTAL_OFFSET = 50000
 
@@ -599,7 +595,6 @@ def main():
         sys.exit(1)
 
     ## summarize the p-values
-    logger.info(f"[MAIN] Using default p-value cutoff of {PVALCUTOFF}")
     reportPvalues(ecpgDataFile, pval_col, chunk_size)
 
     ## Annotate the pairs

--- a/tools/check_catalog_grid.py
+++ b/tools/check_catalog_grid.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import sys
+import argparse
+import pyarrow.parquet as pq
+import pyarrow.compute as pc
+
+def main():
+    parser = argparse.ArgumentParser(description="Check catalog distinct feature counts against bounds.")
+    parser.add_argument('--catalog', required=True, help="Path to the parquet catalog to check.")
+    parser.add_argument('--max-genes', type=int, default=None, help="Upper bound on distinct gene count.")
+    parser.add_argument('--max-loci', type=int, default=None, help="Upper bound on distinct locus count.")
+    parser.add_argument('--gene-column', default='gt_id', help="Name of the gene column (default: gt_id).")
+    parser.add_argument('--locus-column', default='mt_id', help="Name of the locus column (default: mt_id).")
+    args = parser.parse_args()
+
+    try:
+        schema = pq.read_schema(args.catalog)
+    except Exception as e:
+        print(f"Error reading schema from {args.catalog}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    names = schema.names
+    if args.gene_column not in names:
+        print(f"Missing column '{args.gene_column}'. Available columns: {', '.join(names)}", file=sys.stderr)
+        sys.exit(1)
+    if args.locus_column not in names:
+        print(f"Missing column '{args.locus_column}'. Available columns: {', '.join(names)}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        # Read only the two required columns
+        table = pq.read_table(args.catalog, columns=[args.gene_column, args.locus_column])
+    except Exception as e:
+        print(f"Error reading table from {args.catalog}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    n_rows = table.num_rows
+
+    try:
+        u_genes = pc.count_distinct(table[args.gene_column]).as_py()
+        u_loci = pc.count_distinct(table[args.locus_column]).as_py()
+    except Exception as e:
+        print(f"Error computing distinct counts: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"catalog grid: {n_rows} rows, {u_genes} distinct {args.gene_column}, {u_loci} distinct {args.locus_column}")
+
+    if args.max_genes is not None and u_genes > args.max_genes:
+        print(f"Validation failed: distinct '{args.gene_column}' ({u_genes}) exceeds bound ({args.max_genes}).", file=sys.stderr)
+        sys.exit(1)
+
+    if args.max_loci is not None and u_loci > args.max_loci:
+        print(f"Validation failed: distinct '{args.locus_column}' ({u_loci}) exceeds bound ({args.max_loci}).", file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(0)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This change updates `pipelinePermute.sh` to provide a robust "golden path" by making `--cis-enrich` the default master source, and deriving `TOTAL_TESTS` directly from `mlr_run_<ds>.log` just as `pipeline.sh` does.

It introduces validation via a new Python tool, `tools/check_catalog_grid.py`, which is run inside the annotation loop to ensure that the actual number of distinct genes and loci in the target catalog does not exceed the `GENES_EVAL` and `LOCI_EVAL` dimensions reported in the `mlr_run_<ds>.log`. This catches the dangerous failure mode where a valid-looking `TOTAL_TESTS` belongs to an older, incompatible run.

It also introduces the `--n-null-pairs` passthrough for backward compatibility with older permutation outputs and backs up the eval_permute_report.json file to avoid overwriting prior valuable evaluations during `--start-stage eval`.

---
*PR created automatically by Jules for task [1625236045658282903](https://jules.google.com/task/1625236045658282903) started by @kordk*