### PR TITLE
Keep genome-wide IG on the master and suffix the bootstrap's

### DIFF
--- a/tecpg/bootstrap.py
+++ b/tecpg/bootstrap.py
@@ -18,18 +18,42 @@ BOOTSTRAP_RESULT_COLUMNS = [
 ]
 
 
+BOOTSTRAP_IG_SUFFIX = '_boot'
+
+
 def merge_bootstrap_into_master(master_df, res_df, ig_columns, logger=None):
     """Left-join bootstrap results onto the master catalog on [mt_id, gt_id].
 
     Columns the bootstrap produces are dropped from the master first, so a
     re-run replaces them rather than producing suffixed duplicates.
+
+    IG columns are treated differently. The mapper writes them for every row of
+    the catalog, while the bootstrap recomputes them for the candidate subset
+    only. Dropping the genome-wide values and repopulating from the bootstrap
+    would leave them null on every unbootstrapped row, so an IG column already
+    present on the master is kept and the bootstrap's value is written beside
+    it under BOOTSTRAP_IG_SUFFIX. An IG column absent from the master is taken
+    from the bootstrap under its own name, as before.
     """
-    cols_to_drop = [
-        c for c in BOOTSTRAP_RESULT_COLUMNS + list(ig_columns)
-        if c in master_df.columns
-    ]
+    ig_columns = list(ig_columns)
+    ig_on_master = [c for c in ig_columns if c in master_df.columns]
+
+    cols_to_drop = [c for c in BOOTSTRAP_RESULT_COLUMNS if c in master_df.columns]
     if cols_to_drop:
         master_df = master_df.drop(columns=cols_to_drop)
+
+    if ig_on_master:
+        rename_map = {c: c + BOOTSTRAP_IG_SUFFIX for c in ig_on_master}
+        collisions = [v for v in rename_map.values() if v in master_df.columns]
+        if collisions:
+            master_df = master_df.drop(columns=collisions)
+        res_df = res_df.rename(columns=rename_map)
+        if logger is not None:
+            logger.info(
+                "Preserving genome-wide IG on the master and writing the "
+                "bootstrap values beside them: "
+                + ", ".join(f"{k} -> {v}" for k, v in rename_map.items())
+            )
 
     # We might need to ensure types match for joining
     master_df = master_df.copy()

--- a/tests/test_bootstrap_merge.py
+++ b/tests/test_bootstrap_merge.py
@@ -2,10 +2,9 @@
 
 The bootstrap covers a small candidate subset of the catalog, and its results
 are left-joined onto the master. This file pins what that join does today,
-including one behaviour that is a defect: IG columns present on the master are
-dropped before the join and repopulated only for the bootstrapped pairs, so
-they end up null on every unbootstrapped row. That is characterized here rather
-than fixed, so the change that fixes it has something to move against.
+including how IG columns are handled: those already present on the master are
+genome-wide and are kept, while the bootstrap's recomputed values are written
+beside them under a suffix.
 """
 import numpy as np
 import pandas as pd
@@ -62,23 +61,39 @@ def test_bootstrap_columns_are_null_outside_the_candidate_set():
         assert merged.loc[merged["mt_id"] == "cg0", col].isna().all()
 
 
-def test_ig_columns_from_master_are_currently_discarded():
-    """CHARACTERIZATION OF A DEFECT, not an endorsement.
-
-    The master carries genome-wide IG for every row. The join drops those
-    columns and repopulates them only for bootstrapped pairs, so an
-    unbootstrapped row loses a value it already had.
-    """
+def test_genome_wide_ig_from_master_survives_the_join():
+    """The mapper writes IG for every row; the join must not discard it."""
     master = _master()
     assert master["mt_ig"].notna().all()
 
     merged = merge_bootstrap_into_master(master, _res([1]), IG_COLUMNS)
 
-    assert merged.loc[merged["mt_id"] == "cg1", "mt_ig"].iloc[0] == 99.0
-    assert merged.loc[merged["mt_id"] == "cg0", "mt_ig"].isna().all()
-    assert merged["mt_ig"].notna().sum() == 1
-    assert merged["Exp_PC1_ig"].notna().sum() == 1
-    assert "mt_ig_boot" not in merged.columns
+    assert merged["mt_ig"].notna().all()
+    assert merged["Exp_PC1_ig"].notna().all()
+    pd.testing.assert_series_equal(
+        merged["mt_ig"], master["mt_ig"], check_names=False)
+
+
+def test_bootstrap_ig_is_written_beside_it_under_a_suffix():
+    """The recomputed values get their own column, filled only where bootstrapped."""
+    merged = merge_bootstrap_into_master(_master(), _res([1]), IG_COLUMNS)
+
+    assert "mt_ig_boot" in merged.columns
+    assert "Exp_PC1_ig_boot" in merged.columns
+    assert merged.loc[merged["mt_id"] == "cg1", "mt_ig_boot"].iloc[0] == 99.0
+    assert merged["mt_ig_boot"].notna().sum() == 1
+    assert merged.loc[merged["mt_id"] == "cg0", "mt_ig_boot"].isna().all()
+
+
+def test_rejoining_does_not_accumulate_suffixes():
+    """A re-run replaces the _boot columns rather than nesting or suffixing them."""
+    once = merge_bootstrap_into_master(_master(), _res([1]), IG_COLUMNS)
+    twice = merge_bootstrap_into_master(once, _res([1]), IG_COLUMNS)
+
+    assert "mt_ig_boot_boot" not in twice.columns
+    assert list(once.columns) == list(twice.columns)
+    assert twice["mt_ig"].notna().all()
+    assert twice["mt_ig_boot"].notna().sum() == 1
 
 
 def test_rejoining_does_not_produce_suffixed_duplicates():


### PR DESCRIPTION
Keep genome-wide IG on the master and suffix the bootstrap's

The Stage-9 join dropped every IG column from the master before the left
join and repopulated it from the bootstrap results, which cover only the
candidate subset. The mapper writes IG for every row of the catalog, so
the join discarded a value each row already had and replaced it with one
that exists for a small fraction of rows. Every product ranked on IG was
confined to that fraction.

An IG column already present on the master is now kept, and the
bootstrap's recomputed value is written beside it under the suffix
_boot. An IG column absent from the master is still taken from the
bootstrap under its own name. That conditional is load-bearing:
tools/runEnrichment.py requires mt_ig by name, so renaming
unconditionally would remove it from a catalog whose mapper wrote no IG.

Both values are kept rather than one being chosen. They are computed by
different code paths with independently settable covariate filters and
baselines, so they agree by configuration rather than by construction,
and holding both makes a divergence observable. Comparing them is a
separate task; this commit compares nothing.

A re-run drops any pre-existing _boot column before renaming, so joining
twice replaces those columns rather than suffixing them to _x and _y.

test_ig_columns_from_master_are_currently_discarded, which recorded the
old behaviour, is replaced by three tests covering the new one. The six
other characterization tests are unchanged and still pass, which is the
evidence that nothing else about the join moved.

Deliberately excluded: no comparison between mt_ig and mt_ig_boot;
neither column is dropped; ig_columns construction, the bootstrap
computation and the IG maths are untouched; no consumer of mt_ig is
modified; the stale per-stage IG comment in pipeline.sh is recorded and
not actioned.

Verification: 9 tests pass, of which 3 fail before the change and 6 pass
throughout; 4 injections each drive the named guards red and revert
green; tests/test_bootstrap_qr.py and
tests/test_bootstrap_concordance_scores.py unchanged at 14 passed.

---
*PR created automatically by Jules for task [1838823592235043003](https://jules.google.com/task/1838823592235043003) started by @kordk*