### PR TITLE
Select enrichment foreground on the FDR column, not the p-value

### DIFF
--- a/tests/test_runEnrichment.py
+++ b/tests/test_runEnrichment.py
@@ -28,6 +28,7 @@ class TestRunEnrichment(unittest.TestCase):
             'gt_id': ['ENSG1', 'ENSG2'],
             'region': ['CIS', 'CIS'],
             'precise_mt_p': [0.01, 0.06],
+            'fdr_est': [0.01, 0.06],
             'mt_chrom': ['chr1', 'chr1'],
             'mt_chromStart': [100, 200]
         })

--- a/tests/test_run_enrichment_fdr_selection.py
+++ b/tests/test_run_enrichment_fdr_selection.py
@@ -1,0 +1,106 @@
+"""Guards for significance selection in tools/runEnrichment.py.
+
+The FDR path compared raw p-values against --fdr-threshold, whose name, help
+text and default of 0.05 all describe an FDR. On a catalog already cut at
+p <= 1e-3 that comparison is satisfied by every row, so the enrichment
+foreground was the whole catalog while presenting as FDR-controlled. These
+tests pin the replacement contract: selection is made on an FDR column, the
+column is required, and how many rows it selected is reported.
+"""
+import logging
+import os
+import sys
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "tools"))
+
+import runEnrichment  # noqa: E402
+
+
+def _write_fdr_input(path, fdr_values, p_values=None, include_fdr=True):
+    n = len(fdr_values)
+    if p_values is None:
+        p_values = [1e-9] * n
+    df = pd.DataFrame({
+        "mt_id": [f"cg{i}" for i in range(n)],
+        "gt_id": [f"ENSG{i}" for i in range(n)],
+        "region": ["CIS"] * n,
+        "precise_mt_p": p_values,
+        "mt_chrom": ["chr1"] * n,
+        "mt_chromStart": [100 * (i + 1) for i in range(n)],
+    })
+    if include_fdr:
+        df["fdr_est"] = fdr_values
+    pq.write_table(pa.Table.from_pandas(df, preserve_index=False), path)
+    return path
+
+
+def _argv(fdr_input, out_dir, extra=None):
+    argv = ["runEnrichment.py", "--fdr-input", str(fdr_input),
+            "--out-dir", str(out_dir), "--rank-by", "fdr",
+            "--dry-run-enrichment", "--enrichment-libraries", "L1"]
+    if extra:
+        argv.extend(extra)
+    return argv
+
+
+def _run(monkeypatch, caplog, fdr_input, out_dir, extra=None):
+    monkeypatch.setattr(sys, "argv", _argv(fdr_input, out_dir, extra))
+    monkeypatch.setattr(runEnrichment.gseapy, "get_library_name", lambda: ["L1"])
+    monkeypatch.setattr(runEnrichment, "clean_and_translate_gene_ids",
+                        lambda genes, *a, **k: (list(genes), 0))
+    monkeypatch.setattr(runEnrichment.time, "sleep", lambda *a, **k: None)
+    with caplog.at_level(logging.INFO, logger="runEnrichment"):
+        runEnrichment.main()
+    return caplog.text
+
+
+def test_selection_is_made_on_the_fdr_column_not_the_p_value(tmp_path, monkeypatch, caplog):
+    """Every row here has p = 1e-9; only one has an FDR at or under the cut.
+
+    Under the previous comparison against raw p-values, both rows were selected.
+    """
+    inp = _write_fdr_input(tmp_path / "summarized.parquet", [0.01, 0.90])
+    text = _run(monkeypatch, caplog, inp, tmp_path / "out")
+    assert "selected 1 of 2 rows" in text
+
+
+def test_null_fdr_rows_are_not_selected(tmp_path, monkeypatch, caplog):
+    """A row with no FDR estimate has not been assessed and is not significant."""
+    inp = _write_fdr_input(tmp_path / "summarized.parquet", [0.01, float("nan"), 0.02])
+    text = _run(monkeypatch, caplog, inp, tmp_path / "out")
+    assert "selected 2 of 3 rows" in text
+
+
+def test_threshold_is_applied_to_the_named_column(tmp_path, monkeypatch, caplog):
+    """--fdr-column routes selection to an alternative FDR estimate."""
+    inp = tmp_path / "summarized.parquet"
+    df = pd.DataFrame({
+        "mt_id": ["cg0", "cg1"], "gt_id": ["ENSG0", "ENSG1"],
+        "region": ["CIS", "CIS"], "precise_mt_p": [1e-9, 1e-9],
+        "mt_chrom": ["chr1", "chr1"], "mt_chromStart": [100, 200],
+        "fdr_est": [0.90, 0.90], "fdr_permute": [0.01, 0.90],
+    })
+    pq.write_table(pa.Table.from_pandas(df, preserve_index=False), inp)
+    text = _run(monkeypatch, caplog, inp, tmp_path / "out",
+                extra=["--fdr-column", "fdr_permute"])
+    assert "selected 1 of 2 rows" in text
+    assert "'fdr_permute'" in text
+
+
+def test_missing_fdr_column_fails_closed(tmp_path, monkeypatch, caplog):
+    """Falling back to raw p-values is what produced an uncontrolled foreground."""
+    inp = _write_fdr_input(tmp_path / "summarized.parquet", [0.01, 0.90],
+                           include_fdr=False)
+    monkeypatch.setattr(sys, "argv", _argv(inp, tmp_path / "out"))
+    with caplog.at_level(logging.ERROR, logger="runEnrichment"):
+        with pytest.raises(SystemExit) as exc:
+            runEnrichment.main()
+    assert exc.value.code == 1
+    assert "fdr_est" in caplog.text
+    assert "refusing to fall back to raw p-values" in caplog.text

