### PR TITLE
Extract the bootstrap-to-master join into a testable function

### DIFF
--- a/tecpg/bootstrap.py
+++ b/tecpg/bootstrap.py
@@ -12,6 +12,36 @@ from .logger import Logger
 
 from typing import Optional
 
+BOOTSTRAP_RESULT_COLUMNS = [
+    'mt_est_boot_mean', 'mt_est_boot_std', 'ci_low', 'ci_high',
+    'p_boot', 'degenerate_resamples',
+]
+
+
+def merge_bootstrap_into_master(master_df, res_df, ig_columns, logger=None):
+    """Left-join bootstrap results onto the master catalog on [mt_id, gt_id].
+
+    Columns the bootstrap produces are dropped from the master first, so a
+    re-run replaces them rather than producing suffixed duplicates.
+    """
+    cols_to_drop = [
+        c for c in BOOTSTRAP_RESULT_COLUMNS + list(ig_columns)
+        if c in master_df.columns
+    ]
+    if cols_to_drop:
+        master_df = master_df.drop(columns=cols_to_drop)
+
+    # We might need to ensure types match for joining
+    master_df = master_df.copy()
+    res_df = res_df.copy()
+    master_df['mt_id'] = master_df['mt_id'].astype(str)
+    master_df['gt_id'] = master_df['gt_id'].astype(str)
+    res_df['mt_id'] = res_df['mt_id'].astype(str)
+    res_df['gt_id'] = res_df['gt_id'].astype(str)
+
+    return master_df.merge(res_df, on=['mt_id', 'gt_id'], how='left')
+
+
 def tecpg_mlr_qr_bootstrap(
     M: pd.DataFrame,
     G: pd.DataFrame,
@@ -386,20 +416,7 @@ def tecpg_mlr_qr_bootstrap(
         logger.error(f"Failed to read master parquet file: {e}")
         return
 
-    # Perform Left Join on [mt_id, gt_id]
-    # Rows not in res_df will automatically get NaN
-    # But before join, check if those columns already exist to avoid suffixing
-    cols_to_drop = [c for c in ['mt_est_boot_mean', 'mt_est_boot_std', 'ci_low', 'ci_high', 'p_boot', 'degenerate_resamples'] + ig_columns if c in master_df.columns]
-    if cols_to_drop:
-        master_df = master_df.drop(columns=cols_to_drop)
-
-    # We might need to ensure types match for joining
-    master_df['mt_id'] = master_df['mt_id'].astype(str)
-    master_df['gt_id'] = master_df['gt_id'].astype(str)
-    res_df['mt_id'] = res_df['mt_id'].astype(str)
-    res_df['gt_id'] = res_df['gt_id'].astype(str)
-
-    merged_df = master_df.merge(res_df, on=['mt_id', 'gt_id'], how='left')
+    merged_df = merge_bootstrap_into_master(master_df, res_df, ig_columns, logger)
 
     # Record the seed actually used alongside every output row so a run is
     # reproducible from its artifact. The seed is a run-level constant, so it

--- a/tests/test_bootstrap_merge.py
+++ b/tests/test_bootstrap_merge.py
@@ -1,0 +1,125 @@
+"""Characterization of the Stage-9 join in tecpg/bootstrap.py.
+
+The bootstrap covers a small candidate subset of the catalog, and its results
+are left-joined onto the master. This file pins what that join does today,
+including one behaviour that is a defect: IG columns present on the master are
+dropped before the join and repopulated only for the bootstrapped pairs, so
+they end up null on every unbootstrapped row. That is characterized here rather
+than fixed, so the change that fixes it has something to move against.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+from tecpg.bootstrap import BOOTSTRAP_RESULT_COLUMNS, merge_bootstrap_into_master
+
+IG_COLUMNS = ["mt_ig", "Exp_PC1_ig"]
+
+
+def _master(n=5, with_ig=True):
+    df = pd.DataFrame({
+        "mt_id": [f"cg{i}" for i in range(n)],
+        "gt_id": [f"ENSG{i}" for i in range(n)],
+        "mt_est": np.linspace(0.1, 0.5, n),
+        "precise_mt_p": np.linspace(1e-9, 1e-4, n),
+    })
+    if with_ig:
+        df["mt_ig"] = np.linspace(1.0, 5.0, n)
+        df["Exp_PC1_ig"] = np.linspace(10.0, 50.0, n)
+    return df
+
+
+def _res(indices, with_ig=True):
+    n = len(indices)
+    df = pd.DataFrame({
+        "mt_id": [f"cg{i}" for i in indices],
+        "gt_id": [f"ENSG{i}" for i in indices],
+        "mt_est_boot_mean": np.full(n, 0.2),
+        "mt_est_boot_std": np.full(n, 0.02),
+        "ci_low": np.full(n, 0.1),
+        "ci_high": np.full(n, 0.3),
+        "p_boot": np.full(n, 0.001),
+        "degenerate_resamples": np.zeros(n, dtype=int),
+    })
+    if with_ig:
+        df["mt_ig"] = np.full(n, 99.0)
+        df["Exp_PC1_ig"] = np.full(n, 88.0)
+    return df
+
+
+def test_join_keeps_every_master_row():
+    """The join is a left join: the catalog is never subset by it."""
+    merged = merge_bootstrap_into_master(_master(), _res([1]), IG_COLUMNS)
+    assert len(merged) == 5
+    assert list(merged["mt_id"]) == [f"cg{i}" for i in range(5)]
+
+
+def test_bootstrap_columns_are_null_outside_the_candidate_set():
+    """Unbootstrapped rows carry no bootstrap result, by design."""
+    merged = merge_bootstrap_into_master(_master(), _res([1, 3]), IG_COLUMNS)
+    for col in BOOTSTRAP_RESULT_COLUMNS:
+        assert merged.loc[merged["mt_id"] == "cg1", col].notna().all()
+        assert merged.loc[merged["mt_id"] == "cg0", col].isna().all()
+
+
+def test_ig_columns_from_master_are_currently_discarded():
+    """CHARACTERIZATION OF A DEFECT, not an endorsement.
+
+    The master carries genome-wide IG for every row. The join drops those
+    columns and repopulates them only for bootstrapped pairs, so an
+    unbootstrapped row loses a value it already had.
+    """
+    master = _master()
+    assert master["mt_ig"].notna().all()
+
+    merged = merge_bootstrap_into_master(master, _res([1]), IG_COLUMNS)
+
+    assert merged.loc[merged["mt_id"] == "cg1", "mt_ig"].iloc[0] == 99.0
+    assert merged.loc[merged["mt_id"] == "cg0", "mt_ig"].isna().all()
+    assert merged["mt_ig"].notna().sum() == 1
+    assert merged["Exp_PC1_ig"].notna().sum() == 1
+    assert "mt_ig_boot" not in merged.columns
+
+
+def test_rejoining_does_not_produce_suffixed_duplicates():
+    """A re-run replaces the bootstrap columns rather than adding _x and _y."""
+    once = merge_bootstrap_into_master(_master(), _res([1]), IG_COLUMNS)
+    twice = merge_bootstrap_into_master(once, _res([1]), IG_COLUMNS)
+    assert list(once.columns) == list(twice.columns)
+    for col in list(twice.columns):
+        assert not col.endswith("_x") and not col.endswith("_y")
+
+
+def test_master_without_ig_columns_takes_them_from_the_bootstrap():
+    """When the mapper wrote no IG, the bootstrap values are the only ones."""
+    merged = merge_bootstrap_into_master(_master(with_ig=False), _res([1]), IG_COLUMNS)
+    assert "mt_ig" in merged.columns
+    assert merged["mt_ig"].notna().sum() == 1
+
+
+def test_id_columns_are_compared_as_strings():
+    """A master with integer-like ids still joins against string ids."""
+    master = _master()
+    master["mt_id"] = [str(i) for i in range(5)]
+    res = _res([1])
+    res["mt_id"] = [1]
+    merged = merge_bootstrap_into_master(master, res, IG_COLUMNS)
+    assert merged.loc[merged["mt_id"] == "1", "p_boot"].notna().all()
+
+
+def test_inputs_are_not_mutated():
+    """The caller's frames survive the join unchanged.
+
+    Both frames carry integer ids and no droppable column, so the string cast
+    inside the join would be visible in the caller's data if it were applied
+    in place.
+    """
+    master = _master(with_ig=False)
+    master["mt_id"] = list(range(5))
+    res = _res([1], with_ig=False)
+    res["mt_id"] = [1]
+    master_before = master.copy()
+    res_before = res.copy()
+    merge_bootstrap_into_master(master, res, [])
+    pd.testing.assert_frame_equal(master, master_before)
+    pd.testing.assert_frame_equal(res, res_before)


### PR DESCRIPTION
Extract the bootstrap-to-master join into a testable function

The Stage-9 join sits inside a 400-line GPU function and has no test
coverage of any kind. It also contains a defect: cols_to_drop includes
ig_columns, so IG values the mapper wrote genome-wide are dropped from
the master and repopulated only for the bootstrapped candidate pairs,
leaving them null on the rest. Changing that safely needs something to
change it against.

Moves the join to a module-level merge_bootstrap_into_master and adds
seven characterization tests. One of them,
test_ig_columns_from_master_are_currently_discarded, asserts the defect
is present. That is deliberate: it records today's behaviour so the
commit that changes it has to move a test, and it is the evidence that
this commit changed nothing.

One deliberate difference from the inline code: the function copies both
frames before casting the id columns to string. Inline, both were locals
and writing through them was invisible; as parameters they belong to the
caller. The single caller is unaffected either way, and a test pins it.

Deliberately excluded: the IG defect is not fixed here; ig_columns
construction, the bootstrap computation, the seed stamping and the output
writing are untouched; no consumer of mt_ig is modified.

Behaviour preserving for the pipeline: the join produces the same frame
for the same inputs, including the null IG columns.

Verification: 7 new tests, none of which can run before the change
because the import fails; 4 injections each drive the named guards red
and revert green; tests/test_bootstrap_qr.py and
tests/test_bootstrap_concordance_scores.py unchanged at 14 passed.

---
*PR created automatically by Jules for task [9044865295804077926](https://jules.google.com/task/9044865295804077926) started by @kordk*