### PR TITLE
fix: default the qr_permute null population and add a host-memory ceiling

### DIFF
--- a/pipelinePermute.sh
+++ b/pipelinePermute.sh
@@ -23,6 +23,19 @@ N_NULL_PAIRS=""
 
 PERMUTE_ARGS=()
 
+# Null-population size. qr_permute's null is a seeded subsample of raw M/G, NOT the
+# reported universe -- these do not change which pairs receive a p-value, only the
+# size of the yardstick they are scored against. Left unset, the method builds the
+# FULL M x G cross-product as a host-side DataFrame of Python strings: on GTP that
+# is 1.35e10 rows, ~230 GB of RAM, and the run never reaches the GPU.
+#
+# These values are a starting point with a known resource profile (a GTP run at
+# these counts: 63.5 min, 14.1 GB peak RSS, GPU-resident), NOT a methodological
+# recommendation. Null size and composition are part of the parameter space this
+# pipeline exists to explore -- override freely.
+SUBSAMPLE_MT_COUNT=2000
+SUBSAMPLE_G_COUNT=2000
+
 # Parse arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -70,8 +83,10 @@ while [[ "$#" -gt 0 ]]; do
             echo "  -s, --start-stage STAGE        Specify the starting stage. Options: all, permute, eval. Default is 'all'."
             echo "      --no-assign-regions        Skip adding a 'region' column via assignRegionToEcpg_parquet.py"
             echo "      --permutations N           Passthrough to qr_permute."
-            echo "      --subsample-mt-count N     Passthrough to qr_permute. NOTE: does NOT shrink output."
-            echo "      --subsample-g-count N      Passthrough to qr_permute. NOTE: does NOT shrink output."
+            echo "      --subsample-mt-count N     Null-population CpG count. Default: 2000."
+            echo "                                 NOTE: sizes the NULL only; does NOT shrink output."
+            echo "      --subsample-g-count N      Null-population gene count. Default: 2000."
+            echo "                                 NOTE: sizes the NULL only; does NOT shrink output."
             echo "      --seed N                   Passthrough to qr_permute."
             exit 0
             ;;
@@ -125,11 +140,11 @@ while [[ "$#" -gt 0 ]]; do
             shift 2
             ;;
         --subsample-mt-count)
-            PERMUTE_ARGS+=(--subsample-mt-count "$2")
+            SUBSAMPLE_MT_COUNT="$2"
             shift 2
             ;;
         --subsample-g-count)
-            PERMUTE_ARGS+=(--subsample-g-count "$2")
+            SUBSAMPLE_G_COUNT="$2"
             shift 2
             ;;
         --seed)
@@ -217,17 +232,20 @@ log "Start Stage: $START_STAGE"
 if [ $CIS_ENRICH -eq 1 ]; then log "Mode: cis-enrich (cis map + assemble; cis-window=+/-${CIS_WINDOW} bp)"; fi
 log "============================================================"
 
+# Append the resolved null-population size. Defaults apply unless overridden above.
+PERMUTE_ARGS+=(--subsample-mt-count "$SUBSAMPLE_MT_COUNT")
+PERMUTE_ARGS+=(--subsample-g-count "$SUBSAMPLE_G_COUNT")
+
 # Warnings
-for arg in "${PERMUTE_ARGS[@]}"; do
-    if [[ "$arg" == "--subsample-mt-count" || "$arg" == "--subsample-g-count" ]]; then
-        log "NOTE: --subsample-mt-count/--subsample-g-count subsample the NULL population only."
-        log "      The reported set is the master parquet's (mt_id, gt_id) universe; these flags"
-        log "      do NOT reduce output size. To score a smaller set, narrow the master (map a"
-        log "      smaller universe) -- a --pairs-file subset is not exposed by this wrapper."
-        log "      Subsample LOCI, never SAMPLES -- dropping samples changes DF."
-        break
-    fi
-done
+NULL_PRODUCT=$((SUBSAMPLE_MT_COUNT * SUBSAMPLE_G_COUNT))
+log "Null population: ${SUBSAMPLE_MT_COUNT} CpGs x ${SUBSAMPLE_G_COUNT} genes = ${NULL_PRODUCT} pairs before trans filtering."
+log "      The two axes are sampled independently and need not be balanced; qr_permute"
+log "      reports the realized null-pair count after trans filtering."
+log "NOTE: --subsample-mt-count/--subsample-g-count subsample the NULL population only."
+log "      The reported set is the master parquet's (mt_id, gt_id) universe; these flags"
+log "      do NOT reduce output size. To score a smaller set, narrow the master (map a"
+log "      smaller universe) -- a --pairs-file subset is not exposed by this wrapper."
+log "      Subsample LOCI, never SAMPLES -- dropping samples changes DF."
 
 if [ "$DATASET" == "dummy" ]; then
     log "NOTE: dummy is a WIRING SMOKE TEST ONLY. Disbelieve its numbers."