--- a/tools/runEnrichment.py
+++ b/tools/runEnrichment.py
@@ -425,6 +425,7 @@ def main():
     parser.add_argument("--out-dir", default=".", help="Output directory for results.")
     parser.add_argument("--rank-by", nargs="+", choices=["fdr", "ig"], default=["fdr"], help="Methods to run enrichment on.")
     parser.add_argument("--fdr-threshold", type=float, default=0.05, help="FDR threshold for significance.")
+    parser.add_argument("--fdr-column", default="fdr_est", help="Column carrying the FDR estimate used for significance selection.")
     parser.add_argument("--ig-inflection-method", default="auto", choices=["auto", "kneed", "chord"], help="Method for IG inflection detection.")
     parser.add_argument("--encode-enrichment", action="store_true", help="Run ENCODE enrichment analysis.")
     parser.add_argument("--encode-bed-dir", default="encode_beds", help="Directory for ENCODE BED files.")
@@ -451,21 +452,26 @@ def main():
         else:
             try:
                 parquet_file = pq.ParquetFile(args.fdr_input)
-                using_fallback = 'precise_mt_p' not in parquet_file.schema.names
+                if args.fdr_column not in parquet_file.schema.names:
+                    logger.error(
+                        f"FDR column '{args.fdr_column}' not found in {args.fdr_input}. "
+                        f"Observed columns: {list(parquet_file.schema.names)}. "
+                        "Significance selection must be made on an FDR estimate; "
+                        "refusing to fall back to raw p-values."
+                    )
+                    sys.exit(1)
+                n_rows_read = 0
+                n_rows_selected = 0
 
                 for batch in parquet_file.iter_batches(batch_size=args.chunk_size):
                     df_chunk = batch.to_pandas()
                     if df_chunk.index.names != [None]:
                         df_chunk = df_chunk.reset_index()
 
-                    if not using_fallback:
-                        chunk_p_vals = df_chunk['precise_mt_p'].values
-                    else:
-                        t_col = 'mt_t' if 'mt_t' in df_chunk.columns else 't'
-                        t_stats = df_chunk[t_col].values
-                        chunk_p_vals = stats.t.sf(np.abs(t_stats), np.float64(args.df)) * 2.0
-
-                    sig_mask = chunk_p_vals <= args.fdr_threshold
+                    fdr_vals = df_chunk[args.fdr_column].astype(np.float64).values
+                    sig_mask = fdr_vals <= args.fdr_threshold
+                    n_rows_read += len(df_chunk)
+                    n_rows_selected += int(sig_mask.sum())
                     if sig_mask.any():
                         sig_df = df_chunk[sig_mask]
                         if 'region' in sig_df.columns:
@@ -498,6 +504,10 @@ def main():
                                         start = int(row['mt_chromStart'])
                                         fdr_significant_cpgs.add((chrom, start))
                                         fdr_cpgs_by_region[region].add((chrom, start))
+                logger.info(
+                    f"FDR selection on '{args.fdr_column}' <= {args.fdr_threshold}: "
+                    f"selected {n_rows_selected} of {n_rows_read} rows."
+                )
                 logger.info(f"FDR processing complete. Collected regions: {list(fdr_genes_by_region.keys())}")
             except Exception as e:
                 logger.error(f"Error processing FDR path: {e}")


### PR DESCRIPTION
This submission selects the enrichment foreground using the explicitly calculated FDR column rather than relying incorrectly on raw p-values. It also verifies this process meticulously with backwards and forwards testing in addition to negative testing injections.

---
*PR created automatically by Jules for task [17839356360909127433](https://jules.google.com/task/17839356360909127433) started by @kordk*