### PR TITLE
Make the mapper p-value threshold explicit in pipeline.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,14 @@ stages. Each stage name (in `code`) matches the value accepted by
 `--start-stage`, so any individual step can be re-run in isolation.
 
 1. **`map` — eQTM mapping** *(stage `[3/9]`)*. Runs `tecpg ... run
-   mlr --mlr-method qr --<mapping> --compute-ig`, with chunk sizes
-   auto-selected by the CLI's `_auto_chunk_sizes` (overridable by
-   exporting `TECPG_M_CHUNK` / `TECPG_G_CHUNK`). Logs are tee'd to
-   `mlr_run_<dataset>.log` and `TOTAL_TESTS` is extracted from that
-   log for downstream FDR.
+   mlr --mlr-method qr --<mapping> -p "$MAP_P_THRESH" --compute-ig`,
+   with chunk sizes auto-selected by the CLI's `_auto_chunk_sizes`
+   (overridable by exporting `TECPG_M_CHUNK` / `TECPG_G_CHUNK`).
+   `MAP_P_THRESH` (default `0.001`, matching the CLI's own `-p`
+   default) is the catalog's inclusion gate: pairs above it are never
+   written. It is set explicitly in `pipeline.sh` so it appears in the
+   run log. Logs are tee'd to `mlr_run_<dataset>.log` and
+   `TOTAL_TESTS` is extracted from that log for downstream FDR.
 2. **`merge` — Merge chunked output** *(stage `[4/9]`)*.
    `tools/mergeOutputs.py` combines per-chunk files into a single
    `output_<dataset>/merged.parquet`; intermediate chunk files are

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -31,6 +31,18 @@ START_STAGE="all"
 MLR_IG_COVARIATES="all"
 BOOTSTRAP_IG_COVARIATES="all"
 
+# Mapper p-value threshold. This is the FIRST filter in the pipeline and the
+# rule that decides which pairs enter the catalog at all: the mapper keeps a
+# pair only if its p-value is <= this value. tecpg's own `-p` default for
+# `run mlr` is 0.001; it is set explicitly here so the value appears in the run
+# log and can be cited in methods instead of being an implicit CLI default.
+# The threshold is applied to the float32 `mt_p` column inside the mapper,
+# before Stage 6 recomputes `precise_mt_p` in float64. float32 is sound AT this
+# cutoff (|t| ~ 3.3, far above the ~5.96e-08 cancellation floor), but the
+# ranking within the retained set is not -- that is what Stage 6 repairs.
+# Changing this value changes the catalog and therefore every downstream count.
+MAP_P_THRESH="0.001"
+
 # Chunk sizes for `tecpg run mlr` are intentionally NOT set here. As of
 # tecpg 1.21.0-dev the CLI's anchored auto-sizer (`_auto_chunk_sizes` in
 # tecpg/cli.py) picks `--gene-loci-per-chunk` and `--meth-loci-per-chunk`
@@ -216,6 +228,7 @@ if [ "${#MLR_CHUNK_ARGS[@]}" -gt 0 ]; then
 else
     log "Chunk sizes auto-selected by tecpg CLI from host budget. Input: $DATA_DIR, Annotations: $ANNOT_DIR, Output: $OUT_DIR"
 fi
+log "Mapper p-value threshold: -p $MAP_P_THRESH (catalog inclusion gate, applied to float32 mt_p)"
 
 # Ensure pipefail is set so pipeline errors (like in mlr) are not masked by tee
 set -o pipefail
@@ -225,7 +238,7 @@ if [ "$MLR_IG_COVARIATES" = "all" ]; then
 elif [ -n "$MLR_IG_COVARIATES" ] && [ "$MLR_IG_COVARIATES" != "none" ]; then
     MLR_IG_ARGS+=(--ig-covariates-list "$MLR_IG_COVARIATES")
 fi
-python3 -m tecpg -i "$DATA_DIR" -a "$ANNOT_DIR" -o "$OUT_DIR" run mlr --mlr-method qr --$MAPPING "${MLR_CHUNK_ARGS[@]}" --compute-ig "${MLR_IG_ARGS[@]}" 2>&1 | tee "mlr_run_${DATASET}.log"
+python3 -m tecpg -i "$DATA_DIR" -a "$ANNOT_DIR" -o "$OUT_DIR" run mlr --mlr-method qr --$MAPPING -p "$MAP_P_THRESH" "${MLR_CHUNK_ARGS[@]}" --compute-ig "${MLR_IG_ARGS[@]}" 2>&1 | tee "mlr_run_${DATASET}.log"
 set +o pipefail
 fi
 

--- a/tests/test_map_p_threshold_explicit.py
+++ b/tests/test_map_p_threshold_explicit.py
@@ -1,0 +1,106 @@
+"""Guards for D2: the mapper p-threshold is explicit in pipeline.sh.
+
+`tecpg run mlr` gates the catalog at `-p` (default 0.001) before anything else
+runs. pipeline.sh previously relied on that CLI default implicitly, so the
+catalog's inclusion rule never appeared in the run log and could shift silently
+if the CLI default changed. These tests pin the value, its wiring into the Stage
+3 invocation, and its agreement with the CLI default.
+"""
+import ast
+import os
+import re
+import subprocess
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PIPELINE_SH = os.path.join(REPO_ROOT, "pipeline.sh")
+CLI_PY = os.path.join(REPO_ROOT, "tecpg", "cli.py")
+
+
+def _pipeline_text():
+    with open(PIPELINE_SH, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _shell_var(name, text):
+    """Return the value of a top-level `NAME="value"` assignment."""
+    m = re.search(rf'^{name}="([^"]*)"\s*$', text, re.MULTILINE)
+    assert m, f"{name} is not assigned in pipeline.sh"
+    return m.group(1)
+
+
+def _cli_mlr_p_default():
+    """The -p/--p-thresh default on `run mlr`, read from source without importing torch.
+
+    tecpg/cli.py declares -p twice: once on `mlr` and once on `mlr-single`
+    (a different default). Walking to the FunctionDef named `mlr` disambiguates.
+    """
+    tree = ast.parse(open(CLI_PY, encoding="utf-8").read())
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != "mlr":
+            continue
+        for dec in node.decorator_list:
+            if not (isinstance(dec, ast.Call)
+                    and getattr(dec.func, "attr", None) == "option"):
+                continue
+            flags = [a.value for a in dec.args if isinstance(a, ast.Constant)]
+            if "-p" not in flags and "--p-thresh" not in flags:
+                continue
+            for kw in dec.keywords:
+                if kw.arg == "default":
+                    return ast.literal_eval(kw.value)
+    raise AssertionError("could not locate the -p default on the `run mlr` command")
+
+
+def test_map_p_thresh_is_defined():
+    """pipeline.sh must define the threshold as a named variable."""
+    assert _shell_var("MAP_P_THRESH", _pipeline_text()) == "0.001"
+
+
+def test_map_p_thresh_matches_cli_default():
+    """Load-bearing guard: making the gate explicit must not change the gate.
+
+    If the CLI default and the pipeline value ever diverge, the catalog silently
+    changes size. This forces the divergence to be a deliberate, reviewed edit.
+    """
+    shell_value = float(_shell_var("MAP_P_THRESH", _pipeline_text()))
+    assert shell_value == _cli_mlr_p_default(), (
+        "pipeline.sh MAP_P_THRESH and the `run mlr` -p default disagree. "
+        "Making the mapper gate explicit was meant to be behaviour-preserving; "
+        "changing either value changes the catalog and every downstream count."
+    )
+
+
+def test_stage3_invocation_passes_the_threshold():
+    """The qr mapping call must actually receive -p, not merely define it."""
+    text = _pipeline_text()
+    m = re.search(r"^.*run mlr --mlr-method qr .*$", text, re.MULTILINE)
+    assert m, "could not find the Stage 3 `run mlr --mlr-method qr` invocation"
+    invocation = m.group(0)
+    assert '-p "$MAP_P_THRESH"' in invocation, (
+        f"Stage 3 does not pass -p; invocation was:\n{invocation}"
+    )
+
+
+def test_threshold_is_logged():
+    """The value must reach the run log so it is citable in methods."""
+    text = _pipeline_text()
+    log_lines = [ln for ln in text.splitlines()
+                 if ln.strip().startswith("log ") and "MAP_P_THRESH" in ln]
+    assert log_lines, "no log line emits MAP_P_THRESH"
+
+
+def test_bootstrap_invocation_does_not_pass_the_threshold():
+    """qr_bootstrap ignores p_thresh; passing it there would imply otherwise."""
+    text = _pipeline_text()
+    m = re.search(r"^.*run mlr --mlr-method qr_bootstrap .*$", text, re.MULTILINE)
+    assert m, "could not find the Stage 9 `run mlr --mlr-method qr_bootstrap` invocation"
+    assert "MAP_P_THRESH" not in m.group(0)
+
+
+def test_pipeline_sh_is_valid_bash():
+    """Quoting errors in the edited invocation must not reach a production run."""
+    proc = subprocess.run(["bash", "-n", PIPELINE_SH],
+                          capture_output=True, text=True)
+    assert proc.returncode == 0, f"bash -n failed:\n{proc.stderr}"


### PR DESCRIPTION
Make the mapper p-value threshold explicit in pipeline.sh

`tecpg run mlr` gates the catalog at -p (default 0.001, tecpg/cli.py on the
`mlr` command; applied at tecpg/processing.py:950). pipeline.sh invoked the
mapper without -p, so the pipeline inherited that default silently: the rule
deciding which pairs enter the catalog never appeared in mlr_run_<dataset>.log,
could not be cited in methods without reading the CLI source, and would have
shifted without notice if the CLI default changed.

Adds MAP_P_THRESH="0.001" with a comment recording that the threshold is applied
to the float32 mt_p column before Stage 6 recomputes precise_mt_p in float64,
passes it to the Stage 3 qr invocation, and logs it unconditionally in the
Stage 3 preamble. The Stage 9 qr_bootstrap invocation deliberately does not
receive it: qr_bootstrap dispatches before the p_thresh filter and ignores the
value.

The value is identical to the CLI default, so behaviour is unchanged. README's
stage [3/9] description updated to match.

tests/test_map_p_threshold_explicit.py adds six guards. The load-bearing one is
test_map_p_thresh_matches_cli_default, a cross-file oracle that goes red if
pipeline.sh and the CLI default ever diverge -- the exact silent-drift failure
this change exists to prevent. Verified: 4 failed / 2 passed against the
unmodified pipeline, 6 passed after, and six one-at-a-time injections each turn
the expected test(s) red.

Tracked as D2 in docs/ecpg-filtering-prioritization.md.

---
*PR created automatically by Jules for task [1060970001585294159](https://jules.google.com/task/1060970001585294159) started by @kordk*