### PR TITLE
benchmark_kennedy: compute_eligibility must use the tecpg universe

### DIFF
--- a/tests/test_benchmark_kennedy.py
+++ b/tests/test_benchmark_kennedy.py
@@ -83,6 +83,33 @@ def test_na_preservation(tmp_path):
     loaded = load_kennedy(path, sep='\t')
     assert len(loaded) == 2
 
+# O5b. test_eligibility_uses_tecpg_universe
+
+
+def test_eligibility_uses_tecpg_universe():
+    import pandas as pd
+    from tools.benchmark_kennedy import compute_eligibility
+
+    kennedy_df = pd.DataFrame({
+        'CpG.probe': ['cgA', 'cgB', 'cgA', 'cgC'],
+        'exp.Probe': ['prA', 'prA', 'prB', 'prC'],
+    })
+    cols = {'cpg': 'CpG.probe', 'probe': 'exp.Probe'}
+
+    # tecpg universe deliberately NARROWER than the Kennedy frame
+    distinct_mt = {'cgA'}
+    distinct_gt = {'prA'}
+
+    out = compute_eligibility(distinct_mt, distinct_gt, kennedy_df, cols)
+
+    assert list(out['cpg_in_tecpg_universe'])   == [True, False, True, False]
+    assert list(out['probe_in_tecpg_universe']) == [True, True, False, False]
+    assert list(out['eligible'])                == [True, False, False, False]
+
+    # not vacuous: at least one row must be ineligible
+    assert not out['eligible'].all()
+
+
 # O6. eligibility_classification
 
 
@@ -118,10 +145,7 @@ def test_eligibility_classification(tmp_path):
     assert len(df_k_only) == 3
     # Check reasons
     reasons = df_k_only.set_index(['mt_id', 'gt_id'])['non_overlap_reason'].to_dict()
-    assert reasons[('cg2', 'pr1')] in ['ineligible_cpg', 'kennedy_tested_and_missed',
-                                       'kennedy_universe_unknown', 'tested_and_missed']
-    pass
-    pass
+    assert reasons[('cg2', 'pr1')] == 'ineligible_cpg'
 
 # O7. recovery_confirmation_arithmetic
 

--- a/tools/benchmark_kennedy.py
+++ b/tools/benchmark_kennedy.py
@@ -188,8 +188,8 @@ def stream_catalog_and_match(args, schema, tecpg_p_col, kennedy_pairs,
 
 def compute_eligibility(distinct_mt, distinct_gt, kennedy_df, cols):
     df = kennedy_df.copy()
-    df['cpg_in_tecpg_universe'] = df[cols['cpg']].isin(set(df[cols['cpg']].dropna()))
-    df['probe_in_tecpg_universe'] = df[cols['probe']].isin(set(df[cols['probe']].dropna()))
+    df['cpg_in_tecpg_universe'] = df[cols['cpg']].isin(set(distinct_mt))
+    df['probe_in_tecpg_universe'] = df[cols['probe']].isin(set(distinct_gt))
     df['eligible'] = df['cpg_in_tecpg_universe'] & df['probe_in_tecpg_universe']
     return df
 


### PR DESCRIPTION
Fixes a logic error in `compute_eligibility` where the Kennedy frame was being matched against itself rather than the `tecpg` universe, incorrectly marking all pairs as eligible. Added exact assertions and test coverage in `test_benchmark_kennedy.py` to prevent regressions. Tested against false positives using selective fault injections.

---
*PR created automatically by Jules for task [15787488879940438272](https://jules.google.com/task/15787488879940438272) started by @kordk*