### PR TITLE
Use precise_mt_p for edge p-values, keeping mt_p as a fallback

### DIFF
--- a/tests/test_export_edge_p_column.py
+++ b/tests/test_export_edge_p_column.py
@@ -1,0 +1,129 @@
+"""Guards for the edge p-value column in tools/exportBipartiteNetwork.py.
+
+The edge table hardcoded mt_p, which is float32 and is computed by a
+subtraction in which values below about 5.96e-08 (2**-24) are lost to
+cancellation. It therefore reads as exactly zero across the range the
+top-ranked edges occupy, since ranking is by IG or |t| descending. The exported
+p-values for the most significant edges were therefore zero while precise_mt_p,
+float64, sat unused in the same file. These tests pin the replacement:
+precise_mt_p is preferred, mt_p remains a fallback, and using the fallback says
+so.
+"""
+import logging
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO_ROOT, "tools"))
+
+import exportBipartiteNetwork  # noqa: E402
+
+# The value precise_mt_p carries for a top edge, and the zero mt_p carries for
+# the same edge once cancellation has taken it.
+TINY_P = 1e-12
+FLUSHED_P = 0.0
+
+
+def _rows(include_precise=True, include_mt_p=True):
+    data = {
+        "mt_id": ["cpg1", "cpg2"],
+        "mt_chrom": ["chr1", "chr2"],
+        "mt_chromStart": [100, 200],
+        "mt_strand": ["+", "-"],
+        "gt_id": ["geneA", "geneB"],
+        "gt_chrom": ["chr1", "chr2"],
+        "gt_chromStart": [500, 600],
+        "gt_strand": ["+", "-"],
+        "mt_est": [0.5, -0.4],
+        "mt_ig": [1.5, 1.2],
+    }
+    if include_mt_p:
+        data["mt_p"] = np.array([FLUSHED_P, 0.05], dtype=np.float32)
+    if include_precise:
+        data["precise_mt_p"] = np.array([TINY_P, 0.05], dtype=np.float64)
+    return data
+
+
+class TestEdgePColumn(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.input_file = os.path.join(self.temp_dir.name, "input.parquet")
+        self.out_prefix = os.path.join(self.temp_dir.name, "cyto")
+        self.out_edges = f"{self.out_prefix}_edges.csv"
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _write(self, data):
+        pd.DataFrame(data).to_parquet(self.input_file)
+
+    def _run(self):
+        args = ["exportBipartiteNetwork.py", "-i", self.input_file,
+                "-o", self.out_prefix]
+        with patch("sys.argv", args):
+            exportBipartiteNetwork.main()
+        return pd.read_csv(self.out_edges)
+
+    def test_fixture_encodes_the_loss_being_avoided(self):
+        """The premise: for the top edge, mt_p is zero and precise_mt_p is not."""
+        data = _rows()
+        self.assertEqual(float(data["mt_p"][0]), 0.0)
+        self.assertGreater(float(data["precise_mt_p"][0]), 0.0)
+
+    def test_precise_column_is_used_when_present(self):
+        self._write(_rows())
+        edges = self._run()
+        self.assertIn("precise_mt_p", edges.columns)
+        self.assertNotIn("mt_p", edges.columns)
+        self.assertGreater(edges["precise_mt_p"].min(), 0.0)
+
+    def test_mt_p_is_used_when_the_precise_column_is_absent(self):
+        self._write(_rows(include_precise=False))
+        edges = self._run()
+        self.assertIn("mt_p", edges.columns)
+        self.assertNotIn("precise_mt_p", edges.columns)
+
+    def test_falling_back_to_mt_p_is_announced(self):
+        self._write(_rows(include_precise=False))
+        with self.assertLogs(level=logging.WARNING) as cm:
+            self._run()
+        joined = " ".join(cm.output)
+        self.assertIn("mt_p", joined)
+        self.assertIn("cancellation", joined)
+
+    def test_using_the_precise_column_does_not_warn_about_precision_loss(self):
+        self._write(_rows())
+        with self.assertLogs(level=logging.INFO) as cm:
+            self._run()
+        joined = " ".join(cm.output)
+        self.assertIn("precise_mt_p", joined)
+        self.assertNotIn("cancellation", joined)
+
+    def test_neither_p_column_present_exits_one(self):
+        self._write(_rows(include_precise=False, include_mt_p=False))
+        args = ["exportBipartiteNetwork.py", "-i", self.input_file,
+                "-o", self.out_prefix]
+        with patch("sys.argv", args):
+            with self.assertRaises(SystemExit) as cm:
+                exportBipartiteNetwork.main()
+        self.assertEqual(cm.exception.code, 1)
+        self.assertFalse(os.path.exists(self.out_edges))
+
+    def test_boot_suffixed_ig_columns_are_not_exported_as_ig(self):
+        """mt_ig_boot ends with _boot, so the _ig sweep must not collect it."""
+        data = _rows()
+        data["mt_ig_boot"] = [9.9, 8.8]
+        self._write(data)
+        edges = self._run()
+        self.assertIn("mt_ig", edges.columns)
+        self.assertNotIn("mt_ig_boot", edges.columns)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/exportBipartiteNetwork.py
+++ b/tools/exportBipartiteNetwork.py
@@ -7,6 +7,9 @@ import logging
 
 logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 
+P_COLUMN_PREFERENCE = ['precise_mt_p', 'mt_p']
+
+
 def main():
     parser = argparse.ArgumentParser(description="Export eQTM Parquet file to Cytoscape Node and Edge tables.")
     parser.add_argument("-i", "--input", required=True, help="Path to the input Parquet file (e.g., results.precise_p.annot.fdr.parquet).")
@@ -37,11 +40,25 @@ def main():
         sys.exit(1)
 
     # 2. Check required edge columns (statistical)
-    required_edge_cols = ['mt_est', 'mt_p']
-    missing_edge_cols = [col for col in required_edge_cols if col not in df.columns]
+    # precise_mt_p is float64. mt_p is float32 and is computed by a subtraction
+    # in which values below about 5.96e-08 (2**-24) are lost to cancellation, so
+    # it can read as exactly zero across the range the top-ranked edges occupy.
+    p_column = next((c for c in P_COLUMN_PREFERENCE if c in df.columns), None)
+    missing_edge_cols = [c for c in ['mt_est'] if c not in df.columns]
+    if p_column is None:
+        missing_edge_cols.append(' or '.join(P_COLUMN_PREFERENCE))
     if missing_edge_cols:
-        logging.error(f"Missing required edge columns: {missing_edge_cols}. Expected at least: {required_edge_cols}")
+        logging.error(f"Missing required edge columns: {missing_edge_cols}. Expected 'mt_est' and one of: {P_COLUMN_PREFERENCE}")
         sys.exit(1)
+    if p_column == 'mt_p':
+        logging.warning(
+            "Using 'mt_p' for edge p-values because 'precise_mt_p' is absent. "
+            "mt_p is float32 and loses values below about 5.96e-08 to "
+            "cancellation, so the most significant edges may carry a p-value "
+            "of exactly zero."
+        )
+    else:
+        logging.info(f"Using '{p_column}' for edge p-values.")
 
     # 3. Handle region column
     if 'region' not in df.columns:
@@ -83,7 +100,7 @@ def main():
 
     # 5. Build Edge Table
     logging.info("Building Edge table...")
-    base_edge_cols = ['mt_id', 'gt_id', 'region', 'mt_est', 'mt_p']
+    base_edge_cols = ['mt_id', 'gt_id', 'region', 'mt_est', p_column]
     if 'mt_t' in df_top.columns:
         base_edge_cols.append('mt_t')
     if used_abs_t:


### PR DESCRIPTION
Use precise_mt_p for edge p-values, keeping mt_p as a fallback

The Cytoscape edge table hardcoded mt_p in both the required-column
check and the exported columns. mt_p is float32 and is produced by a
subtraction in which values below about 5.96e-08, which is 2**-24, are
lost to cancellation, so it reads as exactly zero across a range of
significance. That range is not incidental: the tool ranks by mt_ig
descending, falling back to absolute mt_t, and exports the top K, so the
edges selected for the network are the ones whose p-values mt_p cannot
carry. precise_mt_p, float64 and holding the real value, was present in
the same file and unused.

The p-column is now chosen by preference, precise_mt_p first and mt_p
second, and the chosen column is required rather than mt_p specifically.
The exported column keeps its own name, so the artifact records which
quantity it holds instead of labelling a float64 value as mt_p.

Falling back to mt_p logs a warning naming the mechanism, so a run
against a catalog without precise_mt_p reports that its edge p-values may
be zero rather than presenting them as measured.

The existing suite is unchanged. Its fixtures carry only mt_p, so they
exercise the fallback path and pass without modification, which is also
the evidence the fallback still works.

Deliberately excluded: the ranking logic, --min-effect, --max-boot-p and
the mt_ig to abs_t fallback are untouched; the node table is untouched;
--top-k's default, which disagrees with pipelinePost.sh, is a recorded
single-source-of-truth item and is not addressed here; the exported
column is not renamed to a fixed name.

Verification: 7 new tests, of which 3 fail before the change; the
existing export suite is 9 passed before and after; 4 injections each
drive the named guards red and revert green, one of them failing a test
in the existing suite as well; the bootstrap suites are unchanged at 14
passed.

---
*PR created automatically by Jules for task [10468296163092279237](https://jules.google.com/task/10468296163092279237) started by @kordk*