### PR TITLE
Add per-region se-ratio trend diagnostic

### DIFF
--- a/tests/test_se_ratio_trend.py
+++ b/tests/test_se_ratio_trend.py
@@ -1,0 +1,259 @@
+"""Guards for tools/diagnose_se_ratio_trend.py.
+
+The tool reports how boot_se_ratio behaves against |mt_t| within each region.
+It computes no threshold and no verdict; these tests pin that scope alongside
+the arithmetic. Every expected value is recomputed from the fixture at test
+time rather than hardcoded, so the fixture and the assertions cannot drift
+apart.
+"""
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from scipy import stats
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TOOL = os.path.join(REPO_ROOT, "tools", "diagnose_se_ratio_trend.py")
+
+MIN_REGION_N = 200
+
+# Fixture composition. TRANS carries a declining r-vs-|t| relationship by
+# construction, CIS5 a flat one, PROMOTER is below MIN_REGION_N, and the
+# unassigned bucket receives both a NULL label and a non-canonical one.
+N_TRANS = 1200
+N_CIS5 = 800
+N_PROMOTER = 50
+N_NULL = 120
+N_WEIRD = 60
+N_UNSCORED = 300
+
+
+def _build_frame():
+    rng = np.random.default_rng(11)
+
+    def block(n, label, slope):
+        t = rng.uniform(3.4, 12.0, n)
+        r = 1.35 + slope * t + rng.normal(0.0, 0.02, n)
+        return pd.DataFrame({
+            "region": pd.Series([label] * n, dtype=object),
+            "mt_t": t * rng.choice([-1.0, 1.0], n),
+            "boot_se_ratio": r,
+        })
+
+    parts = [
+        block(N_TRANS, "TRANS", -0.045),
+        block(N_CIS5, "CIS5", 0.0),
+        block(N_PROMOTER, "PROMOTER", -0.03),
+        block(N_NULL, None, -0.01),
+        block(N_WEIRD, "WEIRD", -0.01),
+    ]
+    unscored = block(N_UNSCORED, "TRANS", -0.045)
+    unscored["boot_se_ratio"] = np.nan
+    parts.append(unscored)
+
+    df = pd.concat(parts, ignore_index=True)
+    df["mt_id"] = [f"cg{i:06d}" for i in range(len(df))]
+    df["gt_id"] = [f"G{i % 23}" for i in range(len(df))]
+    df["boot_bias_ratio"] = 0.0
+    return df
+
+
+def _write_fixture(path):
+    df = _build_frame()
+    pq.write_table(pa.Table.from_pandas(df, preserve_index=False), path)
+    return df
+
+
+def _run(inp, out_json, expect_ok=True, extra=None):
+    cmd = [sys.executable, TOOL, "-i", str(inp), "-s", str(out_json),
+           "--min-region-n", str(MIN_REGION_N)]
+    if extra:
+        cmd.extend(extra)
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if expect_ok:
+        assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+    return proc
+
+
+def _sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for block in iter(lambda: fh.read(65536), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+@pytest.fixture(scope="module")
+def run_result(tmp_path_factory):
+    d = tmp_path_factory.mktemp("se_ratio_trend")
+    inp = d / "concordance.parquet"
+    df = _write_fixture(inp)
+    out_json = d / "summary.json"
+    proc = _run(inp, out_json)
+    with open(out_json) as fh:
+        summary = json.load(fh)
+    return df, summary, proc, d
+
+
+def _scored(df, label):
+    if label is None:
+        m = df["region"].isna()
+    else:
+        m = df["region"] == label
+    sub = df[m & np.isfinite(df["boot_se_ratio"])]
+    return sub
+
+
+def test_declining_trend_recovered(run_result):
+    """TRANS is built with r falling in |t|; rho and its CI must both be negative."""
+    _, summary, _, _ = run_result
+    reg = summary["regions"]["TRANS"]
+    assert reg["spearman_rho"] < 0
+    assert reg["spearman_ci"][1] < 0
+
+
+def test_flat_trend_ci_spans_zero(run_result):
+    """CIS5 is built with no dependence on |t|; the CI must not exclude zero."""
+    _, summary, _, _ = run_result
+    reg = summary["regions"]["CIS5"]
+    assert reg["spearman_ci"][0] <= 0.0 <= reg["spearman_ci"][1]
+
+
+def test_per_region_median_and_mad_match_numpy(run_result):
+    """Location and scale are the median and the unscaled MAD, not the mean and SD."""
+    df, summary, _, _ = run_result
+    for label in ("TRANS", "CIS5", "PROMOTER"):
+        x = _scored(df, label)["boot_se_ratio"].to_numpy(dtype=np.float64)
+        med = float(np.median(x))
+        mad = float(np.median(np.abs(x - med)))
+        assert summary["regions"][label]["median_se_ratio"] == pytest.approx(med, abs=1e-12)
+        assert summary["regions"][label]["mad_se_ratio"] == pytest.approx(mad, abs=1e-12)
+
+
+def test_bins_partition_scored_rows(run_result):
+    """Bins must tile the region's scored rows exactly: no row lost, none double-counted."""
+    _, summary, _, _ = run_result
+    for label in ("TRANS", "CIS5"):
+        reg = summary["regions"][label]
+        assert reg["bins"] is not None
+        assert sum(b["n"] for b in reg["bins"]) == reg["n_scored"]
+        occupied = [b for b in reg["bins"] if b["n"] > 0]
+        for prev, nxt in zip(occupied, occupied[1:]):
+            assert prev["t_abs_hi"] <= nxt["t_abs_lo"]
+
+
+def test_t_range_is_over_scored_rows_only(run_result):
+    """The reported |t| range must exclude unscored rows."""
+    df, summary, _, _ = run_result
+    for label in ("TRANS", "CIS5", "PROMOTER"):
+        a = np.abs(_scored(df, label)["mt_t"].to_numpy(dtype=np.float64))
+        assert summary["regions"][label]["t_abs_min"] == pytest.approx(float(a.min()), abs=1e-12)
+        assert summary["regions"][label]["t_abs_max"] == pytest.approx(float(a.max()), abs=1e-12)
+
+
+def test_unassigned_bucket_collects_null_and_noncanonical(run_result):
+    """No scored row is silently dropped for carrying a NULL or unrecognised region."""
+    df, summary, _, _ = run_result
+    reg = summary["regions"]["unassigned"]
+    n_null = len(_scored(df, None))
+    n_weird = len(_scored(df, "WEIRD"))
+    assert reg["n_scored"] == n_null + n_weird
+    assert reg["n_null_region"] == n_null
+    assert reg["n_noncanonical_region"] == n_weird
+    assert reg["noncanonical_labels"] == ["WEIRD"]
+    total_scored = int(np.isfinite(df["boot_se_ratio"]).sum())
+    assert sum(r["n_scored"] for r in summary["regions"].values()) == total_scored
+    assert summary["n_scored"] == total_scored
+
+
+def test_small_region_keeps_census_but_omits_trend(run_result):
+    """Below --min-region-n the trend is withheld with a stated reason, not guessed."""
+    _, summary, _, _ = run_result
+    reg = summary["regions"]["PROMOTER"]
+    assert reg["n_scored"] == N_PROMOTER
+    assert reg["median_se_ratio"] is not None
+    assert reg["bins"] is None
+    assert reg["spearman_rho"] is None
+    assert reg["spearman_ci"] is None
+    assert reg["trend_omitted_reason"] == "n_scored below --min-region-n"
+
+
+def test_deterministic_under_seed(run_result):
+    """Same input and same seed must give a byte-identical summary."""
+    _, summary, _, d = run_result
+    second = d / "summary_again.json"
+    _run(d / "concordance.parquet", second)
+    with open(second) as fh:
+        again = json.load(fh)
+    again["input"] = summary["input"]
+    assert json.dumps(again, sort_keys=True) == json.dumps(summary, sort_keys=True)
+
+
+def test_missing_required_column_fails_closed(tmp_path):
+    """A missing score column must abort, not report an empty analysis as success."""
+    inp = tmp_path / "concordance.parquet"
+    df = _build_frame().drop(columns=["boot_se_ratio"])
+    pq.write_table(pa.Table.from_pandas(df, preserve_index=False), inp)
+    out_json = tmp_path / "summary.json"
+    proc = _run(inp, out_json, expect_ok=False)
+    assert proc.returncode == 1
+    assert "boot_se_ratio" in proc.stderr
+    assert not out_json.exists()
+
+
+def test_no_scored_rows_fails_closed(tmp_path):
+    """An input where nothing was bootstrapped must abort rather than divide by zero."""
+    inp = tmp_path / "concordance.parquet"
+    df = _build_frame()
+    df["boot_se_ratio"] = np.nan
+    pq.write_table(pa.Table.from_pandas(df, preserve_index=False), inp)
+    out_json = tmp_path / "summary.json"
+    proc = _run(inp, out_json, expect_ok=False)
+    assert proc.returncode == 1
+    assert not out_json.exists()
+
+
+def test_input_is_left_unchanged(tmp_path):
+    """The tool is read-only: the input bytes must survive a run untouched."""
+    inp = tmp_path / "concordance.parquet"
+    _write_fixture(inp)
+    before = _sha256(inp)
+    _run(inp, tmp_path / "summary.json")
+    assert _sha256(inp) == before
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["concordance.parquet", "summary.json"]
+
+
+def test_summary_carries_no_decision_field_and_notes_are_hedged(run_result):
+    """No key may encode a decision, and every note must hedge and name its assumption."""
+    _, summary, _, _ = run_result
+
+    def _keys(obj):
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                yield k
+                yield from _keys(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                yield from _keys(v)
+
+    banned = ("threshold", "flag", "cutoff", "cut_point", "status", "badge",
+              "verdict", "outlier", "problematic", "significant", "pass", "fail")
+    for key in _keys(summary):
+        low = key.lower()
+        for word in banned:
+            assert word not in low, f"summary carries a decision field: {key!r}"
+
+    hedges = ("may", "likely", "assumes", "assumption", "consistent with",
+              "worth considering", "if ")
+    assert set(summary["notes"].keys()) == {
+        "mad_scaling", "range_restriction", "trend_reading", "ci_interpretation"}
+    for name, text in summary["notes"].items():
+        low = text.lower()
+        assert any(h in low for h in hedges), f"note {name!r} is not hedged: {text!r}"

--- a/tools/diagnose_se_ratio_trend.py
+++ b/tools/diagnose_se_ratio_trend.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Diagnose SE ratio trend across regions."""
+import argparse
+import json
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pyarrow.parquet as pq
+from scipy import stats
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import eval_permute as E
+    CANONICAL_REGIONS = E.CANONICAL_REGIONS
+except ImportError:
+    CANONICAL_REGIONS = ['TRANS', 'DISTAL5', 'CIS5', 'PROMOTER', 'GENEBODY', 'CIS3', 'DISTAL3']
+
+try:
+    import tecpg
+    TEC_VERSION = tecpg.__version__
+except ImportError:
+    TEC_VERSION = None
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input", required=True, help="path to the concordance parquet")
+    parser.add_argument("-s", "--summary-json", help="path to write the JSON summary")
+    parser.add_argument("--chunk-size", type=int, default=100000)
+    parser.add_argument("--bins", type=int, default=10)
+    parser.add_argument("--min-region-n", type=int, default=200)
+    parser.add_argument("--ci-resamples", type=int, default=1000)
+    parser.add_argument("--ci-level", type=float, default=0.95)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    required_cols = ["mt_t", "boot_se_ratio"]
+    try:
+        parquet_file = pq.ParquetFile(args.input)
+    except Exception as e:
+        print(f"Error opening parquet file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    schema_names = parquet_file.schema.names
+    missing = [c for c in required_cols if c not in schema_names]
+    if missing:
+        print(f"Missing required columns: {missing}", file=sys.stderr)
+        sys.exit(1)
+
+    has_region = "region" in schema_names
+    read_cols = required_cols + (["region"] if has_region else [])
+
+    n_rows_read = 0
+    scored_rows = []
+
+    for batch in parquet_file.iter_batches(batch_size=args.chunk_size, columns=read_cols):
+        n_rows_read += batch.num_rows
+        df = batch.to_pandas()
+
+        valid = np.isfinite(df["boot_se_ratio"]) & np.isfinite(df["mt_t"])
+        if not valid.any():
+            continue
+
+        sub = df[valid].copy()
+        sub["mt_t_abs"] = np.abs(sub["mt_t"])
+        scored_rows.append(sub)
+
+    if n_rows_read == 0:
+        print("Input has zero rows", file=sys.stderr)
+        sys.exit(1)
+
+    if not scored_rows:
+        print("Input has zero rows with finite boot_se_ratio and finite mt_t", file=sys.stderr)
+        sys.exit(1)
+
+    df_scored = pd.concat(scored_rows, ignore_index=True)
+    total_scored = len(df_scored)
+
+    regions_data = {}
+
+    if not has_region:
+        df_scored["assigned_region"] = "unassigned"
+    else:
+        # Route to region
+        def map_region(r):
+            if pd.isna(r):
+                return "unassigned"
+            if r in CANONICAL_REGIONS:
+                return r
+            return "unassigned"
+
+        df_scored["assigned_region"] = df_scored["region"].apply(map_region)
+
+    rng = np.random.default_rng(args.seed)
+
+    out_regions = {}
+    for region_name, group in df_scored.groupby("assigned_region"):
+        n_scored = len(group)
+        t_abs = group["mt_t_abs"].to_numpy(dtype=np.float64)
+        r = group["boot_se_ratio"].to_numpy(dtype=np.float64)
+
+        med = float(np.median(r))
+        mad = float(np.median(np.abs(r - med)))
+        t_abs_min = float(np.min(t_abs))
+        t_abs_max = float(np.max(t_abs))
+
+        reg_dict = {
+            "n_scored": n_scored,
+            "median_se_ratio": med,
+            "mad_se_ratio": mad,
+            "t_abs_min": t_abs_min,
+            "t_abs_max": t_abs_max,
+            "spearman_rho": None,
+            "spearman_ci": None,
+            "spearman_ci_omitted_reason": None,
+            "trend_omitted_reason": None,
+            "bins": None
+        }
+
+        if region_name == "unassigned":
+            if has_region:
+                null_mask = group["region"].isna()
+                n_null = int(null_mask.sum())
+                n_noncan = n_scored - n_null
+                noncan_labels = group.loc[~null_mask, "region"].unique()
+                noncan_labels_sorted = sorted([str(x) for x in noncan_labels])
+                reg_dict["n_null_region"] = n_null
+                reg_dict["n_noncanonical_region"] = n_noncan
+                reg_dict["noncanonical_labels"] = noncan_labels_sorted[:20]
+                reg_dict["noncanonical_labels_truncated"] = len(noncan_labels_sorted) > 20
+            else:
+                reg_dict["n_null_region"] = n_scored
+                reg_dict["n_noncanonical_region"] = 0
+                reg_dict["noncanonical_labels"] = []
+                reg_dict["noncanonical_labels_truncated"] = False
+
+        if n_scored < args.min_region_n:
+            reg_dict["trend_omitted_reason"] = "n_scored below --min-region-n"
+        else:
+            q = np.linspace(0, 1, args.bins + 1)
+            edges = np.quantile(t_abs, q)
+            # Ensure bins partition exactly. searchsorted gives index 1 for first bin
+            # interior edges: edges[1:-1]
+            bin_idx = np.searchsorted(edges[1:-1], t_abs, side='right')
+
+            bins = []
+            for b in range(args.bins):
+                b_mask = (bin_idx == b)
+                n_b = int(np.sum(b_mask))
+                if n_b > 0:
+                    t_b = t_abs[b_mask]
+                    r_b = r[b_mask]
+                    bins.append({
+                        "bin": b + 1,
+                        "n": n_b,
+                        "t_abs_lo": float(np.min(t_b)),
+                        "t_abs_hi": float(np.max(t_b)),
+                        "median_se_ratio": float(np.median(r_b))
+                    })
+                else:
+                    bins.append({
+                        "bin": b + 1,
+                        "n": 0,
+                        "t_abs_lo": None,
+                        "t_abs_hi": None,
+                        "median_se_ratio": None
+                    })
+            reg_dict["bins"] = bins
+
+            rho_val = float(stats.spearmanr(t_abs, r).statistic)
+            reg_dict["spearman_rho"] = rho_val
+
+            # Bootstrap CI
+            resampled_rhos = []
+            indices = np.arange(n_scored)
+            for _ in range(args.ci_resamples):
+                idx = rng.choice(indices, size=n_scored, replace=True)
+                rho = stats.spearmanr(t_abs[idx], r[idx]).statistic
+                resampled_rhos.append(rho)
+
+            resampled_rhos = np.array(resampled_rhos, dtype=np.float64)
+            finite_rhos = resampled_rhos[np.isfinite(resampled_rhos)]
+
+            if len(finite_rhos) < 50:
+                reg_dict["spearman_ci_omitted_reason"] = "fewer than 50 finite resample statistics"
+            else:
+                alpha = (1 - args.ci_level) / 2
+                ci_lo = np.percentile(finite_rhos, alpha * 100)
+                ci_hi = np.percentile(finite_rhos, (1 - alpha) * 100)
+                reg_dict["spearman_ci"] = [float(ci_lo), float(ci_hi)]
+
+        out_regions[region_name] = reg_dict
+
+    out = {
+        "input": os.path.abspath(args.input),
+        "tool_version": TEC_VERSION,
+        "n_rows_read": n_rows_read,
+        "n_scored": total_scored,
+        "params": {
+            "bins": args.bins,
+            "min_region_n": args.min_region_n,
+            "ci_resamples": args.ci_resamples,
+            "ci_level": args.ci_level,
+            "seed": args.seed,
+            "chunk_size": args.chunk_size
+        },
+        "regions": out_regions,
+        "notes": {
+            "mad_scaling": "reading mad_se_ratio as a standard deviation assumes approximate normality of the region's boot_se_ratio; under that assumption the scale factor is about 1.4826, and the assumption may not hold where the distribution is skewed.",
+            "range_restriction": "a region whose scored rows were selected by ranking on precise_mt_p will have its |mt_t| range truncated from below, so a trend measured within that region is measured over a restricted range and may not extend to the region's unscored rows.",
+            "trend_reading": "under the assumption that the bootstrap and analytic standard errors estimate the same quantity, a slope that is flat in |mt_t| may be consistent with a specification effect that applies to all rows, whereas a slope that declines as |mt_t| grows may be consistent with an effect confined to the selected subset; the tool computes no verdict and both readings are worth considering against other evidence.",
+            "ci_interpretation": "the interval is a percentile bootstrap over rows and assumes the scored rows within a region are exchangeable; if they are not, the interval is likely optimistic."
+        }
+    }
+
+    if args.summary_json:
+        with open(args.summary_json, "w") as f:
+            json.dump(out, f, indent=2)
+    else:
+        print(json.dumps(out, indent=2))
+
+    print(f"n_rows_read: {n_rows_read}")
+    print(f"n_scored: {total_scored}")
+    print(f"params: {out['params']}")
+    print()
+    print(f"{'region':<15} {'n_scored':<10} {'median_r':<10} {'mad_r':<10} {'t_min':<10} {'t_max':<10} {'rho':<10} {'ci'}")
+    for k, v in out_regions.items():
+        ci_str = f"[{v['spearman_ci'][0]:.3f}, {v['spearman_ci'][1]:.3f}]" if v['spearman_ci'] else "None"
+        rho_str = f"{v['spearman_rho']:.3f}" if v['spearman_rho'] is not None else "None"
+        print(f"{k:<15} {v['n_scored']:<10} {v['median_se_ratio']:<10.3f} {v['mad_se_ratio']:<10.3f} {v['t_abs_min']:<10.3f} {v['t_abs_max']:<10.3f} {rho_str:<10} {ci_str}")
+        if v["bins"]:
+            print(f"  Bins:")
+            for b in v["bins"]:
+                if b["n"] > 0:
+                    print(f"    bin {b['bin']}: n={b['n']}, t_abs in [{b['t_abs_lo']:.3f}, {b['t_abs_hi']:.3f}], med_r={b['median_se_ratio']:.3f}")
+                else:
+                    print(f"    bin {b['bin']}: n=0")
+        print()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds `tools/diagnose_se_ratio_trend.py` to analyze the relationship between `boot_se_ratio` and `|mt_t|` across different canonical regions. Includes a comprehensive test suite for this new tool under `tests/test_se_ratio_trend.py`.

---
*PR created automatically by Jules for task [9908847800310696057](https://jules.google.com/task/9908847800310696057) started by @kordk*