### PR TITLE
Fail closed when the FDR parquet write fails

### DIFF
--- a/tests/test_summarize_fdr_write_atomic.py
+++ b/tests/test_summarize_fdr_write_atomic.py
@@ -1,0 +1,93 @@
+"""Guards for the FDR output write path in tools/summarizeOutput_parquet.py.
+
+The write loop previously caught every exception, printed to stdout, closed the
+writer in a finally block and returned zero. Because the writer pointed at the
+destination, a failure part way through left a valid but truncated parquet at
+the path a downstream stage would read, with a success exit code. These tests
+pin the replacement contract: the destination is written only after the whole
+file is, and a failure is loud and non-zero.
+"""
+import os
+import subprocess
+import sys
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TOOL = os.path.join(REPO_ROOT, "tools", "summarizeOutput_parquet.py")
+
+N_ROWS = 4
+
+
+def _make_inputs(d):
+    schema = pa.schema([
+        ("id", pa.int64()),
+        ("mt_chromStart", pa.int64()),
+        ("gt_chromStart", pa.int64()),
+        ("precise_mt_p", pa.float64()),
+    ])
+    df1 = pd.DataFrame({"id": [1, 2], "mt_chromStart": [100, 200],
+                        "gt_chromStart": [100, 200], "precise_mt_p": [0.01, 0.05]})
+    df2 = pd.DataFrame({"id": [3, 4], "mt_chromStart": [300, 400],
+                        "gt_chromStart": [300, 400], "precise_mt_p": [0.10, 0.20]})
+    inp = os.path.join(d, "input.parquet")
+    with pq.ParquetWriter(inp, schema) as w:
+        w.write_table(pa.Table.from_pandas(df1, schema=schema))
+        w.write_table(pa.Table.from_pandas(df2, schema=schema))
+    res = os.path.join(d, "reservoir.csv")
+    pd.DataFrame({"id": [1, 2, 3, 4],
+                  "precise_mt_p": [0.01, 0.05, 0.10, 0.20]}).to_csv(res, index=False)
+    return inp, res
+
+
+def _run(d, out):
+    inp, res = _make_inputs(d)
+    return subprocess.run(
+        [sys.executable, TOOL, "--main-file", inp, "--reservoir-file", res,
+         "--total-tests", str(N_ROWS), "--df", "100", "--calculate-fdr",
+         "--output-fdr-file", out, "--chunk-size", "2"],
+        capture_output=True, text=True, cwd=d)
+
+
+def test_success_writes_destination_and_leaves_no_scratch_file(tmp_path):
+    """A clean run still produces the file, and clears up after itself."""
+    out = str(tmp_path / "out.parquet")
+    proc = _run(str(tmp_path), out)
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+    assert os.path.exists(out)
+    assert pq.read_table(out).num_rows == N_ROWS
+    assert not os.path.exists(out + ".tmp")
+
+
+def test_scratch_path_is_used_so_the_destination_is_never_partial(tmp_path):
+    """Occupying the scratch path must abort before the destination is touched.
+
+    This fails if the writer points straight at the destination, because then
+    the scratch path is irrelevant and the run succeeds.
+    """
+    out = str(tmp_path / "out.parquet")
+    os.mkdir(out + ".tmp")
+    proc = _run(str(tmp_path), out)
+    assert proc.returncode == 1
+    assert not os.path.exists(out)
+
+
+def test_unwritable_destination_exits_non_zero(tmp_path):
+    """A write that cannot start must not report success."""
+    out = str(tmp_path / "no_such_dir" / "out.parquet")
+    proc = _run(str(tmp_path), out)
+    assert proc.returncode == 1
+    assert not os.path.exists(out)
+
+
+def test_write_failure_is_reported_on_stderr(tmp_path):
+    """A failure printed to stdout is invisible to a shell checking for errors."""
+    out = str(tmp_path / "out.parquet")
+    os.mkdir(out + ".tmp")
+    proc = _run(str(tmp_path), out)
+    assert proc.returncode == 1
+    assert "Error writing output FDR file" in proc.stderr
+    assert "Error writing output FDR file" not in proc.stdout

--- a/tools/summarizeOutput_parquet.py
+++ b/tools/summarizeOutput_parquet.py
@@ -565,6 +565,9 @@ Outputs and Metrics Calculated:
     if args.output_fdr_file:
         print(f"\nWriting output FDR Parquet file to: {args.output_fdr_file}")
 
+        tmp_output_fdr_file = args.output_fdr_file + ".tmp"
+        write_error = None
+
         do_compare = args.compare_fdr_column is not None
         if do_compare and args.compare_fdr_column not in schema_cols:
             print(f"Notice: --compare-fdr-column '{args.compare_fdr_column}' not found in schema. Skipping comparison.")
@@ -648,7 +651,7 @@ Outputs and Metrics Calculated:
                 if writer is None:
                     # Define explicit schema once on the first chunk
                     explicit_schema = table.schema
-                    writer = pq.ParquetWriter(args.output_fdr_file, explicit_schema)
+                    writer = pq.ParquetWriter(tmp_output_fdr_file, explicit_schema)
                 else:
                     # Cast subsequent chunks to the explicit schema established by the first chunk
                     table = table.cast(explicit_schema)
@@ -660,10 +663,25 @@ Outputs and Metrics Calculated:
 
             print(f"\nFinished writing FDR Parquet file.")
         except Exception as e:
-            print(f"Error writing output FDR file: {e}")
+            write_error = e
         finally:
             if writer is not None:
                 writer.close()
+
+        if write_error is not None:
+            # Cleanup must never raise: a failure here would replace the real
+            # diagnosis with an unrelated traceback.
+            if os.path.isfile(tmp_output_fdr_file):
+                try:
+                    os.remove(tmp_output_fdr_file)
+                except OSError:
+                    pass
+            sys.stderr.write(
+                f"Error writing output FDR file: {write_error}\n"
+                "No output was written; the destination is unchanged.\n")
+            sys.exit(1)
+
+        os.replace(tmp_output_fdr_file, args.output_fdr_file)
 
         if do_compare:
             if cmp_n_comparable == 0:


### PR DESCRIPTION
Fixes the FDR parquet write path in tools/summarizeOutput_parquet.py to write to a temporary scratch path and atomicly replace the output file only on successful completion. Exits non-zero and outputs errors to stderr if failure occurs during writing, and correctly cleans up the scratch file.

---
*PR created automatically by Jules for task [12965758289551083866](https://jules.google.com/task/12965758289551083866) started by @kordk*