--- a/tecpg/permute.py
+++ b/tecpg/permute.py
@@ -17,6 +17,12 @@ T_MAX = 10.0
 N_BINS = 1000
 TOPK_CAPACITY = 10_000
 
+# Host-memory ceiling on the null-population cross-product (|M| x |G|), which is
+# built as a DataFrame of Python string pairs before any GPU work begins. This is a
+# resource limit, NOT a methodological bound: any product under it is a legitimate
+# configuration. Raise it if a larger null is wanted and the host can hold it.
+MAX_NULL_PAIR_PRODUCT = 50_000_000
+
 
 def _normalize_annotations(M_annot, G_annot, M, G, logger):
     from .chrom import canonicalize_chrom
@@ -64,6 +70,16 @@ def _select_null_population(M, G, C, M_annot, G_annot, region,
                             subsample_mt_count, subsample_g_count, seed, logger):
     # CHUNK 4: seeded uniform pair subsample for the NULL population.
     if subsample_mt_count is None and subsample_g_count is None:
+        product = len(M) * len(G)
+        if product > MAX_NULL_PAIR_PRODUCT:
+            raise ValueError(
+                "Host-memory ceiling exceeded: {0} CpGs x {1} genes = {2} null pairs "
+                "(ceiling is {3}). These flags size the null only and do not change "
+                "which pairs are reported. Provide --subsample-mt-count and "
+                "--subsample-g-count to set a manageable null population size.".format(
+                    len(M), len(G), product, MAX_NULL_PAIR_PRODUCT
+                )
+            )
         return M, G
 
     rng = np.random.default_rng(seed)
@@ -91,6 +107,17 @@ def _select_null_population(M, G, C, M_annot, G_annot, region,
         idx = rng.choice(len(G), size=subsample_g_count, replace=False)
         idx.sort()
         null_G = G.iloc[idx]
+
+    product = len(null_M) * len(null_G)
+    if product > MAX_NULL_PAIR_PRODUCT:
+        raise ValueError(
+            "Host-memory ceiling exceeded: {0} CpGs x {1} genes = {2} null pairs "
+            "(ceiling is {3}). These flags size the null only and do not change "
+            "which pairs are reported. Provide --subsample-mt-count and "
+            "--subsample-g-count to set a manageable null population size.".format(
+                len(null_M), len(null_G), product, MAX_NULL_PAIR_PRODUCT
+            )
+        )
 
     return null_M, null_G
 

--- a/tests/test_permute_null_population.py
+++ b/tests/test_permute_null_population.py
@@ -1,0 +1,131 @@
+import pandas as pd
+import numpy as np
+import pytest
+from tecpg import permute
+
+# Using a mock logger since _select_null_population expects one
+class MockLogger:
+    def info(self, *args, **kwargs):
+        pass
+    def warning(self, *args, **kwargs):
+        pass
+
+@pytest.fixture
+def mock_logger():
+    return MockLogger()
+
+@pytest.fixture
+def small_M():
+    return pd.DataFrame(index=['cg1', 'cg2'])
+
+@pytest.fixture
+def small_G():
+    return pd.DataFrame(index=['geneA', 'geneB'])
+
+@pytest.fixture
+def large_M(monkeypatch):
+    size = 1000
+    df = pd.DataFrame(index=[f'cg{i}' for i in range(size)])
+    # Set ceiling lower to avoid creating a real 50M frame
+    monkeypatch.setattr(permute, 'MAX_NULL_PAIR_PRODUCT', 500)
+    return df
+
+@pytest.fixture
+def large_G():
+    size = 1000
+    return pd.DataFrame(index=[f'gene{i}' for i in range(size)])
+
+
+def test_small_unsubsampled_returns_full_matrices(small_M, small_G, mock_logger):
+    # Product is 4, well below ceiling
+    null_M, null_G = permute._select_null_population(
+        small_M, small_G, None, None, None, 'all', None, None, None,
+        None, None, 42, mock_logger
+    )
+    assert null_M is small_M
+    assert null_G is small_G
+
+def test_oversized_unsubsampled_raises(large_M, large_G, mock_logger):
+    # Ceiling patched to 500. M=1000, G=1000, product=1,000,000 > 500
+    with pytest.raises(ValueError) as excinfo:
+        permute._select_null_population(
+            large_M, large_G, None, None, None, 'all', None, None, None,
+            None, None, 42, mock_logger
+        )
+    assert 'Host-memory ceiling exceeded' in str(excinfo.value)
+
+def test_oversized_message_names_both_flags(large_M, large_G, mock_logger):
+    with pytest.raises(ValueError) as excinfo:
+        permute._select_null_population(
+            large_M, large_G, None, None, None, 'all', None, None, None,
+            None, None, 42, mock_logger
+        )
+    msg = str(excinfo.value)
+    assert '--subsample-mt-count' in msg
+    assert '--subsample-g-count' in msg
+
+def test_oversized_message_names_dimensions_and_ceiling(large_M, large_G, mock_logger):
+    with pytest.raises(ValueError) as excinfo:
+        permute._select_null_population(
+            large_M, large_G, None, None, None, 'all', None, None, None,
+            None, None, 42, mock_logger
+        )
+    msg = str(excinfo.value)
+    assert str(len(large_M)) in msg
+    assert str(len(large_G)) in msg
+    product = len(large_M) * len(large_G)
+    assert str(product) in msg
+    assert str(permute.MAX_NULL_PAIR_PRODUCT) in msg
+
+def test_explicit_counts_below_ceiling_subsample(large_M, large_G, mock_logger):
+    # Explicit subsample to 20x20 = 400 < 500 (ceiling)
+    null_M, null_G = permute._select_null_population(
+        large_M, large_G, None, None, None, 'all', None, None, None,
+        20, 20, 42, mock_logger
+    )
+    assert len(null_M) == 20
+    assert len(null_G) == 20
+
+def test_explicit_counts_above_ceiling_raises(large_M, large_G, mock_logger):
+    # Explicit subsample to 30x30 = 900 > 500 (ceiling)
+    with pytest.raises(ValueError) as excinfo:
+        permute._select_null_population(
+            large_M, large_G, None, None, None, 'all', None, None, None,
+            30, 30, 42, mock_logger
+        )
+    assert 'Host-memory ceiling exceeded' in str(excinfo.value)
+
+def test_product_exactly_at_ceiling_is_allowed(large_M, large_G, mock_logger):
+    # Ceiling is 500. Explicitly set to 25x20 = 500
+    null_M, null_G = permute._select_null_population(
+        large_M, large_G, None, None, None, 'all', None, None, None,
+        25, 20, 42, mock_logger
+    )
+    assert len(null_M) == 25
+    assert len(null_G) == 20
+
+def test_seeded_subsample_is_reproducible(large_M, large_G, mock_logger):
+    # Below ceiling subsample 10x10 = 100 < 500
+    null_M_1, null_G_1 = permute._select_null_population(
+        large_M, large_G, None, None, None, 'all', None, None, None,
+        10, 10, 42, mock_logger
+    )
+
+    null_M_2, null_G_2 = permute._select_null_population(
+        large_M, large_G, None, None, None, 'all', None, None, None,
+        10, 10, 42, mock_logger
+    )
+
+    # Different seed
+    null_M_3, null_G_3 = permute._select_null_population(
+        large_M, large_G, None, None, None, 'all', None, None, None,
+        10, 10, 99, mock_logger
+    )
+
+    pd.testing.assert_frame_equal(null_M_1, null_M_2)
+    pd.testing.assert_frame_equal(null_G_1, null_G_2)
+
+    with pytest.raises(AssertionError):
+        pd.testing.assert_frame_equal(null_M_1, null_M_3)
+    with pytest.raises(AssertionError):
+        pd.testing.assert_frame_equal(null_G_1, null_G_3)


### PR DESCRIPTION
Fix null population defaults and host memory ceiling.

---
*PR created automatically by Jules for task [14235398284082809432](https://jules.google.com/task/14235398284082809432) started by @kordk*